### PR TITLE
[refactor] userId 타입 통일 및 파라미터 순서 통일 - String → long, 변환 책임 Controller로 이동 (#81)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCreateController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCreateController.java
@@ -53,7 +53,7 @@ public class ProblemCreateController {
         ProblemCreateObjectiveResponse responseBody = new ProblemCreateObjectiveResponse();
 
         //실제 비즈니스 로직, 서비스 호출
-        responseBody = problemCreateService.createObjective(request, userId);
+        responseBody = problemCreateService.createObjective(Long.parseLong(userId), request);
 
         // 이거 호출함수 형태 수정해야함, 우리가 200 말고 다른 값을 넣을수없음(ApiResopone.success())
         return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
@@ -63,7 +63,7 @@ public class ProblemCreateController {
     @PostMapping("/coding")
     public ResponseEntity<ApiResponse<ProblemCreateCodingResponse>> createCodingProblem(@Valid @RequestBody ProblemCreateCodingRequest request,
         @AuthenticationPrincipal String userId) {
-        ProblemCreateCodingResponse responseBody = problemCreateService.createCoding(request, userId);
+        ProblemCreateCodingResponse responseBody = problemCreateService.createCoding(Long.parseLong(userId), request);
         return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
     }
 
@@ -73,7 +73,7 @@ public class ProblemCreateController {
             @Valid @RequestBody ProblemCreatePracticeRequest request,
             @AuthenticationPrincipal String userId) {
 
-            ProblemCreatePracticeResponse responseBody = problemCreateService.createPractice(request, userId); // 서비스를 호출
+            ProblemCreatePracticeResponse responseBody = problemCreateService.createPractice(Long.parseLong(userId), request); // 서비스를 호출
 
             return ResponseEntity.status(201).body(ApiResponse.success("문제가 등록되었습니다.", responseBody));
     }
@@ -84,7 +84,7 @@ public class ProblemCreateController {
     public ResponseEntity<ApiResponse<ProblemDeleteResponse>> deleteProblem(@PathVariable long prob_id,
         @AuthenticationPrincipal String userId){
 
-            ProblemDeleteResponse problemDeleteResponse = problemDeleteService.deleteProblem(userId, prob_id);
+            ProblemDeleteResponse problemDeleteResponse = problemDeleteService.deleteProblem(Long.parseLong(userId), prob_id);
             return ResponseEntity.status(200).body(ApiResponse.success("문제가 삭제되었습니다.", problemDeleteResponse));
         }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemUpdateController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemUpdateController.java
@@ -29,7 +29,8 @@ public class ProblemUpdateController {
 
     // 객관식
     @PatchMapping("/{prob_id}")
-    public ResponseEntity<ApiResponse<ProblemUpdateObjectiveResponse>> updateProblemObjective(@AuthenticationPrincipal String userId, 
+    public ResponseEntity<ApiResponse<ProblemUpdateObjectiveResponse>> updateProblemObjective(
+        @AuthenticationPrincipal String userId, 
         @RequestBody ProblemUpdateObjectiveRequest request,
         @PathVariable("prob_id") long probId){
 
@@ -50,7 +51,7 @@ public class ProblemUpdateController {
             @RequestBody ProblemUpdatePracticeRequest request,
             @PathVariable("prob_id") long probId) {
 
-        ProblemUpdatePracticeResponse responseData = problemUpdateService.updateProblemPractice(userId, probId, request);
+        ProblemUpdatePracticeResponse responseData = problemUpdateService.updateProblemPractice(Long.parseLong(userId), probId, request);
         return ResponseEntity.status(200).body(ApiResponse.success("문제가 수정되었습니다.", responseData));
     }
 
@@ -61,7 +62,7 @@ public class ProblemUpdateController {
             @RequestBody ProblemUpdateCodingRequest request,
             @PathVariable("prob_id") long probId) {
 
-        ProblemUpdateCodingResponse responseData = problemUpdateService.updateProblemCoding(userId, probId, request);
+        ProblemUpdateCodingResponse responseData = problemUpdateService.updateProblemCoding(Long.parseLong(userId), probId, request);
         return ResponseEntity.status(200).body(ApiResponse.success("문제가 수정되었습니다.", responseData));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
@@ -53,8 +53,8 @@ public class ProblemCreateService {
 
     // 객관식형
     @Transactional
-    public ProblemCreateObjectiveResponse createObjective(ProblemCreateObjectiveRequest request, String userId){
-        User author = userRepository.findById(Long.parseLong(userId))
+    public ProblemCreateObjectiveResponse createObjective(long userId, ProblemCreateObjectiveRequest request){
+        User author = userRepository.findById(userId)
                 .orElseThrow();
 
         Problem problem = new Problem(
@@ -111,8 +111,8 @@ public class ProblemCreateService {
 
     // 실습형
     @Transactional
-    public ProblemCreatePracticeResponse createPractice(ProblemCreatePracticeRequest request, String userId){
-        User author = userRepository.findById(Long.parseLong(userId))
+    public ProblemCreatePracticeResponse createPractice(long userId, ProblemCreatePracticeRequest request){
+        User author = userRepository.findById(userId)
                 .orElseThrow();
 
         Problem problem = new Problem(
@@ -148,8 +148,8 @@ public class ProblemCreateService {
 
     // 코딩형
     @Transactional
-    public ProblemCreateCodingResponse createCoding(ProblemCreateCodingRequest request, String userId) {
-        User author = userRepository.findById(Long.parseLong(userId))
+    public ProblemCreateCodingResponse createCoding(long userId, ProblemCreateCodingRequest request) {
+        User author = userRepository.findById(userId)
                 .orElseThrow();
 
         Problem problem = new Problem(

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemDeleteService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemDeleteService.java
@@ -55,7 +55,7 @@ public class ProblemDeleteService {
 
     // 분기 로직
     @Transactional
-    public ProblemDeleteResponse deleteProblem(String userId, long probId){
+    public ProblemDeleteResponse deleteProblem(long userId, long probId){
         Problem problem = problemRepository.findById(probId)
             .orElseThrow(() -> new ProblemNotFoundException(probId + "번에 해당하는 문제가 존재하지 않습니다."));
 
@@ -74,7 +74,7 @@ public class ProblemDeleteService {
 
     // 객관식형
     @Transactional
-    public ProblemDeleteResponse deleteProblemObjective(String userId, long prodId){
+    public ProblemDeleteResponse deleteProblemObjective(long userId, long prodId){
 
         // // 아래 코드는 검증을 좀더 깔끔한 방식으로 할 수 있다면 좋을듯.
         // problemRepository.findById(prodId).orElseThrow(ProblemNotFoundException::new);
@@ -107,7 +107,7 @@ public class ProblemDeleteService {
 
     // 실습형
     @Transactional
-    public ProblemDeleteResponse deleteProblemPractice(String userId, long probId){
+    public ProblemDeleteResponse deleteProblemPractice(long userId, long probId){
         problemPracticeRepository.deleteById(probId);
         problemRepository.deleteById(probId);
 
@@ -116,7 +116,7 @@ public class ProblemDeleteService {
 
     // 코딩형
     @Transactional
-    public ProblemDeleteResponse deleteProblemCoding(String userId, long probId){
+    public ProblemDeleteResponse deleteProblemCoding(long userId, long probId){
         problemCodingRepository.deleteById(probId);
         problemRepository.deleteById(probId);
 

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -100,7 +100,7 @@ public class ProblemUpdateService {
 
     // 코딩형
     @Transactional
-    public ProblemUpdateCodingResponse updateProblemCoding(String userId, long probId,
+    public ProblemUpdateCodingResponse updateProblemCoding(long userId, long probId,
         ProblemUpdateCodingRequest request) {
         Problem problem = problemRepository.findById(probId).orElseThrow();
         ProblemCoding problemCoding = problemCodingRepository.findById(probId).orElseThrow();
@@ -134,7 +134,7 @@ public class ProblemUpdateService {
     
     // 실습형
     @Transactional
-    public ProblemUpdatePracticeResponse updateProblemPractice(String userId, long probId,
+    public ProblemUpdatePracticeResponse updateProblemPractice(long userId, long probId,
         ProblemUpdatePracticeRequest request){
             Problem problem = problemRepository.findById(probId).orElseThrow();
             ProblemPractice problemPractice = problemPracticeRepository.findById(probId).orElseThrow();


### PR DESCRIPTION
## 변경 사항
- Controller에서 Long.parseLong(userId) 변환 후 Service에 long으로 전달하도록 통일
- Service 파라미터 타입 String userId → long userId 변경
- 생성/수정/삭제 서비스 파라미터 순서도 (long userId, Request request)로 통일

## 변경 파일
- ProblemCreateController, ProblemUpdateController
- ProblemCreateService, ProblemUpdateService, ProblemDeleteService

Closes #81
