### PR TITLE
[feat] 댓글 CRUD API 구현 (#79)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCommentController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCommentController.java
@@ -43,6 +43,20 @@ public class ProblemCommentController {
             .body(ApiResponse.success("댓글 목록 조회에 성공하였습니다.", responseData));
     }
 
+    // 댓글 상세 조회
+    @GetMapping("/{prob_id}/comments/{comment_id}")
+    public ResponseEntity<ApiResponse<ProblemCommentResponse.CommentItem>> getComment(
+        @AuthenticationPrincipal String userId,
+        @PathVariable("prob_id") long probId,
+        @PathVariable("comment_id") long commentId
+    ) {
+        ProblemCommentResponse.CommentItem responseData =
+            commentService.getComment(Long.parseLong(userId), probId, commentId);
+
+        return ResponseEntity.status(200)
+            .body(ApiResponse.success("댓글 상세 조회에 성공하였습니다.", responseData));
+    }
+
     // 댓글 생성
     @PostMapping("/{prob_id}/comments")
     public ResponseEntity<ApiResponse<ProblemCommentResponse.CommentCreate>> createComment(

--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCommentController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemCommentController.java
@@ -1,0 +1,88 @@
+package net.diveon.backend.domain.problem.controller;
+
+import jakarta.validation.Valid;
+import net.diveon.backend.domain.problem.dto.request.ProblemCommentCreateRequest;
+import net.diveon.backend.domain.problem.dto.request.ProblemCommentUpdateRequest;
+import net.diveon.backend.domain.problem.dto.response.ProblemCommentResponse;
+import net.diveon.backend.domain.problem.service.ProblemCommentService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/problems")
+public class ProblemCommentController {
+
+    private final ProblemCommentService commentService;
+
+    public ProblemCommentController(ProblemCommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    // 댓글 조회
+    @GetMapping("/{prob_id}/comments")
+    public ResponseEntity<ApiResponse<ProblemCommentResponse.CommentList>> getComments(
+        @AuthenticationPrincipal String userId,
+        @PathVariable("prob_id") long probId,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        ProblemCommentResponse.CommentList responseData =
+            commentService.getComments(Long.parseLong(userId), probId, page, size);
+
+        return ResponseEntity.status(200)
+            .body(ApiResponse.success("댓글 목록 조회에 성공하였습니다.", responseData));
+    }
+
+    // 댓글 생성
+    @PostMapping("/{prob_id}/comments")
+    public ResponseEntity<ApiResponse<ProblemCommentResponse.CommentCreate>> createComment(
+        @AuthenticationPrincipal String userId,
+        @PathVariable("prob_id") long probId,
+        @Valid @RequestBody ProblemCommentCreateRequest request
+    ) {
+        ProblemCommentResponse.CommentCreate responseData =
+            commentService.createComment(Long.parseLong(userId), probId, request);
+
+        return ResponseEntity.status(201)
+            .body(ApiResponse.success("댓글이 작성되었습니다.", responseData));
+    }
+
+    // 댓글 수정
+    @PatchMapping("/{prob_id}/comments/{comment_id}")
+    public ResponseEntity<ApiResponse<ProblemCommentResponse.CommentUpdate>> updateComment(
+        @AuthenticationPrincipal String userId,
+        @PathVariable("prob_id") long probId,
+        @PathVariable("comment_id") long commentId,
+        @RequestBody ProblemCommentUpdateRequest request
+    ) {
+        ProblemCommentResponse.CommentUpdate responseData =
+            commentService.updateComment(Long.parseLong(userId), probId, commentId, request);
+
+        return ResponseEntity.status(200)
+            .body(ApiResponse.success("댓글이 수정되었습니다.", responseData));
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{prob_id}/comments/{comment_id}")
+    public ResponseEntity<ApiResponse<ProblemCommentResponse.CommentDelete>> deleteComment(
+        @AuthenticationPrincipal String userId,
+        @PathVariable("prob_id") long probId,
+        @PathVariable("comment_id") long commentId
+    ) {
+        ProblemCommentResponse.CommentDelete responseData =
+            commentService.deleteComment(Long.parseLong(userId), probId, commentId);
+
+        return ResponseEntity.status(200)
+            .body(ApiResponse.success("댓글이 삭제되었습니다.", responseData));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCommentCreateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCommentCreateRequest.java
@@ -1,0 +1,28 @@
+package net.diveon.backend.domain.problem.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public class ProblemCommentCreateRequest {
+
+    @NotBlank
+    private String content;
+
+    @JsonProperty("is_private")
+    private Boolean isPrivate = false;
+
+    @JsonProperty("parent_id")
+    private Long parentId;
+
+    public ProblemCommentCreateRequest() {
+    }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public Boolean getIsPrivate() { return isPrivate; }
+    public void setIsPrivate(Boolean isPrivate) { this.isPrivate = isPrivate; }
+
+    public Long getParentId() { return parentId; }
+    public void setParentId(Long parentId) { this.parentId = parentId; }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCommentUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCommentUpdateRequest.java
@@ -1,0 +1,20 @@
+package net.diveon.backend.domain.problem.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ProblemCommentUpdateRequest {
+
+    private String content;
+
+    @JsonProperty("is_private")
+    private Boolean isPrivate;
+
+    public ProblemCommentUpdateRequest() {
+    }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public Boolean getIsPrivate() { return isPrivate; }
+    public void setIsPrivate(Boolean isPrivate) { this.isPrivate = isPrivate; }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCommentResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCommentResponse.java
@@ -1,0 +1,220 @@
+package net.diveon.backend.domain.problem.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import net.diveon.backend.domain.problem.entity.ProblemComment;
+
+import java.util.List;
+
+public class ProblemCommentResponse {
+
+    public static class CommentList {
+
+        private long total;
+        private int page;
+        private int size;
+        private List<CommentItem> comments;
+
+        public CommentList(long total, int page, int size, List<CommentItem> comments) {
+            this.total = total;
+            this.page = page;
+            this.size = size;
+            this.comments = comments;
+        }
+
+        public long getTotal() { return total; }
+        public int getPage() { return page; }
+        public int getSize() { return size; }
+        public List<CommentItem> getComments() { return comments; }
+    }
+
+    public static class CommentItem {
+
+        @JsonProperty("comment_id")
+        private Long commentId;
+
+        @JsonProperty("author_nickname")
+        private String authorNickname;
+
+        private String content;
+
+        @JsonProperty("is_private")
+        private Boolean isPrivate;
+
+        @JsonProperty("created_at")
+        private String createdAt;
+
+        @JsonProperty("updated_at")
+        private String updatedAt;
+
+        private List<ReplyItem> replies;
+
+        public CommentItem(Long commentId, String authorNickname, String content,
+                           Boolean isPrivate, String createdAt, String updatedAt,
+                           List<ReplyItem> replies) {
+            this.commentId = commentId;
+            this.authorNickname = authorNickname;
+            this.content = content;
+            this.isPrivate = isPrivate;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+            this.replies = replies;
+        }
+
+        public static CommentItem of(ProblemComment comment, List<ReplyItem> replies) {
+            return new CommentItem(
+                comment.getId(),
+                comment.getAuthor().getNickname(),
+                comment.getContent(),
+                comment.getIsPrivate(),
+                comment.getCreatedAt().toString(),
+                comment.getUpdatedAt().toString(),
+                replies
+            );
+        }
+
+        public Long getCommentId() { return commentId; }
+        public String getAuthorNickname() { return authorNickname; }
+        public String getContent() { return content; }
+        public Boolean getIsPrivate() { return isPrivate; }
+        public String getCreatedAt() { return createdAt; }
+        public String getUpdatedAt() { return updatedAt; }
+        public List<ReplyItem> getReplies() { return replies; }
+    }
+
+    public static class ReplyItem {
+
+        @JsonProperty("comment_id")
+        private Long commentId;
+
+        @JsonProperty("author_nickname")
+        private String authorNickname;
+
+        private String content;
+
+        @JsonProperty("is_private")
+        private Boolean isPrivate;
+
+        @JsonProperty("created_at")
+        private String createdAt;
+
+        @JsonProperty("updated_at")
+        private String updatedAt;
+
+        public ReplyItem(Long commentId, String authorNickname, String content,
+                         Boolean isPrivate, String createdAt, String updatedAt) {
+            this.commentId = commentId;
+            this.authorNickname = authorNickname;
+            this.content = content;
+            this.isPrivate = isPrivate;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+        }
+
+        public static ReplyItem of(ProblemComment reply) {
+            return new ReplyItem(
+                reply.getId(),
+                reply.getAuthor().getNickname(),
+                reply.getContent(),
+                reply.getIsPrivate(),
+                reply.getCreatedAt().toString(),
+                reply.getUpdatedAt().toString()
+            );
+        }
+
+        public Long getCommentId() { return commentId; }
+        public String getAuthorNickname() { return authorNickname; }
+        public String getContent() { return content; }
+        public Boolean getIsPrivate() { return isPrivate; }
+        public String getCreatedAt() { return createdAt; }
+        public String getUpdatedAt() { return updatedAt; }
+    }
+
+    public static class CommentCreate {
+
+        @JsonProperty("comment_id")
+        private Long commentId;
+
+        @JsonProperty("prob_id")
+        private Long probId;
+
+        @JsonProperty("author_nickname")
+        private String authorNickname;
+
+        private String content;
+
+        @JsonProperty("created_at")
+        private String createdAt;
+
+        public CommentCreate(Long commentId, Long probId, String authorNickname,
+                             String content, String createdAt) {
+            this.commentId = commentId;
+            this.probId = probId;
+            this.authorNickname = authorNickname;
+            this.content = content;
+            this.createdAt = createdAt;
+        }
+
+        public static CommentCreate of(ProblemComment comment) {
+            return new CommentCreate(
+                comment.getId(),
+                comment.getProblem().getId(),
+                comment.getAuthor().getNickname(),
+                comment.getContent(),
+                comment.getCreatedAt().toString()
+            );
+        }
+
+        public Long getCommentId() { return commentId; }
+        public Long getProbId() { return probId; }
+        public String getAuthorNickname() { return authorNickname; }
+        public String getContent() { return content; }
+        public String getCreatedAt() { return createdAt; }
+    }
+
+    public static class CommentUpdate {
+
+        @JsonProperty("comment_id")
+        private Long commentId;
+
+        private String content;
+
+        @JsonProperty("is_private")
+        private Boolean isPrivate;
+
+        @JsonProperty("updated_at")
+        private String updatedAt;
+
+        public CommentUpdate(Long commentId, String content, Boolean isPrivate, String updatedAt) {
+            this.commentId = commentId;
+            this.content = content;
+            this.isPrivate = isPrivate;
+            this.updatedAt = updatedAt;
+        }
+
+        public static CommentUpdate of(ProblemComment comment) {
+            return new CommentUpdate(
+                comment.getId(),
+                comment.getContent(),
+                comment.getIsPrivate(),
+                comment.getUpdatedAt().toString()
+            );
+        }
+
+        public Long getCommentId() { return commentId; }
+        public String getContent() { return content; }
+        public Boolean getIsPrivate() { return isPrivate; }
+        public String getUpdatedAt() { return updatedAt; }
+    }
+
+    public static class CommentDelete {
+
+        @JsonProperty("comment_id")
+        private Long commentId;
+
+        public CommentDelete(Long commentId) {
+            this.commentId = commentId;
+        }
+
+        public Long getCommentId() { return commentId; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCommentResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemCommentResponse.java
@@ -12,9 +12,9 @@ public class ProblemCommentResponse {
         private long total;
         private int page;
         private int size;
-        private List<CommentItem> comments;
+        private List<CommentListItem> comments;
 
-        public CommentList(long total, int page, int size, List<CommentItem> comments) {
+        public CommentList(long total, int page, int size, List<CommentListItem> comments) {
             this.total = total;
             this.page = page;
             this.size = size;
@@ -24,9 +24,59 @@ public class ProblemCommentResponse {
         public long getTotal() { return total; }
         public int getPage() { return page; }
         public int getSize() { return size; }
-        public List<CommentItem> getComments() { return comments; }
+        public List<CommentListItem> getComments() { return comments; }
     }
 
+    // 댓글 목록 조회용 (replies 없음)
+    public static class CommentListItem {
+
+        @JsonProperty("comment_id")
+        private Long commentId;
+
+        @JsonProperty("author_nickname")
+        private String authorNickname;
+
+        private String content;
+
+        @JsonProperty("is_private")
+        private Boolean isPrivate;
+
+        @JsonProperty("created_at")
+        private String createdAt;
+
+        @JsonProperty("updated_at")
+        private String updatedAt;
+
+        public CommentListItem(Long commentId, String authorNickname, String content,
+                               Boolean isPrivate, String createdAt, String updatedAt) {
+            this.commentId = commentId;
+            this.authorNickname = authorNickname;
+            this.content = content;
+            this.isPrivate = isPrivate;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+        }
+
+        public static CommentListItem of(ProblemComment comment) {
+            return new CommentListItem(
+                comment.getId(),
+                comment.getAuthor().getNickname(),
+                comment.getContent(),
+                comment.getIsPrivate(),
+                comment.getCreatedAt().toString(),
+                comment.getUpdatedAt().toString()
+            );
+        }
+
+        public Long getCommentId() { return commentId; }
+        public String getAuthorNickname() { return authorNickname; }
+        public String getContent() { return content; }
+        public Boolean getIsPrivate() { return isPrivate; }
+        public String getCreatedAt() { return createdAt; }
+        public String getUpdatedAt() { return updatedAt; }
+    }
+
+    // 댓글 상세 조회용 (replies 있음)
     public static class CommentItem {
 
         @JsonProperty("comment_id")

--- a/src/main/java/net/diveon/backend/domain/problem/entity/ProblemComment.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/ProblemComment.java
@@ -1,0 +1,77 @@
+package net.diveon.backend.domain.problem.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import net.diveon.backend.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+public class ProblemComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id") // PK
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) // ManyToOne - Many(댓글) -> One(문제) 문제 하나에 댓글 여러개 가능
+    @JoinColumn(name = "prob_id", nullable = false) // FK
+    private Problem problem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false) // FK
+    private User author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id") // 자기 자신 테이블 참조 FK
+    private ProblemComment parent;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "is_private", nullable = false)
+    private Boolean isPrivate;
+
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    public ProblemComment() {
+    }
+
+    public ProblemComment(Problem problem, User author, ProblemComment parent, String content, Boolean isPrivate) {
+        this.problem = problem;
+        this.author = author;
+        this.parent = parent;
+        this.content = content;
+        this.isPrivate = isPrivate != null ? isPrivate : false;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    public Long getId() { return id; }
+    public Problem getProblem() { return problem; }
+    public User getAuthor() { return author; }
+    public ProblemComment getParent() { return parent; }
+    public String getContent() { return content; }
+    public Boolean getIsPrivate() { return isPrivate; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+
+    public void updateComment(String content, Boolean isPrivate) {
+        if (content != null) this.content = content;
+        if (isPrivate != null) this.isPrivate = isPrivate;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/repository/ProblemCommentRepository.java
+++ b/src/main/java/net/diveon/backend/domain/problem/repository/ProblemCommentRepository.java
@@ -11,5 +11,5 @@ public interface ProblemCommentRepository extends JpaRepository<ProblemComment, 
 
     Page<ProblemComment> findByProblem_IdAndParentIsNull(Long probId, Pageable pageable);
     // Page<>는 데이터 목록이랑 총 개수를 한번에 가져와 줌. (List<>로 받으면 count쿼리를 따로 날려야.)
-    List<ProblemComment> findByParent_IdIn(List<Long> parentIds);
+    List<ProblemComment> findByParent_IdInOrderByCreatedAtAsc(List<Long> parentIds);
 }

--- a/src/main/java/net/diveon/backend/domain/problem/repository/ProblemCommentRepository.java
+++ b/src/main/java/net/diveon/backend/domain/problem/repository/ProblemCommentRepository.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.problem.repository;
+
+import net.diveon.backend.domain.problem.entity.ProblemComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProblemCommentRepository extends JpaRepository<ProblemComment, Long> {
+
+    Page<ProblemComment> findByProblem_IdAndParentIsNull(Long probId, Pageable pageable);
+    // Page<>는 데이터 목록이랑 총 개수를 한번에 가져와 줌. (List<>로 받으면 count쿼리를 따로 날려야.)
+    List<ProblemComment> findByParent_IdIn(List<Long> parentIds);
+}

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCommentService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCommentService.java
@@ -13,12 +13,11 @@ import net.diveon.backend.global.exception.CommentNotFoundException;
 import net.diveon.backend.global.exception.ProblemNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 public class ProblemCommentService {
@@ -37,7 +36,7 @@ public class ProblemCommentService {
         this.userRepository = userRepository;
     }
 
-    // 댓글 조회
+    // 댓글 목록 조회
     // readOnly = true: DB 읽기만 하는 메서드. 변경 감지 안 해서 성능 최적화
     @Transactional(readOnly = true)
     public ProblemCommentResponse.CommentList getComments(long userId, long probId, int page, int size) {
@@ -45,27 +44,11 @@ public class ProblemCommentService {
             .orElseThrow(() -> new ProblemNotFoundException(probId + "번에 해당하는 문제가 존재하지 않습니다."));
 
         // 최상위 댓글만 (parent = null) 페이지 단위로 가져옴. page-1인 이유: JPA는 페이지 0부터 시작
-        Page<ProblemComment> commentPage = commentRepository.findByProblem_IdAndParentIsNull(probId, PageRequest.of(page - 1, size));
+        Page<ProblemComment> commentPage = commentRepository.findByProblem_IdAndParentIsNull(probId, PageRequest.of(page - 1, size, Sort.by("createdAt").descending()));
 
-        // 댓글 객체들에서 id만 뽑아서 [1, 2, 3] 리스트로 만듦. 아래 답글 조회에 사용
-        List<Long> commentIds = commentPage.getContent().stream().map(comment -> comment.getId()).toList();
-
-        // [1, 2, 3] 댓글들의 답글을 한번에 조회하고 부모 댓글id 기준으로 그룹핑
-        // 결과: { 1 → [답글A, 답글B], 2 → [답글C] } 형태의 Map
-        Map<Long, List<ProblemCommentResponse.ReplyItem>> repliesMap = commentRepository
-            .findByParent_IdIn(commentIds)
-            .stream()
-            .collect(Collectors.groupingBy(
-                reply -> reply.getParent().getId(),
-                Collectors.mapping(reply -> ProblemCommentResponse.ReplyItem.of(reply), Collectors.toList())
-            ));
-
-        // 댓글 하나씩 돌면서 해당 답글 붙여서 CommentItem DTO로 변환. 답글 없으면 빈 리스트
-        List<ProblemCommentResponse.CommentItem> comments = commentPage.getContent().stream()
-            .map(comment -> ProblemCommentResponse.CommentItem.of(
-                comment,
-                repliesMap.getOrDefault(comment.getId(), List.of())
-            ))
+        // 댓글 하나씩 돌면서 CommentListItem DTO로 변환 (replies 없음)
+        List<ProblemCommentResponse.CommentListItem> comments = commentPage.getContent().stream()
+            .map(comment -> ProblemCommentResponse.CommentListItem.of(comment))
             .toList();
 
         // 총 댓글 수, 페이지, 사이즈, 댓글 목록 묶어서 반환
@@ -75,6 +58,21 @@ public class ProblemCommentService {
             size,
             comments
         );
+    }
+
+    // 댓글 상세 조회
+    @Transactional(readOnly = true)
+    public ProblemCommentResponse.CommentItem getComment(long userId, long probId, long commentId) {
+        ProblemComment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new CommentNotFoundException(commentId + "번에 해당하는 댓글이 존재하지 않습니다."));
+
+        List<ProblemCommentResponse.ReplyItem> replies = commentRepository
+            .findByParent_IdInOrderByCreatedAtAsc(List.of(commentId))
+            .stream()
+            .map(reply -> ProblemCommentResponse.ReplyItem.of(reply))
+            .toList();
+
+        return ProblemCommentResponse.CommentItem.of(comment, replies);
     }
 
     // 댓글 생성

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCommentService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCommentService.java
@@ -1,0 +1,120 @@
+package net.diveon.backend.domain.problem.service;
+
+import net.diveon.backend.domain.problem.dto.request.ProblemCommentCreateRequest;
+import net.diveon.backend.domain.problem.dto.request.ProblemCommentUpdateRequest;
+import net.diveon.backend.domain.problem.dto.response.ProblemCommentResponse;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.entity.ProblemComment;
+import net.diveon.backend.domain.problem.repository.ProblemCommentRepository;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.CommentNotFoundException;
+import net.diveon.backend.global.exception.ProblemNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class ProblemCommentService {
+
+    private final ProblemCommentRepository commentRepository;
+    private final ProblemRepository problemRepository;
+    private final UserRepository userRepository;
+
+    public ProblemCommentService(
+        ProblemCommentRepository commentRepository,
+        ProblemRepository problemRepository,
+        UserRepository userRepository
+    ) {
+        this.commentRepository = commentRepository;
+        this.problemRepository = problemRepository;
+        this.userRepository = userRepository;
+    }
+
+    // 댓글 조회
+    // readOnly = true: DB 읽기만 하는 메서드. 변경 감지 안 해서 성능 최적화
+    @Transactional(readOnly = true)
+    public ProblemCommentResponse.CommentList getComments(long userId, long probId, int page, int size) {
+        problemRepository.findById(probId)
+            .orElseThrow(() -> new ProblemNotFoundException(probId + "번에 해당하는 문제가 존재하지 않습니다."));
+
+        // 최상위 댓글만 (parent = null) 페이지 단위로 가져옴. page-1인 이유: JPA는 페이지 0부터 시작
+        Page<ProblemComment> commentPage = commentRepository.findByProblem_IdAndParentIsNull(probId, PageRequest.of(page - 1, size));
+
+        // 댓글 객체들에서 id만 뽑아서 [1, 2, 3] 리스트로 만듦. 아래 답글 조회에 사용
+        List<Long> commentIds = commentPage.getContent().stream().map(comment -> comment.getId()).toList();
+
+        // [1, 2, 3] 댓글들의 답글을 한번에 조회하고 부모 댓글id 기준으로 그룹핑
+        // 결과: { 1 → [답글A, 답글B], 2 → [답글C] } 형태의 Map
+        Map<Long, List<ProblemCommentResponse.ReplyItem>> repliesMap = commentRepository
+            .findByParent_IdIn(commentIds)
+            .stream()
+            .collect(Collectors.groupingBy(
+                reply -> reply.getParent().getId(),
+                Collectors.mapping(reply -> ProblemCommentResponse.ReplyItem.of(reply), Collectors.toList())
+            ));
+
+        // 댓글 하나씩 돌면서 해당 답글 붙여서 CommentItem DTO로 변환. 답글 없으면 빈 리스트
+        List<ProblemCommentResponse.CommentItem> comments = commentPage.getContent().stream()
+            .map(comment -> ProblemCommentResponse.CommentItem.of(
+                comment,
+                repliesMap.getOrDefault(comment.getId(), List.of())
+            ))
+            .toList();
+
+        // 총 댓글 수, 페이지, 사이즈, 댓글 목록 묶어서 반환
+        return new ProblemCommentResponse.CommentList(
+            commentPage.getTotalElements(),
+            page,
+            size,
+            comments
+        );
+    }
+
+    // 댓글 생성
+    @Transactional
+    public ProblemCommentResponse.CommentCreate createComment(long userId, long probId, ProblemCommentCreateRequest request) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Problem problem = problemRepository.findById(probId)
+            .orElseThrow(() -> new ProblemNotFoundException(probId + "번에 해당하는 문제가 존재하지 않습니다."));
+
+        ProblemComment parent = null;
+        if (request.getParentId() != null) {
+            parent = commentRepository.findById(request.getParentId())
+                .orElseThrow(() -> new CommentNotFoundException(request.getParentId() + "번에 해당하는 댓글이 존재하지 않습니다."));
+        }
+
+        ProblemComment comment = new ProblemComment(problem, user, parent, request.getContent(), request.getIsPrivate());
+        ProblemComment saved = commentRepository.save(comment);
+
+        return ProblemCommentResponse.CommentCreate.of(saved);
+    }
+
+    // 댓글 수정
+    @Transactional
+    public ProblemCommentResponse.CommentUpdate updateComment(long userId, long probId, long commentId, ProblemCommentUpdateRequest request) {
+        ProblemComment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new CommentNotFoundException(commentId + "번에 해당하는 댓글이 존재하지 않습니다."));
+
+        comment.updateComment(request.getContent(), request.getIsPrivate());
+
+        return ProblemCommentResponse.CommentUpdate.of(comment);
+    }
+
+    // 댓글 삭제
+    @Transactional
+    public ProblemCommentResponse.CommentDelete deleteComment(long userId, long probId, long commentId) {
+        ProblemComment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new CommentNotFoundException(commentId + "번에 해당하는 댓글이 존재하지 않습니다."));
+
+        commentRepository.delete(comment);
+
+        return new ProblemCommentResponse.CommentDelete(commentId);
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/CommentNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package net.diveon.backend.global.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException() {
+        super("댓글을 찾을 수 없습니다.");
+    }
+
+    public CommentNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- 댓글/답글 생성, 목록 조회, 상세 조회, 수정, 삭제 API 구현
- 댓글 목록 조회와 상세 조회 분리 (목록: 댓글만, 상세: 댓글+답글)
- 댓글 최신순, 답글 오래된순 정렬

## Test plan
- [ ] 댓글 생성 (POST /api/problems/{prob_id}/comments)
- [ ] 답글 생성 (POST /api/problems/{prob_id}/comments + parent_id)
- [ ] 댓글 목록 조회 (GET /api/problems/{prob_id}/comments)
- [ ] 댓글 상세 조회 (GET /api/problems/{prob_id}/comments/{comment_id})
- [ ] 댓글 수정 (PATCH /api/problems/{prob_id}/comments/{comment_id})
- [ ] 댓글 삭제 (DELETE /api/problems/{prob_id}/comments/{comment_id})

Closes #79