### PR TITLE
[refactor] User 엔티티 userId 필드명을 loginId로 변경 (#97)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/dto/AuthLoginRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/AuthLoginRequest.java
@@ -5,11 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 public class AuthLoginRequest {
 
     @NotBlank
-    private String user_id;
+    private String login_id;
 
     @NotBlank
     private String password;
 
-    public String getUser_id() { return user_id; }
+    public String getLogin_id() { return login_id; }
     public String getPassword() { return password; }
 }

--- a/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.NotBlank;
  * 현재 회원 가입 기능의 request body는 다음과 같음
  * {
     "email": "{{userEmailAddrInput}}",
-    "user_id": "{{userIdInput}}",
+    "login_id": "{{userIdInput}}",
     "password": "{{userPwInput}}",
     "nick_name": "{{userNicknameInpu}}",
     "belong": "{{userBelongInput}}", 
@@ -25,8 +25,8 @@ public class AuthSignUpRequest {
     private String email;
 
     @NotBlank
-    @JsonProperty("user_id")
-    private String userId;
+    @JsonProperty("login_id")
+    private String loginId;
 
     @NotBlank
     @JsonProperty("password")
@@ -55,12 +55,12 @@ public class AuthSignUpRequest {
         this.email = email;
     }
 
-    public String getUserId() {
-        return userId;
+    public String getLoginId() {
+        return loginId;
     }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
+    public void setLoginId(String loginId) {
+        this.loginId = loginId;
     }
 
     public String getPassword() {

--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -19,8 +19,8 @@ public class User {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "user_id", unique = true, nullable = false, length = 50)
-    private String userId;
+    @Column(name = "login_id", unique = true, nullable = false, length = 50)
+    private String loginId;
 
     @Column(name = "password", nullable = false)
     private String password;
@@ -66,8 +66,8 @@ public class User {
 
     public User() {}
 
-    public User(String userId, String password, String nickname, String email, String belong, String interest) {
-        this.userId = userId;
+    public User(String loginId, String password, String nickname, String email, String belong, String interest) {
+        this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
         this.email = email;
@@ -79,7 +79,7 @@ public class User {
     }
 
     public Long getId() { return id; }
-    public String getUserId() { return userId; }
+    public String getLoginId() { return loginId; }
     public String getPassword() { return password; }
     public String getRealName() { return realName; }
     public String getNickname() { return nickname; }

--- a/src/main/java/net/diveon/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/user/repository/UserRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUserId(String userId);
-    boolean existsByUserId(String userId);
+    Optional<User> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/net/diveon/backend/domain/user/service/UserService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserService.java
@@ -24,7 +24,7 @@ public class UserService {
 
     public AuthLoginResponse login(AuthLoginRequest request) {
         // 아이디로 유저 조회, 없으면 401
-        User user = userRepository.findByUserId(request.getUser_id())
+        User user = userRepository.findByLoginId(request.getLogin_id())
                 .orElseThrow(InvalidCredentialsException::new);
 
         // 비밀번호 검증 (BCrypt), 불일치 시 401

--- a/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
@@ -53,14 +53,14 @@ public class UserSignUpService {
         // //existsById()를 사용하여 검색만 진행한다.
         // 이 아래의 한줄은 우리가 의도한 표준 에러가 아니라서 차후에 수정이 필요할 것임 2026.04.18 - 안상완
         // 일반 @valid 어노테이션으로 걸러지는거 확인은 했는데, 일단은 살려두겟습니다 - 2026.04.18 - 안상완
-        String userId = Objects.requireNonNull(signup_request.getUserId(), "아이디는 필수 입력값입니다.");
+        String loginId = Objects.requireNonNull(signup_request.getLoginId(), "아이디는 필수 입력값입니다.");
 
         //인코드를 통해서 비밀번호 암호화 진행
         //수정사항 04.08 dto 변경되면서, getter 메서드 변화로 인한 수정
         String encodedPassword = passwordEncoder.encode(signup_request.getPassword());
 
         // 만약 아이디가 존재한다면, exception 발생
-        if(userRepository.existsByUserId(userId)){
+        if(userRepository.existsByLoginId(loginId)){
             //이미 존재하는 아이디 임. 따라서 해당 아이디로 신규 가입 불가능
             throw new UserAlreadyExistException();
         }
@@ -69,7 +69,7 @@ public class UserSignUpService {
         // 필수값이 아닌 값들은 DTO에서 null로 넘어와도, 생성자를 통해 그대로 생성된다.
         //수정사항 04.08 dto가 변경되면서 수정
         User newUser = new User(
-            signup_request.getUserId(),
+            signup_request.getLoginId(),
             encodedPassword, 
             signup_request.getNickName(),
             signup_request.getEmail(),


### PR DESCRIPTION
## 변경 사항

- `User.java` - 필드 `userId` → `loginId`, DB 컬럼 `user_id` → `login_id`, getter `getUserId()` → `getLoginId()`
- `UserRepository.java` - `findByUserId()` → `findByLoginId()`, `existsByUserId()` → `existsByLoginId()`
- `AuthSignUpRequest.java` - 필드/getter/setter/`@JsonProperty("user_id")` → `@JsonProperty("login_id")`
- `AuthLoginRequest.java` - 필드/getter 변경
- `UserSignUpService.java` - 변수명 및 메서드 호출 변경
- `UserService.java` - `findByLoginId()` 변경

## 변경 이유

`userId` 필드명이 JWT에서 꺼낸 숫자 PK를 담는 변수명과 동일해 혼동될 수 있어 `loginId`로 변경. `problem` 등 다른 도메인은 로그인 아이디를 사용하지 않아 수정 범위에서 제외.

## 참고

- DB 컬럼명 변경으로 인해 로컬 DB 재생성 필요 (ddl-auto: create로 바꾸면 자동 재생성 -> 이후 update로 변경)
- 프론트엔드 회원가입/로그인 요청 JSON 키값 `user_id` → `login_id` 변경 필요

## 관련 이슈

Closes #97
