### PR TITLE
[refactor] Authentication → @AuthenticationPrincipal 방식으로 통일 및 변환 책임 C…

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/controller/ProfileController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/ProfileController.java
@@ -4,7 +4,7 @@ import net.diveon.backend.domain.user.dto.ProfileShowResponse;
 import net.diveon.backend.domain.user.service.ProfileService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,13 +19,9 @@ public class ProfileController {
         this.profileService = profileService;
     }
 
-    // GET /api/profile/show
-    // JwtFilter가 SecurityContext에 저장한 인증 정보에서 userId 추출
-    // 별도로 토큰 파싱 없이 Authentication 객체로 userId 바로 사용 가능
     @GetMapping("/show")
-    public ResponseEntity<ApiResponse<ProfileShowResponse>> show(Authentication authentication) {
-        String userId = authentication.getName(); // userId 꺼냄
-        ProfileShowResponse response = profileService.getProfile(userId);
+    public ResponseEntity<ApiResponse<ProfileShowResponse>> show(@AuthenticationPrincipal String userId) {
+        ProfileShowResponse response = profileService.getProfile(Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("성공", response));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
@@ -18,8 +18,8 @@ public class ProfileService {
 
     // userId로 유저 조회 후 ProfileShowResponse로 변환하여 반환
     // 유저가 없으면 UserNotFoundException → 404
-    public ProfileShowResponse getProfile(String userId) {
-        User user = userRepository.findById(Long.parseLong(userId))
+    public ProfileShowResponse getProfile(long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
         return new ProfileShowResponse(new ProfileShowResponse.UserInfo(user));


### PR DESCRIPTION
## 변경 사항

- `ProfileController`: `Authentication` 객체 → `@AuthenticationPrincipal String userId` 방식으로 변경
- `ProfileController`: `Long.parseLong()` 변환 책임을 Service → Controller로 이동
- `ProfileService`: `getProfile(String userId)` → `getProfile(long userId)` 파라미터 타입 변경

## 변경 이유

기존 `ProfileController`는 `Authentication` 객체를 직접 받아 `authentication.getName()`으로 userId를 꺼내고, `String` 타입 그대로 Service에 넘겨 Service 내부에서 `Long.parseLong()`을 수행했음.

다른 컨트롤러들(`ProblemCommentController` 등)은 이미 `@AuthenticationPrincipal`로 받아 Controller에서 `Long.parseLong()` 변환 후 Service에 `long` 타입으로 넘기는 방식을 사용하고 있어 패턴 불일치가 있었음.

## 관련 이슈

Closes #94
