### PR TITLE
[feat] 차후를 위해 others의 클래스명 수정 (#55) 

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreateObjectiveRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreateObjectiveRequest.java
@@ -1,7 +1,7 @@
 package net.diveon.backend.domain.problem.dto.request;
 
-import net.diveon.backend.domain.problem.others.Choice;
-import net.diveon.backend.domain.problem.others.OboStep;
+import net.diveon.backend.domain.problem.others.ForDtoChoice;
+import net.diveon.backend.domain.problem.others.ForDtoOboStep;
 
 import java.util.List;
 
@@ -47,7 +47,7 @@ public class ProblemCreateObjectiveRequest {
     private String category;
     private String difficulty;
     private String visibility;
-    private List<Choice> choices;
+    private List<ForDtoChoice> choices;
     private List<Integer> answer;
     private Obo obo;
 
@@ -94,11 +94,11 @@ public class ProblemCreateObjectiveRequest {
         this.visibility = visibility;
     }
 
-    public List<Choice> getChoices() {
+    public List<ForDtoChoice> getChoices() {
         return choices;
     }
 
-    public void setChoices(List<Choice> choices) {
+    public void setChoices(List<ForDtoChoice> choices) {
         this.choices = choices;
     }
 
@@ -120,7 +120,7 @@ public class ProblemCreateObjectiveRequest {
 
     public static class Obo {
         private Boolean enabled;
-        private List<OboStep> steps;
+        private List<ForDtoOboStep> steps;
 
         public Obo() {
         }
@@ -133,11 +133,11 @@ public class ProblemCreateObjectiveRequest {
             this.enabled = enabled;
         }
 
-        public List<OboStep> getSteps() {
+        public List<ForDtoOboStep> getSteps() {
             return steps;
         }
 
-        public void setSteps(List<OboStep> steps) {
+        public void setSteps(List<ForDtoOboStep> steps) {
             this.steps = steps;
         }
     }

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdateObjectiveRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdateObjectiveRequest.java
@@ -1,8 +1,8 @@
 
 package net.diveon.backend.domain.problem.dto.request;
 
-import net.diveon.backend.domain.problem.others.Choice;
-import net.diveon.backend.domain.problem.others.OboStep;
+import net.diveon.backend.domain.problem.others.ForDtoChoice;
+import net.diveon.backend.domain.problem.others.ForDtoOboStep;
 
 import java.util.List;
 
@@ -48,7 +48,7 @@ public class ProblemUpdateObjectiveRequest {
     private String category;
     private String difficulty;
     private String visibility;
-    private List<Choice> choices;
+    private List<ForDtoChoice> choices;
     private List<Integer> answer;
     private Obo obo;
 
@@ -95,11 +95,11 @@ public class ProblemUpdateObjectiveRequest {
         this.visibility = visibility;
     }
 
-    public List<Choice> getChoices() {
+    public List<ForDtoChoice> getChoices() {
         return choices;
     }
 
-    public void setChoices(List<Choice> choices) {
+    public void setChoices(List<ForDtoChoice> choices) {
         this.choices = choices;
     }
 
@@ -121,7 +121,7 @@ public class ProblemUpdateObjectiveRequest {
 
     public static class Obo {
         private Boolean enabled;
-        private List<OboStep> steps;
+        private List<ForDtoOboStep> steps;
 
         public Obo() {
         }
@@ -134,11 +134,11 @@ public class ProblemUpdateObjectiveRequest {
             this.enabled = enabled;
         }
 
-        public List<OboStep> getSteps() {
+        public List<ForDtoOboStep> getSteps() {
             return steps;
         }
 
-        public void setSteps(List<OboStep> steps) {
+        public void setSteps(List<ForDtoOboStep> steps) {
             this.steps = steps;
         }
     }

--- a/src/main/java/net/diveon/backend/domain/problem/entity/ProblemObjective.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/ProblemObjective.java
@@ -4,8 +4,8 @@ package net.diveon.backend.domain.problem.entity;
 // 이거는 세부적으로 나누는게 좋을 듯합니다, 일단 구현에 먼저 의미를 두어서 그냥 했습니다. - 안상완
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
-import net.diveon.backend.domain.problem.others.Choice;
-import net.diveon.backend.domain.problem.others.OboStep;
+import net.diveon.backend.domain.problem.others.ForDtoChoice;
+import net.diveon.backend.domain.problem.others.ForDtoOboStep;
 import org.hibernate.annotations.Type;
 
 import java.util.List;
@@ -37,7 +37,7 @@ public class ProblemObjective {
     // Hypersistence Utils를 사용해서 List<Choice>를 PostgreSQL JSONB에 그대로 매핑합니다.
     @Type(JsonType.class)
     @Column(name = "choices", columnDefinition = "JSONB", nullable = false)
-    private List<Choice> choices;
+    private List<ForDtoChoice> choices;
 
     @Type(JsonType.class)
     @Column(name = "answer", columnDefinition = "JSON", nullable = false)
@@ -48,7 +48,7 @@ public class ProblemObjective {
 
     @Type(JsonType.class)
     @Column(name = "obo_steps", columnDefinition = "JSONB")
-    private List<OboStep> oboSteps;
+    private List<ForDtoOboStep> oboSteps;
 
     // 1. JPA용 기본 생성자
     public ProblemObjective() {
@@ -56,8 +56,8 @@ public class ProblemObjective {
 
     // 2. 데이터 생성을 위한 생성자
     public ProblemObjective(Problem problem, String summary, String description, 
-                            List<Choice> choices, List<Integer> answer,
-                            Boolean oboEnabled, List<OboStep> oboSteps) {
+                            List<ForDtoChoice> choices, List<Integer> answer,
+                            Boolean oboEnabled, List<ForDtoOboStep> oboSteps) {
         this.problem = problem;
         this.summary = summary;
         this.description = description;
@@ -72,8 +72,8 @@ public class ProblemObjective {
     public Problem getProblem() { return problem; }
     public String getSummary() { return summary; }
     public String getDescription() { return description; }
-    public List<Choice> getChoices() { return choices; }
+    public List<ForDtoChoice> getChoices() { return choices; }
     public List<Integer> getAnswer() { return answer; }
     public Boolean getOboEnabled() { return oboEnabled; }
-    public List<OboStep> getOboSteps() { return oboSteps; }
+    public List<ForDtoOboStep> getOboSteps() { return oboSteps; }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/others/ForDtoChoice.java
+++ b/src/main/java/net/diveon/backend/domain/problem/others/ForDtoChoice.java
@@ -2,7 +2,7 @@ package net.diveon.backend.domain.problem.others;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Choice {
+public class ForDtoChoice {
 
     private Integer index;
     private String content;
@@ -10,10 +10,10 @@ public class Choice {
     @JsonProperty("image_url")
     private String imageUrl;
 
-    public Choice() {
+    public ForDtoChoice() {
     }
 
-    public Choice(Integer index, String content, String imageUrl) {
+    public ForDtoChoice(Integer index, String content, String imageUrl) {
         this.index = index;
         this.content = content;
         this.imageUrl = imageUrl;

--- a/src/main/java/net/diveon/backend/domain/problem/others/ForDtoOboStep.java
+++ b/src/main/java/net/diveon/backend/domain/problem/others/ForDtoOboStep.java
@@ -2,7 +2,7 @@ package net.diveon.backend.domain.problem.others;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class OboStep {
+public class ForDtoOboStep {
 
     private Integer step;
     private String description;
@@ -10,10 +10,10 @@ public class OboStep {
     @JsonProperty("image_url")
     private String imageUrl;
 
-    public OboStep() {
+    public ForDtoOboStep() {
     }
 
-    public OboStep(Integer step, String description, String imageUrl) {
+    public ForDtoOboStep(Integer step, String description, String imageUrl) {
         this.step = step;
         this.description = description;
         this.imageUrl = imageUrl;


### PR DESCRIPTION
차후 위해서 클래스명을 수정했습니다.
others 폴더에 존재하는것은 절대로 entity 클래스가 아닙니다
따라서 ForDto라는 이름을 기존 이름 앞에 붙여 명시적으로 구분했습니다.

추가로 현재 ProblemObjective entity클래스 내부에 obostep이라는 잘못된 정보가 기입되어있는데 이것은 수정해야하며

동시에 문제의 생성을 위해서는 obo step 에 해당하는 entity를 구현해야합니다.