### PR TITLE
[feat] 실습형 채점 보드 조회 API 구현 (#120)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/controller/GradeBoardController.java
+++ b/src/main/java/net/diveon/backend/domain/grade/controller/GradeBoardController.java
@@ -1,6 +1,6 @@
 package net.diveon.backend.domain.grade.controller;
 
-import net.diveon.backend.domain.grade.dto.response.GradeBoardObjectiveResponse;
+import net.diveon.backend.domain.grade.dto.response.interfaces.GradeBoardResponse;
 import net.diveon.backend.domain.grade.service.GradeBoardService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -21,8 +21,8 @@ public class GradeBoardController {
         this.gradeBoardService = gradeBoardService;
     }
 
-    @GetMapping("/{prob_id}/board/multiple-choice")
-    public ResponseEntity<ApiResponse<GradeBoardObjectiveResponse>> getObjectiveBoard(
+    @GetMapping("/{prob_id}/board")
+    public ResponseEntity<ApiResponse<GradeBoardResponse>> getBoard(
             @AuthenticationPrincipal String userId,
             @PathVariable("prob_id") Long probId,
             @RequestParam(defaultValue = "1") int page,
@@ -30,7 +30,7 @@ public class GradeBoardController {
             @RequestParam(defaultValue = "all") String result,
             @RequestParam(defaultValue = "latest") String sort
     ) {
-        GradeBoardObjectiveResponse response = gradeBoardService.getObjectiveBoard(probId, page, size, result, sort);
-        return ResponseEntity.ok(ApiResponse.success("객관식 채점 보드 조회에 성공하였습니다.", response));
+        GradeBoardResponse response = gradeBoardService.getBoard(probId, page, size, result, sort);
+        return ResponseEntity.ok(ApiResponse.success("채점 보드 조회에 성공하였습니다.", response));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardPracticeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardPracticeResponse.java
@@ -5,7 +5,7 @@ import net.diveon.backend.domain.grade.dto.response.interfaces.GradeBoardRespons
 
 import java.util.List;
 
-public class GradeBoardObjectiveResponse implements GradeBoardResponse {
+public class GradeBoardPracticeResponse implements GradeBoardResponse {
 
     @JsonProperty("prob_id")
     private Long probId;
@@ -14,7 +14,7 @@ public class GradeBoardObjectiveResponse implements GradeBoardResponse {
 
     private List<SubmissionItem> submissions;
 
-    public GradeBoardObjectiveResponse(Long probId, Long total, List<SubmissionItem> submissions) {
+    public GradeBoardPracticeResponse(Long probId, Long total, List<SubmissionItem> submissions) {
         this.probId = probId;
         this.total = total;
         this.submissions = submissions;

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/interfaces/GradeBoardResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/interfaces/GradeBoardResponse.java
@@ -1,0 +1,5 @@
+package net.diveon.backend.domain.grade.dto.response.interfaces;
+
+// 채점 보드 응답 타입을 묶는 마커 인터페이스 (objective / practice / coding)
+public interface GradeBoardResponse {
+}

--- a/src/main/java/net/diveon/backend/domain/grade/service/GradeBoardService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/GradeBoardService.java
@@ -1,10 +1,13 @@
 package net.diveon.backend.domain.grade.service;
 
 import net.diveon.backend.domain.grade.dto.response.GradeBoardObjectiveResponse;
+import net.diveon.backend.domain.grade.dto.response.GradeBoardPracticeResponse;
+import net.diveon.backend.domain.grade.dto.response.interfaces.GradeBoardResponse;
 import net.diveon.backend.domain.grade.entity.SolveSubmission;
 import net.diveon.backend.domain.grade.entity.SovleResult;
 import net.diveon.backend.domain.grade.repository.SolveResultRepository;
 import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.problem.entity.Problem;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -31,16 +34,34 @@ public class GradeBoardService {
         this.problemRepository = problemRepository;
     }
 
-    public GradeBoardObjectiveResponse getObjectiveBoard(Long probId, int page, int size, String result, String sort) {
-        problemRepository.findById(probId).orElseThrow(() -> new RuntimeException("존재하지 않는 문제입니다."));
+    public GradeBoardResponse getBoard(Long probId, int page, int size, String result, String sort) {
+        Problem problem = problemRepository.findById(probId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 문제입니다."));
 
         Sort sortOption = sort.equals("oldest")
-                ? Sort.by("submittedAt").ascending() // 오래된 것부터
-                : Sort.by("submittedAt").descending(); // 최신 것부터
+                ? Sort.by("submittedAt").ascending()
+                : Sort.by("submittedAt").descending();
 
-        Pageable pageable = PageRequest.of(page - 1, size, sortOption); // 1페이지부터 시작인데 Spring은 0부터 시작이라 -1, 한 페이지에 기본 20개씩 보여줌
-        Page<SolveSubmission> submissionPage = solveSubmissionRepository.findCompletedByProbId(probId, pageable); // prob_id=42(예시), COMPLETED 상태인 제출들을 페이지 단위로 가져옴
-        Long total = solveSubmissionRepository.countCompletedByProbId(probId); // 전체 제출이 몇 건인지 카운트
+        Pageable pageable = PageRequest.of(page - 1, size, sortOption);
+
+        String type = problem.getType();
+
+        if (type.equals("objective")) {
+            return buildObjectiveBoard(probId, pageable, result);
+        } else if (type.equals("practice")) {
+            return buildPracticeBoard(probId, pageable, result);
+        }
+
+        throw new RuntimeException("지원하지 않는 문제 유형입니다.");
+    }
+
+    // 객, 코, 실 유형별로 응답 필드가 달라질 수 있어 메소드 분리
+
+    // 객관식
+
+    private GradeBoardObjectiveResponse buildObjectiveBoard(Long probId, Pageable pageable, String result) {
+        Page<SolveSubmission> submissionPage = solveSubmissionRepository.findCompletedByProbId(probId, pageable);
+        Long total = solveSubmissionRepository.countCompletedByProbId(probId);
 
         List<GradeBoardObjectiveResponse.SubmissionItem> items = submissionPage.getContent().stream()
                 .map(submission -> {
@@ -58,7 +79,7 @@ public class GradeBoardService {
 
                     if (!result.equals("all")) {
                         boolean wantCorrect = result.equals("correct");
-                        if (isCorrect == null || isCorrect != wantCorrect) return null; // 둘 중 하나라도 해당되면 null 반환 -> 목록에서 제외
+                        if (isCorrect == null || isCorrect != wantCorrect) return null;
                     }
 
                     return new GradeBoardObjectiveResponse.SubmissionItem(
@@ -70,10 +91,49 @@ public class GradeBoardService {
                             judgedAt
                     );
                 })
-                .filter(item -> item != null) // null 제외
-                .toList(); // 리스트로 반환
-                
-        // prob_id, 전체 건수, 제출 목록 조합해서 반환
+                .filter(item -> item != null)
+                .toList();
+
         return new GradeBoardObjectiveResponse(probId, total, items);
+    }
+
+    // 실습형
+
+    private GradeBoardPracticeResponse buildPracticeBoard(Long probId, Pageable pageable, String result) {
+        Page<SolveSubmission> submissionPage = solveSubmissionRepository.findCompletedByProbId(probId, pageable);
+        Long total = solveSubmissionRepository.countCompletedByProbId(probId);
+
+        List<GradeBoardPracticeResponse.SubmissionItem> items = submissionPage.getContent().stream()
+                .map(submission -> {
+                    SovleResult solveResult = solveResultRepository.findBySubmissionId(submission.getId()).orElse(null);
+
+                    Boolean isCorrect = null;
+                    Short score = null;
+                    String judgedAt = null;
+
+                    if (solveResult != null) {
+                        isCorrect = solveResult.getResultState() == SovleResult.SovleResultState.CORRECT;
+                        score = solveResult.getScore();
+                        judgedAt = solveResult.getCreatedAt().toString();
+                    }
+
+                    if (!result.equals("all")) {
+                        boolean wantCorrect = result.equals("correct");
+                        if (isCorrect == null || isCorrect != wantCorrect) return null;
+                    }
+
+                    return new GradeBoardPracticeResponse.SubmissionItem(
+                            submission.getId(),
+                            submission.getUser().getNickname(),
+                            isCorrect,
+                            score,
+                            submission.getSubmittedAt().toString(),
+                            judgedAt
+                    );
+                })
+                .filter(item -> item != null)
+                .toList();
+
+        return new GradeBoardPracticeResponse(probId, total, items);
     }
 }


### PR DESCRIPTION
## 구현 내용
- GET /api/problems/{prob_id}/board 엔드포인트로 통합
  - prob_id로 문제 유형 판별 후 분기 처리 (objective / practice)
  - 나중에 코딩형 추가 시 else if 하나만 추가하면 됨
- GradeBoardPracticeResponse DTO 추가
- GradeBoardResponse 마커 인터페이스 추가 (채점 보드 응답 타입 묶음용)

## 변경 사항
- 기존 /board/multiple-choice, /board/practice 두 엔드포인트 → /board 하나로 통합

Closes #120
