### PR TITLE
[feat] 실습형(CTF) 문제 생성/수정 API 구현 (#54)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCreateController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCreateController.java
@@ -6,7 +6,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import net.diveon.backend.domain.problem.dto.request.ProblemCreateObjectiveRequest;
+import net.diveon.backend.domain.problem.dto.request.ProblemCreatePracticeRequest;
 import net.diveon.backend.domain.problem.dto.response.ProblemCreateObjectiveResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemCreatePracticeResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemDeleteResponse;
 import net.diveon.backend.domain.problem.service.ProblemCreateService;
 import net.diveon.backend.global.response.ApiResponse;
@@ -53,8 +55,16 @@ public class ProblemCreateController {
         return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
     }
     
+    @PostMapping("/practice")
+    public ResponseEntity<ApiResponse<ProblemCreatePracticeResponse>> createPracticeProblem(
+            @Valid @RequestBody ProblemCreatePracticeRequest request,
+            @AuthenticationPrincipal String userId) {
+        ProblemCreatePracticeResponse responseBody = problemCreateService.createPractice(request, userId);
+        return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
+    }
+
     // DELETE
-    //DELETE /api/problems/{prob_id} 
+    //DELETE /api/problems/{prob_id}
     @DeleteMapping("/{prob_id}")
     public ResponseEntity<ApiResponse<ProblemDeleteResponse>> deleteProblem(@PathVariable long prob_id,
         @AuthenticationPrincipal String userId){

--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCreateController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCreateController.java
@@ -40,6 +40,8 @@ public class ProblemCreateController {
      * @param userId //jwt-AuthenticationPrincipal
      * @return ResponseEntity<ApiResPonse<body> //
      */
+
+    // 객관식
     @PostMapping("/objective")
     public ResponseEntity<ApiResponse<ProblemCreateObjectiveResponse>> createObjectiveProblem(@Valid @RequestBody ProblemCreateObjectiveRequest request, 
         @AuthenticationPrincipal String userId) {
@@ -55,12 +57,15 @@ public class ProblemCreateController {
         return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
     }
     
-    @PostMapping("/practice")
+    // 실습형
+    @PostMapping("/practice") // 프론트 요청을 받음
     public ResponseEntity<ApiResponse<ProblemCreatePracticeResponse>> createPracticeProblem(
             @Valid @RequestBody ProblemCreatePracticeRequest request,
             @AuthenticationPrincipal String userId) {
-        ProblemCreatePracticeResponse responseBody = problemCreateService.createPractice(request, userId);
-        return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
+
+            ProblemCreatePracticeResponse responseBody = problemCreateService.createPractice(request, userId); // 서비스를 호출
+            
+            return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
     }
 
     // DELETE

--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemUpdateController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemUpdateController.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import net.diveon.backend.domain.problem.dto.request.ProblemUpdateObjectiveRequest;
+import net.diveon.backend.domain.problem.dto.request.ProblemUpdatePracticeRequest;
 import net.diveon.backend.domain.problem.dto.response.ProblemUpdateObjectiveResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemUpdatePracticeResponse;
 import net.diveon.backend.domain.problem.service.ProblemUpdateService;
 import net.diveon.backend.global.response.ApiResponse;
 
@@ -23,7 +25,7 @@ public class ProblemUpdateController {
         this.problemUpdateService = problemUpdateService;
     }
 
-
+    // 객관식
     @PatchMapping("/{prob_id}")
     public ResponseEntity<ApiResponse<ProblemUpdateObjectiveResponse>> updateProblemObjective(@AuthenticationPrincipal String userId, 
         @RequestBody ProblemUpdateObjectiveRequest request,
@@ -37,5 +39,16 @@ public class ProblemUpdateController {
             //TODO 실제로 응답 body의 data 부분 객체 할당, 이후 응답 제대로 만들기
             
             return ResponseEntity.status(200).body(ApiResponse.success("문제 변경에 성공했습니다.", responseData));
+    }
+    
+    // 실습형
+    @PatchMapping("/practice/{prob_id}")
+    public ResponseEntity<ApiResponse<ProblemUpdatePracticeResponse>> updateProblemPractice(
+            @AuthenticationPrincipal String userId,
+            @RequestBody ProblemUpdatePracticeRequest request,
+            @PathVariable("prob_id") long probId) {
+
+        ProblemUpdatePracticeResponse responseData = problemUpdateService.updateProblemPractice(userId, probId, request);
+        return ResponseEntity.status(200).body(ApiResponse.success("문제가 수정되었습니다.", responseData));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
@@ -1,0 +1,92 @@
+package net.diveon.backend.domain.problem.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public class ProblemCreatePracticeRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String summary;
+
+    @NotBlank
+    private String description;
+
+    @NotBlank
+    private String category;
+
+    @NotBlank
+    private String difficulty;
+
+    @NotBlank
+    private String visibility;
+
+    @NotNull
+    private VmConfig vmConfig;
+
+    @NotBlank
+    private String flag;
+
+    private String dockerFileUrl;
+
+    public ProblemCreatePracticeRequest() {
+    }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getSummary() { return summary; }
+    public void setSummary(String summary) { this.summary = summary; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+
+    public String getDifficulty() { return difficulty; }
+    public void setDifficulty(String difficulty) { this.difficulty = difficulty; }
+
+    public String getVisibility() { return visibility; }
+    public void setVisibility(String visibility) { this.visibility = visibility; }
+
+    public VmConfig getVmConfig() { return vmConfig; }
+    public void setVmConfig(VmConfig vmConfig) { this.vmConfig = vmConfig; }
+
+    public String getFlag() { return flag; }
+    public void setFlag(String flag) { this.flag = flag; }
+
+    public String getDockerFileUrl() { return dockerFileUrl; }
+    public void setDockerFileUrl(String dockerFileUrl) { this.dockerFileUrl = dockerFileUrl; }
+
+    public static class VmConfig {
+
+        @NotBlank
+        private String osImage;
+
+        private List<String> allowedCommands;
+
+        private String cpuLimit = "0.5";
+
+        private String memoryLimit = "512m";
+
+        public VmConfig() {
+        }
+
+        public String getOsImage() { return osImage; }
+        public void setOsImage(String osImage) { this.osImage = osImage; }
+
+        public List<String> getAllowedCommands() { return allowedCommands; }
+        public void setAllowedCommands(List<String> allowedCommands) { this.allowedCommands = allowedCommands; }
+
+        public String getCpuLimit() { return cpuLimit; }
+        public void setCpuLimit(String cpuLimit) { this.cpuLimit = cpuLimit; }
+
+        public String getMemoryLimit() { return memoryLimit; }
+        public void setMemoryLimit(String memoryLimit) { this.memoryLimit = memoryLimit; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
@@ -1,5 +1,6 @@
 package net.diveon.backend.domain.problem.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -26,11 +27,13 @@ public class ProblemCreatePracticeRequest {
     private String visibility;
 
     @NotNull
+    @JsonProperty("vm_config")
     private VmConfig vmConfig;
 
     @NotBlank
     private String flag;
 
+    @JsonProperty("docker_file_url")
     private String dockerFileUrl;
 
     public ProblemCreatePracticeRequest() {
@@ -66,12 +69,16 @@ public class ProblemCreatePracticeRequest {
     public static class VmConfig {
 
         @NotBlank
+        @JsonProperty("os_image")
         private String osImage;
 
+        @JsonProperty("allowed_commands")
         private List<String> allowedCommands;
 
+        @JsonProperty("cpu_limit")
         private String cpuLimit = "0.5";
 
+        @JsonProperty("memory_limit")
         private String memoryLimit = "512m";
 
         public VmConfig() {

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdatePracticeRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdatePracticeRequest.java
@@ -1,5 +1,7 @@
 package net.diveon.backend.domain.problem.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public class ProblemUpdatePracticeRequest {
@@ -10,8 +12,13 @@ public class ProblemUpdatePracticeRequest {
     private String category;
     private String difficulty;
     private String visibility;
+
+    @JsonProperty("vm_config")
     private VmConfig vmConfig;
+
     private String flag;
+
+    @JsonProperty("docker_file_url")
     private String dockerFileUrl;
 
     public ProblemUpdatePracticeRequest() {
@@ -46,9 +53,16 @@ public class ProblemUpdatePracticeRequest {
 
     public static class VmConfig {
 
+        @JsonProperty("os_image")
         private String osImage;
+
+        @JsonProperty("allowed_commands")
         private List<String> allowedCommands;
+
+        @JsonProperty("cpu_limit")
         private String cpuLimit;
+
+        @JsonProperty("memory_limit")
         private String memoryLimit;
 
         public VmConfig() {

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdatePracticeRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdatePracticeRequest.java
@@ -1,0 +1,69 @@
+package net.diveon.backend.domain.problem.dto.request;
+
+import java.util.List;
+
+public class ProblemUpdatePracticeRequest {
+
+    private String title;
+    private String summary;
+    private String description;
+    private String category;
+    private String difficulty;
+    private String visibility;
+    private VmConfig vmConfig;
+    private String flag;
+    private String dockerFileUrl;
+
+    public ProblemUpdatePracticeRequest() {
+    }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getSummary() { return summary; }
+    public void setSummary(String summary) { this.summary = summary; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+
+    public String getDifficulty() { return difficulty; }
+    public void setDifficulty(String difficulty) { this.difficulty = difficulty; }
+
+    public String getVisibility() { return visibility; }
+    public void setVisibility(String visibility) { this.visibility = visibility; }
+
+    public VmConfig getVmConfig() { return vmConfig; }
+    public void setVmConfig(VmConfig vmConfig) { this.vmConfig = vmConfig; }
+
+    public String getFlag() { return flag; }
+    public void setFlag(String flag) { this.flag = flag; }
+
+    public String getDockerFileUrl() { return dockerFileUrl; }
+    public void setDockerFileUrl(String dockerFileUrl) { this.dockerFileUrl = dockerFileUrl; }
+
+    public static class VmConfig {
+
+        private String osImage;
+        private List<String> allowedCommands;
+        private String cpuLimit;
+        private String memoryLimit;
+
+        public VmConfig() {
+        }
+
+        public String getOsImage() { return osImage; }
+        public void setOsImage(String osImage) { this.osImage = osImage; }
+
+        public List<String> getAllowedCommands() { return allowedCommands; }
+        public void setAllowedCommands(List<String> allowedCommands) { this.allowedCommands = allowedCommands; }
+
+        public String getCpuLimit() { return cpuLimit; }
+        public void setCpuLimit(String cpuLimit) { this.cpuLimit = cpuLimit; }
+
+        public String getMemoryLimit() { return memoryLimit; }
+        public void setMemoryLimit(String memoryLimit) { this.memoryLimit = memoryLimit; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCreatePracticeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCreatePracticeResponse.java
@@ -1,0 +1,35 @@
+package net.diveon.backend.domain.problem.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ProblemCreatePracticeResponse {
+
+    @JsonProperty("prob_id")
+    private long probId;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    public ProblemCreatePracticeResponse() {
+    }
+
+    public ProblemCreatePracticeResponse(long probId, String type, String title, String createdAt) {
+        this.probId = probId;
+        this.type = type;
+        this.title = title;
+        this.createdAt = createdAt;
+    }
+
+    public long getProbId() { return probId; }
+    public String getType() { return type; }
+    public String getTitle() { return title; }
+    public String getCreatedAt() { return createdAt; }
+}
+
+// @JsonProperty - Java 필드명(probId)을 JSON 키(prob_id)로 바꿔줌

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCreatePracticeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCreatePracticeResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ProblemCreatePracticeResponse {
 
-    @JsonProperty("prob_id")
+    @JsonProperty("prob_id") //  Java 필드명 probId를 JSON 키 prob_id로 변환 (다시 프론트한테 돌려줘야 되니까)
     private long probId;
 
     @JsonProperty("type")
@@ -32,4 +32,3 @@ public class ProblemCreatePracticeResponse {
     public String getCreatedAt() { return createdAt; }
 }
 
-// @JsonProperty - Java 필드명(probId)을 JSON 키(prob_id)로 바꿔줌

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemUpdatePracticeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemUpdatePracticeResponse.java
@@ -1,0 +1,33 @@
+package net.diveon.backend.domain.problem.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ProblemUpdatePracticeResponse {
+
+    @JsonProperty("prob_id")
+    private long probId;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("updated_at")
+    private String updatedAt;
+
+    public ProblemUpdatePracticeResponse() {
+    }
+
+    public ProblemUpdatePracticeResponse(long probId, String type, String title, String updatedAt) {
+        this.probId = probId;
+        this.type = type;
+        this.title = title;
+        this.updatedAt = updatedAt;
+    }
+
+    public long getProbId() { return probId; }
+    public String getType() { return type; }
+    public String getTitle() { return title; }
+    public String getUpdatedAt() { return updatedAt; }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/entity/Problem.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/Problem.java
@@ -115,8 +115,9 @@ public class Problem {
      * null 이 아닌 값에 대해서만 변경을 진행함.
      * </pre>
      */
-    public void updateProblem(String title, String difficulty, String visibillity){
+    public void updateProblem(String title, String category, String difficulty, String visibillity){
         if( title != null) this.title = title;
+        if( category != null) this.category = category;
         if( difficulty != null) this.difficulty = difficulty;
         if( visibillity != null) this.visibility = visibillity;
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/net/diveon/backend/domain/problem/entity/ProblemPractice.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/ProblemPractice.java
@@ -9,17 +9,18 @@ import java.util.List;
 @Entity
 @Table(name = "problem_practice")
 public class ProblemPractice {
-
+    // problem_practice 테이블의 prob_id는 PK이면서 동시에 problem_summary.id를 참조하는 FK임! Problem이 저장될 때 id가 자동으로 들어옴!
     @Id
     @Column(name = "prob_id")
     private Long probId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
+    @MapsId // ProblemPractice가 별도 PK 안 만들고 Problem의 id를 그대로 자기 PK로 사용 왜냐?
+            // Problem이랑 ProblemPractice는 1:1 관계니까. 문제 하나에 실습 정보 하나
     @JoinColumn(name = "prob_id")
     private Problem problem;
 
-    @Column(name = "summary", columnDefinition = "TEXT", nullable = false)
+    @Column(name = "summary", columnDefinition = "TEXT", nullable = false) // 이 필드가 DB의 어떤 컬럼에 매핑되는지 설명
     private String summary;
 
     @Column(name = "description", columnDefinition = "TEXT", nullable = false)

--- a/src/main/java/net/diveon/backend/domain/problem/entity/ProblemPractice.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/ProblemPractice.java
@@ -1,0 +1,101 @@
+package net.diveon.backend.domain.problem.entity;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+
+import java.util.List;
+
+@Entity
+@Table(name = "problem_practice")
+public class ProblemPractice {
+
+    @Id
+    @Column(name = "prob_id")
+    private Long probId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "prob_id")
+    private Problem problem;
+
+    @Column(name = "summary", columnDefinition = "TEXT", nullable = false)
+    private String summary;
+
+    @Column(name = "description", columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(name = "os_image", length = 100, nullable = false)
+    private String osImage;
+
+    @Type(JsonType.class)
+    @Column(name = "allowed_commands", columnDefinition = "JSONB")
+    private List<String> allowedCommands;
+
+    @Column(name = "cpu_limit", length = 10, nullable = false)
+    private String cpuLimit;
+
+    @Column(name = "memory_limit", length = 10, nullable = false)
+    private String memoryLimit;
+
+    @Column(name = "flag_hash", length = 255, nullable = false)
+    private String flagHash;
+
+    @Column(name = "docker_file_url", length = 500)
+    private String dockerFileUrl;
+
+    @Column(name = "hint", columnDefinition = "TEXT")
+    private String hint;
+
+    @Column(name = "is_draft")
+    private Boolean isDraft = false;
+
+    @Column(name = "time_limit_sec")
+    private Integer timeLimitSec;
+
+    public ProblemPractice() {
+    }
+
+    public ProblemPractice(Problem problem, String summary, String description,
+                           String osImage, List<String> allowedCommands,
+                           String cpuLimit, String memoryLimit,
+                           String flagHash, String dockerFileUrl) {
+        this.problem = problem;
+        this.summary = summary;
+        this.description = description;
+        this.osImage = osImage;
+        this.allowedCommands = allowedCommands;
+        this.cpuLimit = cpuLimit;
+        this.memoryLimit = memoryLimit;
+        this.flagHash = flagHash;
+        this.dockerFileUrl = dockerFileUrl;
+        this.isDraft = false;
+    }
+
+    public Long getProbId() { return probId; }
+    public Problem getProblem() { return problem; }
+    public String getSummary() { return summary; }
+    public String getDescription() { return description; }
+    public String getOsImage() { return osImage; }
+    public List<String> getAllowedCommands() { return allowedCommands; }
+    public String getCpuLimit() { return cpuLimit; }
+    public String getMemoryLimit() { return memoryLimit; }
+    public String getFlagHash() { return flagHash; }
+    public String getDockerFileUrl() { return dockerFileUrl; }
+    public String getHint() { return hint; }
+    public Boolean getIsDraft() { return isDraft; }
+    public Integer getTimeLimitSec() { return timeLimitSec; }
+
+    public void updatePractice(String summary, String description, String osImage,
+                               List<String> allowedCommands, String cpuLimit,
+                               String memoryLimit, String flagHash, String dockerFileUrl) {
+        if (summary != null) this.summary = summary;
+        if (description != null) this.description = description;
+        if (osImage != null) this.osImage = osImage;
+        if (allowedCommands != null) this.allowedCommands = allowedCommands;
+        if (cpuLimit != null) this.cpuLimit = cpuLimit;
+        if (memoryLimit != null) this.memoryLimit = memoryLimit;
+        if (flagHash != null) this.flagHash = flagHash;
+        if (dockerFileUrl != null) this.dockerFileUrl = dockerFileUrl;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/repository/ProblemPracticeRepository.java
+++ b/src/main/java/net/diveon/backend/domain/problem/repository/ProblemPracticeRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.problem.repository;
+
+import net.diveon.backend.domain.problem.entity.ProblemPractice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemPracticeRepository extends JpaRepository<ProblemPractice, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/problem/repository/ProblemPracticeRepository.java
+++ b/src/main/java/net/diveon/backend/domain/problem/repository/ProblemPracticeRepository.java
@@ -4,4 +4,5 @@ import net.diveon.backend.domain.problem.entity.ProblemPractice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemPracticeRepository extends JpaRepository<ProblemPractice, Long> {
+    // Service에서의 호출을 받아서 실제 DB에 INSERT SQL 날림. 이는 JPA가 알아서 처리
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
@@ -1,30 +1,39 @@
 package net.diveon.backend.domain.problem.service;
 
 import net.diveon.backend.domain.problem.dto.request.ProblemCreateObjectiveRequest;
+import net.diveon.backend.domain.problem.dto.request.ProblemCreatePracticeRequest;
 import net.diveon.backend.domain.problem.dto.response.ProblemCreateObjectiveResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemCreatePracticeResponse;
 import net.diveon.backend.domain.problem.entity.Problem;
 import net.diveon.backend.domain.problem.entity.ProblemObjective;
+import net.diveon.backend.domain.problem.entity.ProblemPractice;
 import net.diveon.backend.domain.problem.repository.ProblemObjectiveRepository;
+import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
 @Service
 public class ProblemCreateService {
     private final ProblemObjectiveRepository problemObjectiveRepository;
+    private final ProblemPracticeRepository problemPracticeRepository;
     private final ProblemRepository problemRepository;
     private final UserRepository userRepository;
 
-
-    public ProblemCreateService(ProblemObjectiveRepository problemObjectiveRepository 
-        ,ProblemRepository problemRepository, UserRepository userRepository){
+    public ProblemCreateService(ProblemObjectiveRepository problemObjectiveRepository,
+        ProblemPracticeRepository problemPracticeRepository,
+        ProblemRepository problemRepository, UserRepository userRepository){
         this.problemObjectiveRepository = problemObjectiveRepository;
+        this.problemPracticeRepository = problemPracticeRepository;
         this.problemRepository = problemRepository;
         this.userRepository = userRepository;
     }
-
 
     @Transactional
     public ProblemCreateObjectiveResponse createObjective(ProblemCreateObjectiveRequest request, String userId){
@@ -56,8 +65,54 @@ public class ProblemCreateService {
         return new ProblemCreateObjectiveResponse(
                 savedProblem.getId(),
                 savedProblem.getType(),
-                savedProblem.getTitle(), 
+                savedProblem.getTitle(),
                 savedProblem.getCreatedAt().toString()
         );
+    }
+
+    @Transactional
+    public ProblemCreatePracticeResponse createPractice(ProblemCreatePracticeRequest request, String userId){
+        User author = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow();
+
+        Problem problem = new Problem(
+                author,
+                "practice",
+                request.getTitle(),
+                request.getCategory(),
+                request.getDifficulty(),
+                request.getVisibility()
+        );
+        Problem savedProblem = problemRepository.save(problem);
+
+        ProblemPractice problemPractice = new ProblemPractice(
+                savedProblem,
+                request.getSummary(),
+                request.getDescription(),
+                request.getVmConfig().getOsImage(),
+                request.getVmConfig().getAllowedCommands(),
+                request.getVmConfig().getCpuLimit(),
+                request.getVmConfig().getMemoryLimit(),
+                hashFlag(request.getFlag()),
+                request.getDockerFileUrl()
+        );
+        problemPracticeRepository.save(problemPractice);
+
+        return new ProblemCreatePracticeResponse(
+                savedProblem.getId(),
+                savedProblem.getType(),
+                savedProblem.getTitle(),
+                savedProblem.getCreatedAt().toString()
+        );
+    }
+
+    private String hashFlag(String flag) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(flag.getBytes());
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
@@ -35,6 +35,7 @@ public class ProblemCreateService {
         this.userRepository = userRepository;
     }
 
+    
     @Transactional
     public ProblemCreateObjectiveResponse createObjective(ProblemCreateObjectiveRequest request, String userId){
         User author = userRepository.findById(Long.parseLong(userId))
@@ -70,9 +71,10 @@ public class ProblemCreateService {
         );
     }
 
+    // 실습형
     @Transactional
     public ProblemCreatePracticeResponse createPractice(ProblemCreatePracticeRequest request, String userId){
-        User author = userRepository.findById(Long.parseLong(userId))
+        User author = userRepository.findById(Long.parseLong(userId)) // ex. "1" -> 1 (long)
                 .orElseThrow();
 
         Problem problem = new Problem(
@@ -85,7 +87,7 @@ public class ProblemCreateService {
         );
         Problem savedProblem = problemRepository.save(problem);
 
-        ProblemPractice problemPractice = new ProblemPractice(
+        ProblemPractice problemPractice = new ProblemPractice( // Java 메모리에 객체만 만든 것, 서버 꺼지면 사라짐
                 savedProblem,
                 request.getSummary(),
                 request.getDescription(),
@@ -96,9 +98,9 @@ public class ProblemCreateService {
                 hashFlag(request.getFlag()),
                 request.getDockerFileUrl()
         );
-        problemPracticeRepository.save(problemPractice);
+        problemPracticeRepository.save(problemPractice); // DB에 실제 저장위해 INSERT, 서버 꺼져도 영구 저장
 
-        return new ProblemCreatePracticeResponse(
+        return new ProblemCreatePracticeResponse( // DB에 저장 완료 후 프론트한테 돌려줄 응답 데이터
                 savedProblem.getId(),
                 savedProblem.getType(),
                 savedProblem.getTitle(),
@@ -106,6 +108,7 @@ public class ProblemCreateService {
         );
     }
 
+    // flag 원문을 암호화해서 저장 - DB에 정답 노출 안 되도록 (실습형)
     private String hashFlag(String flag) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -38,7 +38,7 @@ public class ProblemUpdateService {
             this.userRepository = userRepository;
         }
 
-    // 객관식
+    
     @Transactional
     public ProblemUpdateObjectiveResponse updateProblemObjective(long userId, long prodId, 
         ProblemUpdateObjectiveRequest request){
@@ -93,6 +93,7 @@ public class ProblemUpdateService {
             );
     }
 
+    // flag 원문을 암호화해서 저장 - DB에 정답 노출 안 되도록 (실습형)
     private String hashFlag(String flag) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -4,30 +4,41 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import net.diveon.backend.domain.problem.dto.request.ProblemUpdateObjectiveRequest;
+import net.diveon.backend.domain.problem.dto.request.ProblemUpdatePracticeRequest;
 import net.diveon.backend.domain.problem.dto.response.ProblemCreateObjectiveResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemUpdateObjectiveResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemUpdatePracticeResponse;
 import net.diveon.backend.domain.problem.entity.Problem;
 import net.diveon.backend.domain.problem.entity.ProblemObjective;
+import net.diveon.backend.domain.problem.entity.ProblemPractice;
 import net.diveon.backend.domain.problem.repository.ProblemObjectiveRepository;
+import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.repository.UserRepository;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
 
 @Service
 public class ProblemUpdateService {
     private final ProblemRepository problemRepository;
     private final ProblemObjectiveRepository problemObjectiveRepository;
+    private final ProblemPracticeRepository problemPracticeRepository;
     private final UserRepository userRepository;
 
     public ProblemUpdateService(ProblemRepository problemRepository,
         ProblemObjectiveRepository problemObjectiveRepository,
+        ProblemPracticeRepository problemPracticeRepository,
         UserRepository userRepository){
             this.problemObjectiveRepository = problemObjectiveRepository;
+            this.problemPracticeRepository = problemPracticeRepository;
             this.problemRepository = problemRepository;
             this.userRepository = userRepository;
         }
 
-    
+    // 객관식
     @Transactional
     public ProblemUpdateObjectiveResponse updateProblemObjective(long userId, long prodId, 
         ProblemUpdateObjectiveRequest request){
@@ -35,7 +46,7 @@ public class ProblemUpdateService {
 
             ProblemObjective problemObjective = problemObjectiveRepository.findById(prodId).orElseThrow();
 
-            problem.updateProblem(request.getTitle(), request.getDifficulty(), request.getVisibility());
+            problem.updateProblem(request.getTitle(), request.getCategory(), request.getDifficulty(), request.getVisibility());
 
             // 여기서 request.getObo().getEnabled() 으로 넣는데, 이때 null 이면 null.getEnabled() 라고되어서 문제 생김 나중에 수정이 필요함.
             problemObjective.updateProblemObjective(request.getTitle(), request.getDescription(), 
@@ -46,5 +57,49 @@ public class ProblemUpdateService {
             return new ProblemUpdateObjectiveResponse(prodId, request.getCategory(), request.getTitle(), problem.getUpatedAt().toString());
     }
 
-    
+    // 실습형
+    @Transactional
+    public ProblemUpdatePracticeResponse updateProblemPractice(String userId, long probId,
+        ProblemUpdatePracticeRequest request){
+            Problem problem = problemRepository.findById(probId).orElseThrow();
+            ProblemPractice problemPractice = problemPracticeRepository.findById(probId).orElseThrow();
+
+            problem.updateProblem(
+                request.getTitle(),
+                request.getCategory(),
+                request.getDifficulty(),
+                request.getVisibility()
+            );
+
+            String flagHash = request.getFlag() != null ? hashFlag(request.getFlag()) : null;
+            ProblemUpdatePracticeRequest.VmConfig vmConfig = request.getVmConfig();
+
+            problemPractice.updatePractice(
+                request.getSummary(),
+                request.getDescription(),
+                vmConfig != null ? vmConfig.getOsImage() : null,
+                vmConfig != null ? vmConfig.getAllowedCommands() : null,
+                vmConfig != null ? vmConfig.getCpuLimit() : null,
+                vmConfig != null ? vmConfig.getMemoryLimit() : null,
+                flagHash,
+                request.getDockerFileUrl()
+            );
+
+            return new ProblemUpdatePracticeResponse(
+                probId,
+                problem.getType(),
+                problem.getTitle(),
+                problem.getUpatedAt().toString()
+            );
+    }
+
+    private String hashFlag(String flag) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(flag.getBytes());
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
+    }
 }


### PR DESCRIPTION
## 작업 내용

- `POST /api/problems/practice` 실습형 문제 생성 API 구현
- `PATCH /api/problems/practice/{prob_id}` 실습형 문제 수정 API 구현
- `ProblemPractice` 엔티티 및 Repository 추가
- flag 평문 → SHA-256 해시 후 DB 저장
- Request DTO `@JsonProperty` 누락 수정 (vm_config, docker_file_url 등)

## 변경 파일

- `entity/ProblemPractice.java` (신규)
- `repository/ProblemPracticeRepository.java` (신규)
- `dto/request/ProblemCreatePracticeRequest.java` (신규)
- `dto/request/ProblemUpdatePracticeRequest.java` (신규)
- `dto/response/ProblemCreatePracticeResponse.java` (신규)
- `dto/response/ProblemUpdatePracticeResponse.java` (신규)
- `service/ProblemCreateService.java` (수정)
- `service/ProblemUpdateService.java` (수정)
- `controller/ProblemCreateController.java` (수정)
- `controller/ProblemUpdateController.java` (수정)

Closes #54
