### PR TITLE
[feat] 객관식 채점 보드 조회 API 구현 (#118)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/controller/GradeBoardController.java
+++ b/src/main/java/net/diveon/backend/domain/grade/controller/GradeBoardController.java
@@ -1,0 +1,36 @@
+package net.diveon.backend.domain.grade.controller;
+
+import net.diveon.backend.domain.grade.dto.response.GradeBoardObjectiveResponse;
+import net.diveon.backend.domain.grade.service.GradeBoardService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/problems")
+public class GradeBoardController {
+
+    private final GradeBoardService gradeBoardService;
+
+    public GradeBoardController(GradeBoardService gradeBoardService) {
+        this.gradeBoardService = gradeBoardService;
+    }
+
+    @GetMapping("/{prob_id}/board/multiple-choice")
+    public ResponseEntity<ApiResponse<GradeBoardObjectiveResponse>> getObjectiveBoard(
+            @AuthenticationPrincipal String userId,
+            @PathVariable("prob_id") Long probId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "all") String result,
+            @RequestParam(defaultValue = "latest") String sort
+    ) {
+        GradeBoardObjectiveResponse response = gradeBoardService.getObjectiveBoard(probId, page, size, result, sort);
+        return ResponseEntity.ok(ApiResponse.success("객관식 채점 보드 조회에 성공하였습니다.", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardObjectiveResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardObjectiveResponse.java
@@ -1,0 +1,61 @@
+package net.diveon.backend.domain.grade.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class GradeBoardObjectiveResponse {
+
+    @JsonProperty("prob_id")
+    private Long probId;
+
+    private Long total;
+
+    private List<SubmissionItem> submissions;
+
+    public GradeBoardObjectiveResponse(Long probId, Long total, List<SubmissionItem> submissions) {
+        this.probId = probId;
+        this.total = total;
+        this.submissions = submissions;
+    }
+
+    public Long getProbId() { return probId; }
+    public Long getTotal() { return total; }
+    public List<SubmissionItem> getSubmissions() { return submissions; }
+
+    public static class SubmissionItem {
+
+        @JsonProperty("submission_id")
+        private Long submissionId;
+
+        private String nickname;
+
+        @JsonProperty("is_correct")
+        private Boolean isCorrect;
+
+        private Short score;
+
+        @JsonProperty("submitted_at")
+        private String submittedAt;
+
+        @JsonProperty("judged_at")
+        private String judgedAt;
+
+        public SubmissionItem(Long submissionId, String nickname, Boolean isCorrect,
+                              Short score, String submittedAt, String judgedAt) {
+            this.submissionId = submissionId;
+            this.nickname = nickname;
+            this.isCorrect = isCorrect;
+            this.score = score;
+            this.submittedAt = submittedAt;
+            this.judgedAt = judgedAt;
+        }
+
+        public Long getSubmissionId() { return submissionId; }
+        public String getNickname() { return nickname; }
+        public Boolean getIsCorrect() { return isCorrect; }
+        public Short getScore() { return score; }
+        public String getSubmittedAt() { return submittedAt; }
+        public String getJudgedAt() { return judgedAt; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
@@ -1,9 +1,12 @@
 package net.diveon.backend.domain.grade.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.diveon.backend.domain.grade.entity.SovleResult;
 
 public interface SolveResultRepository extends JpaRepository<SovleResult, Long>{
-    
+
+    Optional<SovleResult> findBySubmissionId(Long submissionId);
 }

--- a/src/main/java/net/diveon/backend/domain/grade/repository/SolveSubmissionRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SolveSubmissionRepository.java
@@ -1,9 +1,18 @@
 package net.diveon.backend.domain.grade.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import net.diveon.backend.domain.grade.entity.SolveSubmission;
 
 public interface SolveSubmissionRepository extends JpaRepository<SolveSubmission, Long>{
-    
+
+    @Query("SELECT s FROM SolveSubmission s WHERE s.problem.id = :probId AND s.submissionState = 'COMPLETED'")
+    Page<SolveSubmission> findCompletedByProbId(@Param("probId") Long probId, Pageable pageable);
+
+    @Query("SELECT COUNT(s) FROM SolveSubmission s WHERE s.problem.id = :probId AND s.submissionState = 'COMPLETED'")
+    Long countCompletedByProbId(@Param("probId") Long probId);
 }

--- a/src/main/java/net/diveon/backend/domain/grade/service/GradeBoardService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/GradeBoardService.java
@@ -1,0 +1,79 @@
+package net.diveon.backend.domain.grade.service;
+
+import net.diveon.backend.domain.grade.dto.response.GradeBoardObjectiveResponse;
+import net.diveon.backend.domain.grade.entity.SolveSubmission;
+import net.diveon.backend.domain.grade.entity.SovleResult;
+import net.diveon.backend.domain.grade.repository.SolveResultRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class GradeBoardService {
+
+    private final SolveSubmissionRepository solveSubmissionRepository;
+    private final SolveResultRepository solveResultRepository;
+    private final ProblemRepository problemRepository;
+
+    public GradeBoardService(SolveSubmissionRepository solveSubmissionRepository,
+                             SolveResultRepository solveResultRepository,
+                             ProblemRepository problemRepository) {
+        this.solveSubmissionRepository = solveSubmissionRepository;
+        this.solveResultRepository = solveResultRepository;
+        this.problemRepository = problemRepository;
+    }
+
+    public GradeBoardObjectiveResponse getObjectiveBoard(Long probId, int page, int size, String result, String sort) {
+        problemRepository.findById(probId).orElseThrow(() -> new RuntimeException("존재하지 않는 문제입니다."));
+
+        Sort sortOption = sort.equals("oldest")
+                ? Sort.by("submittedAt").ascending() // 오래된 것부터
+                : Sort.by("submittedAt").descending(); // 최신 것부터
+
+        Pageable pageable = PageRequest.of(page - 1, size, sortOption); // 1페이지부터 시작인데 Spring은 0부터 시작이라 -1, 한 페이지에 기본 20개씩 보여줌
+        Page<SolveSubmission> submissionPage = solveSubmissionRepository.findCompletedByProbId(probId, pageable); // prob_id=42(예시), COMPLETED 상태인 제출들을 페이지 단위로 가져옴
+        Long total = solveSubmissionRepository.countCompletedByProbId(probId); // 전체 제출이 몇 건인지 카운트
+
+        List<GradeBoardObjectiveResponse.SubmissionItem> items = submissionPage.getContent().stream()
+                .map(submission -> {
+                    SovleResult solveResult = solveResultRepository.findBySubmissionId(submission.getId()).orElse(null);
+
+                    Boolean isCorrect = null;
+                    Short score = null;
+                    String judgedAt = null;
+
+                    if (solveResult != null) {
+                        isCorrect = solveResult.getResultState() == SovleResult.SovleResultState.CORRECT;
+                        score = solveResult.getScore();
+                        judgedAt = solveResult.getCreatedAt().toString();
+                    }
+
+                    if (!result.equals("all")) {
+                        boolean wantCorrect = result.equals("correct");
+                        if (isCorrect == null || isCorrect != wantCorrect) return null; // 둘 중 하나라도 해당되면 null 반환 -> 목록에서 제외
+                    }
+
+                    return new GradeBoardObjectiveResponse.SubmissionItem(
+                            submission.getId(),
+                            submission.getUser().getNickname(),
+                            isCorrect,
+                            score,
+                            submission.getSubmittedAt().toString(),
+                            judgedAt
+                    );
+                })
+                .filter(item -> item != null) // null 제외
+                .toList(); // 리스트로 반환
+                
+        // prob_id, 전체 건수, 제출 목록 조합해서 반환
+        return new GradeBoardObjectiveResponse(probId, total, items);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- GET /api/problems/{prob_id}/board/multiple-choice 구현
- 정답/오답 필터링 (result=correct/wrong/all)
- 최신순/오래된순 정렬 (sort=latest/oldest)
- 페이징 처리 (page, size)

## 테스트
로컬 환경에서 Postman 수동 테스트 완료
- 채점 후 보드 조회 정상 동작 확인
- is_correct, nickname, submitted_at, judged_at 정상 반환 확인

Closes #118
