### PR TITLE
[feat] 객관식 문제 상세 조회 구현을 하면서, 동시에 문제 상세 조회를 위한 기초작업 수행 (#75)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
@@ -1,0 +1,39 @@
+package net.diveon.backend.domain.problem.controller;
+
+import net.diveon.backend.domain.problem.dto.response.interfaces.ProblemDetailResponse;
+import net.diveon.backend.domain.problem.service.ProblemDetailService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/problems")
+public class ProblemController {
+
+    private final ProblemDetailService problemDetailService;
+
+    public ProblemController(ProblemDetailService problemDetailService) {
+        this.problemDetailService = problemDetailService;
+    }
+
+    /*
+     * 현재 컨트롤러 반환 타입은 ProblemDetailResponse 공통 인터페이스를 사용합니다.
+     * 추후 practice, coding 상세 조회 DTO가 추가되면 해당 DTO들도 ProblemDetailResponse를 구현하여
+     * 같은 endpoint에서 문제 유형별 상세 응답을 반환할 수 있습니다.
+     */
+    @GetMapping("/{prob_id}")
+    public ResponseEntity<ApiResponse<ProblemDetailResponse>> detailProblem(
+        @AuthenticationPrincipal String userId,
+        @PathVariable("prob_id") long probId
+    ) {
+        ProblemDetailResponse responseData =
+            problemDetailService.detailProblem(Long.parseLong(userId), probId);
+
+        return ResponseEntity.status(200)
+            .body(ApiResponse.success("문제 상세 조회에 성공하였습니다.", responseData));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemDetailObjectiveResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemDetailObjectiveResponse.java
@@ -1,0 +1,238 @@
+package net.diveon.backend.domain.problem.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.diveon.backend.domain.problem.dto.response.interfaces.ProblemDetailResponse;
+import net.diveon.backend.domain.problem.entity.OboStep;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.entity.ProblemObjective;
+import net.diveon.backend.domain.problem.others.ForDtoChoice;
+import net.diveon.backend.domain.problem.others.ForDtoOboStep;
+
+import java.util.List;
+
+/**
+ * 객관식 문제 상세 조회 응답의 data 영역을 위한 DTO
+ *
+ * <pre>
+ * {
+ *   "status": 200,
+ *   "message": "객관식 문제 상세 조회에 성공하였습니다.",
+ *   "data": {
+ *     "prob_id": 42,
+ *     "author": "박단용",
+ *     "type": "objective",
+ *     "title": "프로세스 스케줄링 이해하기",
+ *     "category": "process",
+ *     "difficulty": "medium",
+ *     "visibility": "public",
+ *     "summary": "Round Robin 스케줄링 개념 이해 문제",
+ *     "description": "다음 중 Round Robin 스케줄링에 대한 설명으로 옳은 것은?",
+ *     "choices": [
+ *       { "index": 1, "content": "선점형이다", "image_url": null }
+ *     ],
+ *     "answer": 1,
+ *     "obo_enabled": true,
+ *     "obo_steps": [
+ *       { "step": 1, "description": "설명", "image_url": null }
+ *     ],
+ *     "solved_count": 317,
+ *     "submitted_count": 412,
+ *     "created_at": "2025-03-01T09:00:00",
+ *     "updated_at": "2025-03-10T14:30:00"
+ *   }
+ * }
+ * </pre>
+ */
+public class ProblemDetailObjectiveResponse implements ProblemDetailResponse {
+
+    @JsonProperty("prob_id")
+    private Long probId;
+
+    private String author;
+    private String type;
+    private String title;
+    private String category;
+    private String difficulty;
+    private String visibility;
+    private String summary;
+    private String description;
+    private List<ForDtoChoice> choices;
+    private Integer answer;
+
+    @JsonProperty("obo_enabled")
+    private Boolean oboEnabled;
+
+    @JsonProperty("obo_steps")
+    private List<ForDtoOboStep> oboSteps;
+
+    @JsonProperty("solved_count")
+    private Integer solvedCount;
+
+    @JsonProperty("submitted_count")
+    private Integer submittedCount;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    @JsonProperty("updated_at")
+    private String updatedAt;
+
+    public ProblemDetailObjectiveResponse() {
+    }
+
+    public ProblemDetailObjectiveResponse(
+        Long probId,
+        String author,
+        String type,
+        String title,
+        String category,
+        String difficulty,
+        String visibility,
+        String summary,
+        String description,
+        List<ForDtoChoice> choices,
+        Integer answer,
+        Boolean oboEnabled,
+        List<ForDtoOboStep> oboSteps,
+        Integer solvedCount,
+        Integer submittedCount,
+        String createdAt,
+        String updatedAt
+    ) {
+        this.probId = probId;
+        this.author = author;
+        this.type = type;
+        this.title = title;
+        this.category = category;
+        this.difficulty = difficulty;
+        this.visibility = visibility;
+        this.summary = summary;
+        this.description = description;
+        this.choices = choices;
+        this.answer = answer;
+        this.oboEnabled = oboEnabled;
+        this.oboSteps = oboSteps;
+        this.solvedCount = solvedCount;
+        this.submittedCount = submittedCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    /*
+     * 현재는 DTO 내부의 정적 팩토리 메서드(of)를 통해
+     * Problem, ProblemObjective, OboStep 엔티티를 응답 DTO로 조립합니다.
+     *
+     * 이 방식은 서비스 코드의 길이를 줄이고, DTO 생성 규칙을 한 곳에 모을 수 있다는 장점이 있습니다.
+     *
+     * 다만 추후 상세 조회 응답 종류가 늘어나거나,
+     * objective/practice/coding 간 변환 로직이 복잡해질 경우
+     * DTO 내부에서 변환을 담당하기보다 별도의 Mapper 클래스로 분리할 수 있습니다.
+     *
+     * 예시:
+     * ProblemDetailMapper.toObjectiveResponse(problem, problemObjective, oboSteps)
+     *
+     * Mapper로 분리하면 DTO는 단순 데이터 전달 객체 역할에 집중하고,
+     * 엔티티 -> 응답 DTO 변환 책임은 Mapper가 담당하게 됩니다.
+     */
+    public static ProblemDetailObjectiveResponse of(
+        Problem problem,
+        ProblemObjective problemObjective,
+        List<OboStep> oboSteps
+    ) {
+        List<ForDtoOboStep> oboStepResponses = oboSteps.stream()
+            .map(oboStep -> new ForDtoOboStep(
+                oboStep.getStep(),
+                oboStep.getDescription(),
+                oboStep.getImageUrl()
+            ))
+            .toList();
+
+        return new ProblemDetailObjectiveResponse(
+            problem.getId(),
+            problem.getAuthor().getNickname(),
+            problem.getType(),
+            problem.getTitle(),
+            problem.getCategory(),
+            problem.getDifficulty(),
+            problem.getVisibility(),
+            problemObjective.getSummary(),
+            problemObjective.getDescription(),
+            problemObjective.getChoices(),
+            problemObjective.getAnswer(),
+            problemObjective.getOboEnabled(),
+            oboStepResponses,
+            problem.getSolvedCount(),
+            problem.getSubmittedCount(),
+            problem.getCreatedAt().toString(),
+            problem.getUpatedAt().toString()
+        );
+    }
+
+    public Long getProbId() {
+        return probId;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDifficulty() {
+        return difficulty;
+    }
+
+    public String getVisibility() {
+        return visibility;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<ForDtoChoice> getChoices() {
+        return choices;
+    }
+
+    public Integer getAnswer() {
+        return answer;
+    }
+
+    public Boolean getOboEnabled() {
+        return oboEnabled;
+    }
+
+    public List<ForDtoOboStep> getOboSteps() {
+        return oboSteps;
+    }
+
+    public Integer getSolvedCount() {
+        return solvedCount;
+    }
+
+    public Integer getSubmittedCount() {
+        return submittedCount;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/interfaces/ProblemDetailResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/interfaces/ProblemDetailResponse.java
@@ -1,0 +1,87 @@
+package net.diveon.backend.domain.problem.dto.response.interfaces;
+
+/**
+ * 문제 상세 조회 응답 DTO들이 공통으로 구현해야 하는 인터페이스입니다.
+ *
+ * <p>
+ * 현재 문제 상세 조회는 objective, practice, coding 등 문제 유형별로
+ * 서로 다른 응답 DTO를 가질 수 있습니다.
+ * 하지만 모든 문제 유형은 Problem 엔티티의 공통 컬럼을 기반으로 하는
+ * 기본 문제 정보를 응답에 포함해야 합니다.
+ * </p>
+ *
+ * <p>
+ * 따라서 이 인터페이스에 공통 getter를 명시하여,
+ * 컨트롤러와 서비스가 특정 문제 유형 DTO에 직접 의존하지 않고
+ * ProblemDetailResponse라는 공통 타입으로 응답을 다룰 수 있도록 합니다.
+ * </p>
+ */
+public interface ProblemDetailResponse {
+
+    /**
+     * 문제 상세 조회의 기준이 되는 Problem 엔티티의 id입니다.
+     * 응답 JSON에서는 prob_id로 내려갑니다.
+     */
+    Long getProbId();
+
+    /**
+     * 문제 작성자 정보입니다.
+     * Problem 엔티티는 User 엔티티를 author로 참조하지만,
+     * 응답에서는 User 전체가 아니라 nickname 문자열만 제공합니다.
+     */
+    String getAuthor();
+
+    /**
+     * 문제 유형입니다.
+     * objective, practice, coding 등 상세 응답 분기 기준으로 사용됩니다.
+     */
+    String getType();
+
+    /**
+     * 문제 제목입니다.
+     * 모든 문제 유형에서 공통적으로 제공되는 핵심 표시 정보입니다.
+     */
+    String getTitle();
+
+    /**
+     * 문제 카테고리입니다.
+     * 문제 목록, 상세 화면, 필터링 기준에서 공통적으로 사용할 수 있는 정보입니다.
+     */
+    String getCategory();
+
+    /**
+     * 문제 난이도입니다.
+     * easy, medium, hard 등 모든 문제 유형에서 공통으로 표시될 수 있습니다.
+     */
+    String getDifficulty();
+
+    /**
+     * 문제 공개 범위입니다.
+     * public, private, group 등 접근 정책이나 화면 표시 판단에 사용할 수 있습니다.
+     */
+    String getVisibility();
+
+    /**
+     * 문제를 성공적으로 해결한 횟수입니다.
+     * 모든 문제 유형에서 통계 정보로 공통 제공될 수 있습니다.
+     */
+    Integer getSolvedCount();
+
+    /**
+     * 문제 제출 횟수입니다.
+     * 풀이 시도 수 또는 제출 통계로 모든 문제 유형에서 공통 제공될 수 있습니다.
+     */
+    Integer getSubmittedCount();
+
+    /**
+     * 문제 생성 시각입니다.
+     * 모든 문제 유형에서 기본 메타데이터로 제공됩니다.
+     */
+    String getCreatedAt();
+
+    /**
+     * 문제 최종 수정 시각입니다.
+     * 모든 문제 유형에서 기본 메타데이터로 제공됩니다.
+     */
+    String getUpdatedAt();
+}

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemDetailService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemDetailService.java
@@ -1,0 +1,58 @@
+package net.diveon.backend.domain.problem.service;
+
+import net.diveon.backend.domain.problem.dto.response.ProblemDetailObjectiveResponse;
+import net.diveon.backend.domain.problem.dto.response.interfaces.ProblemDetailResponse;
+import net.diveon.backend.domain.problem.entity.OboStep;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.entity.ProblemObjective;
+import net.diveon.backend.domain.problem.repository.OboStepRepository;
+import net.diveon.backend.domain.problem.repository.ProblemObjectiveRepository;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ProblemNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ProblemDetailService {
+
+    private final UserRepository userRepository;
+    private final ProblemRepository problemRepository;
+    private final ProblemObjectiveRepository problemObjectiveRepository;
+    private final OboStepRepository oboStepRepository;
+
+    public ProblemDetailService(
+        UserRepository userRepository,
+        ProblemRepository problemRepository,
+        ProblemObjectiveRepository problemObjectiveRepository,
+        OboStepRepository oboStepRepository
+    ) {
+        this.userRepository = userRepository;
+        this.problemRepository = problemRepository;
+        this.problemObjectiveRepository = problemObjectiveRepository;
+        this.oboStepRepository = oboStepRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemDetailResponse detailProblem(long userId, long probId) {
+        userRepository.findById(userId).orElseThrow();
+
+        Problem problem = problemRepository.findById(probId)
+            .orElseThrow(() -> new ProblemNotFoundException(probId + "번에 해당하는 문제가 존재하지 않습니다."));
+
+        if (problem.getType().equals("objective")) {
+            return detailProblemObjective(problem, probId);
+        } else {
+            throw new ProblemNotFoundException(probId + "번 문제의 타입을 알 수 없습니다.");
+        }
+    }
+
+    private ProblemDetailObjectiveResponse detailProblemObjective(Problem problem, long probId) {
+        ProblemObjective problemObjective = problemObjectiveRepository.findById(probId).orElseThrow();
+        List<OboStep> oboSteps = oboStepRepository.findByProblem_IdOrderByStepAsc(probId);
+
+        return ProblemDetailObjectiveResponse.of(problem, problemObjective, oboSteps);
+    }
+}


### PR DESCRIPTION
변경사항
1. ProblemController를 detail 서비스를 위해서 생성
2. api의 형식상, 리턴을 구분하기 위해서, interface 도입
위치는 dto/response/interfaces 폴더 밑 ProblemDetailResponse.java 
3. ProblemDetailObjectiveResponse라는 응답용 dto 생성
4. ProblemDetail 서비스 구현
세부 내용은 코드 및 주석 참고