### PR TITLE
[feat] GlobalExceptionHandler에 CommentNotFoundException 핸들러 추가 (#92)

### DIFF
--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -69,6 +69,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
         }
 
+        // 댓글을 찾을 수 없음 → 404
+        @ExceptionHandler(CommentNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleCommentNotFound(
+                CommentNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/comment-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
         // 문제를 찾을 수 없음 → 404
         @ExceptionHandler(ProblemNotFoundException.class)
         public ResponseEntity<ErrorResponse> handleProblemNotFound(


### PR DESCRIPTION
## Summary
- CommentNotFoundException 발생 시 500 에러 대신 404로 반환하도록 핸들러 추가

## Test plan
- [ ] 없는 댓글 id로 상세 조회 시 404 반환 확인
- [ ] 없는 댓글 id로 수정 시 404 반환 확인
- [ ] 없는 댓글 id로 삭제 시 404 반환 확인

Closes #92