### PR TITLE
[feat] 코딩형 문제 채점 기능, 목으로만 테스트 완료        src/main/java/net/diveon/b… (#112)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/controller/SubmissionGradeController.java
+++ b/src/main/java/net/diveon/backend/domain/grade/controller/SubmissionGradeController.java
@@ -37,15 +37,20 @@ public class SubmissionGradeController {
     ){
         SubmissionGradeResponse initResponse = submissionGradeStarterService.submissionGradeStart(Long.parseLong(userId), reqeust);
         long submissionId = initResponse.getSubmissionId();
+        String problemType = initResponse.getProblemType();
 
         //long probId, 
         // long submitterId, 
         // long submissionId
 
-        if(Long.parseLong(userId) < 2){
+        if(problemType.equals("objective")){
             submissionGradeAsyncService.gradeProblemObjective(reqeust.getProdId(), Long.parseLong(userId), submissionId);
-        }else{
+        }else if(problemType.equals("practice")){
             submissionGradeAsyncService.gradeProblemPractice(reqeust.getProdId(), Long.parseLong(userId), submissionId);
+        }else if(problemType.equals("coding")){
+            submissionGradeAsyncService.gradeProblemCoding(reqeust.getProdId(), Long.parseLong(userId), submissionId);
+        }else{
+            throw new RuntimeException("문제 유형이 3가지중 어느것도 아닙니다.");
         }
 
         return ResponseEntity.status(200).body(ApiResponse.success("접수되었습니다.", initResponse));

--- a/src/main/java/net/diveon/backend/domain/grade/dto/message/CodingGradeMessage.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/message/CodingGradeMessage.java
@@ -1,0 +1,59 @@
+package net.diveon.backend.domain.grade.dto.message;
+
+public class CodingGradeMessage {
+    private String submissionId;
+    private String s3Key;
+    private String language;
+    private String problemId;
+    private Integer timeLimit;
+    private Integer memoryLimit;
+    private Integer testcaseCount;
+
+    public CodingGradeMessage() {}
+
+    public CodingGradeMessage(
+        String submissionId,
+        String s3Key,
+        String language,
+        String problemId,
+        Integer timeLimit,
+        Integer memoryLimit,
+        Integer testcaseCount
+    ) {
+        this.submissionId = submissionId;
+        this.s3Key = s3Key;
+        this.language = language;
+        this.problemId = problemId;
+        this.timeLimit = timeLimit;
+        this.memoryLimit = memoryLimit;
+        this.testcaseCount = testcaseCount;
+    }
+
+    public String getSubmissionId() {
+        return submissionId;
+    }
+
+    public String getS3Key() {
+        return s3Key;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getProblemId() {
+        return problemId;
+    }
+
+    public Integer getTimeLimit() {
+        return timeLimit;
+    }
+
+    public Integer getMemoryLimit() {
+        return memoryLimit;
+    }
+
+    public Integer getTestcaseCount() {
+        return testcaseCount;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionGradeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionGradeResponse.java
@@ -34,16 +34,22 @@ public class SubmissionGradeResponse {
     @JsonProperty("submissionStatus")
     private String submissionStatus;
 
+    @NonNull
+    @JsonProperty("problemType")
+    private String problemType;
+
     //생성자
     public SubmissionGradeResponse() {}
 
     public SubmissionGradeResponse(long submissionId, 
         long probId, 
-        String submissionStatus
+        String submissionStatus,
+        String problemType
     ){
         this.submissionId = submissionId;
         this.probId = probId;
         this.submissionStatus = submissionStatus;
+        this.problemType = problemType;
     }
 
     //getter
@@ -55,6 +61,9 @@ public class SubmissionGradeResponse {
     }
     public String getSubmissionStatus() {
         return submissionStatus;
+    }
+    public String getProblemType() {
+        return problemType;
     }
 
 

--- a/src/main/java/net/diveon/backend/domain/grade/entity/SolveSubmissionCoding.java
+++ b/src/main/java/net/diveon/backend/domain/grade/entity/SolveSubmissionCoding.java
@@ -25,13 +25,20 @@ public class SolveSubmissionCoding {
     @Column(name = "answer", nullable =  false, columnDefinition = "TEXT")
     private String answer;
 
+    @Column(name = "language", nullable = false, length = 20)
+    private String language;
+
     public SolveSubmissionCoding () {}
-    public SolveSubmissionCoding (SolveSubmission submission, String userAnswer) {
+    public SolveSubmissionCoding (SolveSubmission submission, String userAnswer, String language) {
         this.submission = submission;
         this.answer = userAnswer;
+        this.language = language;
     }
     public String getAnswer() {
         return answer;
+    }
+    public String getLanguage() {
+        return language;
     }
     public long getId() {
         return id;

--- a/src/main/java/net/diveon/backend/domain/grade/entity/SovleResult.java
+++ b/src/main/java/net/diveon/backend/domain/grade/entity/SovleResult.java
@@ -19,12 +19,7 @@ import jakarta.persistence.OneToOne;
 | ------------- | --------- | ---------------------------- | --------------- |
 | id            | BIGINT    | PK, AUTO_INCREMENT           | PK용             |
 | submisson_id  | BIGINT    | FK → submission.id, NOT NULL |                 |
-| login_id      | BIGINT    | FK → users.id, NOT NULL      | 이 컬럼은 고민이 좀더 필요 |
 | is_passed     | enum      | NOT NULL                     | 클래스 enum 참고     |
-| socre         | SMALLINT  |                              |                 |
-| memory_useage | SMALLINT  |                              | 총 100점          |
-| runtime       | SMALLINT  |                              | 총 100점          |
-| code_size     | SMALLINT  |                              | 총 100점          |
 | message       | String    |                              |                 |
 | created_at    | TIMESTAMP | NOT NULL, DEFAULT NOW()      | 채점 완료 후 기록시간    |
  * </pre>
@@ -35,7 +30,13 @@ public class SovleResult {
         NOGRADE,
         CORRECT,
         WRONG,
-        ERROR
+        ERROR,
+        ACCEPTED,
+        WRONG_ANSWER,
+        TIME_LIMIT_EXCEEDED,
+        RUNTIME_ERROR,
+        COMPILE_ERROR,
+        SYSTEM_ERROR
     }
 
     @Id
@@ -50,18 +51,6 @@ public class SovleResult {
     @Column(name = "is_passed", nullable = false)
     private SovleResultState resultState = SovleResultState.NOGRADE;
 
-    @Column(name = "score")
-    private Short score = 0;
-
-    @Column(name = "memory_usage")
-    private Short memoryUsage = 0;
-
-    @Column(name = "runtime")
-    private Short runtime = 0;
-
-    @Column(name = "code_size")
-    private Short codeSize = 0;
-
     @Column(name = "message")
     private String message;
 
@@ -75,10 +64,6 @@ public class SovleResult {
     public SovleResult(SolveSubmission submission, SovleResultState resultState, String message) {
         this.submission = submission;
         this.resultState = resultState;
-        // this.score = score;
-        // this.memoryUsage = memoryUsage;
-        // this.runtime = runtime;
-        // this.codeSize = codeSize;
         this.message = message;
         this.createdAt = java.time.LocalDateTime.now();
     }
@@ -86,10 +71,6 @@ public class SovleResult {
     public Long getId() { return id; }
     public SolveSubmission getSubmission() { return submission; }
     public SovleResultState getResultState() { return resultState; }
-    public Short getScore() { return score; }
-    public Short getMemoryUsage() { return memoryUsage; }
-    public Short getRuntime() { return runtime; }
-    public Short getCodeSize() { return codeSize; }
     public String getMessage() { return message; }
     public LocalDateTime getCreatedAt() { return createdAt; }
 }

--- a/src/main/java/net/diveon/backend/domain/grade/entity/SovleResultCoding.java
+++ b/src/main/java/net/diveon/backend/domain/grade/entity/SovleResultCoding.java
@@ -1,0 +1,74 @@
+package net.diveon.backend.domain.grade.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class SovleResultCoding {
+
+    @Id
+    @Column(name = "result_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "result_id", nullable = false)
+    private SovleResult result;
+
+    @Column(name = "score")
+    private Short score = 0;
+
+    @Column(name = "memory_usage")
+    private Integer memoryUsage = 0;
+
+    @Column(name = "runtime")
+    private Integer runtime = 0;
+
+    @Column(name = "code_size")
+    private Integer codeSize = 0;
+
+    public SovleResultCoding() {}
+
+    public SovleResultCoding(
+        SovleResult result,
+        Short score,
+        Integer memoryUsage,
+        Integer runtime,
+        Integer codeSize
+    ) {
+        this.result = result;
+        this.score = score;
+        this.memoryUsage = memoryUsage;
+        this.runtime = runtime;
+        this.codeSize = codeSize;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public SovleResult getResult() {
+        return result;
+    }
+
+    public Short getScore() {
+        return score;
+    }
+
+    public Integer getMemoryUsage() {
+        return memoryUsage;
+    }
+
+    public Integer getRuntime() {
+        return runtime;
+    }
+
+    public Integer getCodeSize() {
+        return codeSize;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/repository/SovleResultCodingRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SovleResultCodingRepository.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.domain.grade.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import net.diveon.backend.domain.grade.entity.SovleResultCoding;
+
+public interface SovleResultCodingRepository extends JpaRepository<SovleResultCoding, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueService.java
@@ -1,0 +1,5 @@
+package net.diveon.backend.domain.grade.service;
+
+public interface CodingGradeQueueService {
+    void sendGradeRequest(long probId, long submitterId, long submissionId);
+}

--- a/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceImpl.java
@@ -1,0 +1,130 @@
+package net.diveon.backend.domain.grade.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.diveon.backend.domain.grade.dto.message.CodingGradeMessage;
+import net.diveon.backend.domain.grade.entity.SolveSubmission;
+import net.diveon.backend.domain.grade.entity.SolveSubmission.SubmissionState;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionCodingRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.problem.entity.ProblemCoding;
+import net.diveon.backend.domain.problem.repository.ProblemCodingRepository;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+@Service
+@Profile("prod")
+@Transactional
+public class CodingGradeQueueServiceImpl implements CodingGradeQueueService {
+
+    private final S3Client s3Client;
+    private final SqsClient sqsClient;
+    private final ObjectMapper objectMapper;
+    private final SolveSubmissionRepository solveSubmissionRepository;
+    private final SolveSubmissionCodingRepository solveSubmissionCodingRepository;
+    private final ProblemCodingRepository problemCodingRepository;
+
+    @Value("${aws.sqs.url}")
+    private String queueUrl;
+
+    @Value("${aws.s3.bucket-code}")
+    private String codeBucket;
+
+    public CodingGradeQueueServiceImpl(
+        S3Client s3Client,
+        SqsClient sqsClient,
+        ObjectMapper objectMapper,
+        SolveSubmissionRepository solveSubmissionRepository,
+        SolveSubmissionCodingRepository solveSubmissionCodingRepository,
+        ProblemCodingRepository problemCodingRepository
+    ) {
+        this.s3Client = s3Client;
+        this.sqsClient = sqsClient;
+        this.objectMapper = objectMapper;
+        this.solveSubmissionRepository = solveSubmissionRepository;
+        this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
+        this.problemCodingRepository = problemCodingRepository;
+    }
+
+    @Override
+    public void sendGradeRequest(long probId, long submitterId, long submissionId) {
+        SolveSubmission submission = solveSubmissionRepository.findById(submissionId)
+            .orElseThrow(() -> new RuntimeException("제출 정보가 없습니다."));
+        SolveSubmissionCoding submissionCoding = solveSubmissionCodingRepository.findById(submissionId)
+            .orElseThrow(() -> new RuntimeException("코딩형 제출 정보가 없습니다."));
+        ProblemCoding problemCoding = problemCodingRepository.findById(probId)
+            .orElseThrow(() -> new RuntimeException("코딩형 문제가 없습니다."));
+
+        String language = submissionCoding.getLanguage();
+        String s3Key = "submissions/" + submissionId + "/" + getFileName(language);
+
+        uploadCode(s3Key, submissionCoding.getAnswer());
+        sendMessage(createMessage(submissionId, s3Key, language, probId, problemCoding));
+
+        submission.setSubmissionState(SubmissionState.RECEIVED);
+    }
+
+    private void uploadCode(String s3Key, String code) {
+        s3Client.putObject(
+            PutObjectRequest.builder()
+                .bucket(codeBucket)
+                .key(s3Key)
+                .build(),
+            RequestBody.fromString(code)
+        );
+    }
+
+    private void sendMessage(CodingGradeMessage message) {
+        try {
+            sqsClient.sendMessage(
+                SendMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .messageBody(objectMapper.writeValueAsString(message))
+                    .build()
+            );
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("코딩 채점 요청 메시지 생성에 실패했습니다.", e);
+        }
+    }
+
+    private CodingGradeMessage createMessage(
+        long submissionId,
+        String s3Key,
+        String language,
+        long probId,
+        ProblemCoding problemCoding
+    ) {
+        return new CodingGradeMessage(
+            String.valueOf(submissionId),
+            s3Key,
+            language,
+            String.valueOf(probId),
+            convertTimeLimitToSeconds(problemCoding.getTimeLimitMs()),
+            problemCoding.getMemoryLimitMb(),
+            problemCoding.getTestcases().size()
+        );
+    }
+
+    private int convertTimeLimitToSeconds(Integer timeLimitMs) {
+        return (timeLimitMs + 999) / 1000;
+    }
+
+    private String getFileName(String language) {
+        return switch (language) {
+            case "python" -> "Main.py";
+            case "c" -> "Main.c";
+            case "cpp" -> "Main.cpp";
+            default -> throw new IllegalArgumentException("지원하지 않는 언어: " + language);
+        };
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceMock.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceMock.java
@@ -1,0 +1,99 @@
+package net.diveon.backend.domain.grade.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.grade.entity.SolveSubmission;
+import net.diveon.backend.domain.grade.entity.SolveSubmission.SubmissionState;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
+import net.diveon.backend.domain.grade.entity.SovleResult;
+import net.diveon.backend.domain.grade.entity.SovleResult.SovleResultState;
+import net.diveon.backend.domain.grade.entity.SovleResultCoding;
+import net.diveon.backend.domain.grade.repository.SolveResultRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionCodingRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.grade.repository.SovleResultCodingRepository;
+
+@Service
+@Profile("local")
+@Transactional
+public class CodingGradeQueueServiceMock implements CodingGradeQueueService {
+
+    private static final Logger log = LoggerFactory.getLogger(CodingGradeQueueServiceMock.class);
+
+    private final SolveSubmissionRepository solveSubmissionRepository;
+    private final SolveSubmissionCodingRepository solveSubmissionCodingRepository;
+    private final SolveResultRepository solveResultRepository;
+    private final SovleResultCodingRepository sovleResultCodingRepository;
+
+    public CodingGradeQueueServiceMock(
+        SolveSubmissionRepository solveSubmissionRepository,
+        SolveSubmissionCodingRepository solveSubmissionCodingRepository,
+        SolveResultRepository solveResultRepository,
+        SovleResultCodingRepository sovleResultCodingRepository
+    ) {
+        this.solveSubmissionRepository = solveSubmissionRepository;
+        this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
+        this.solveResultRepository = solveResultRepository;
+        this.sovleResultCodingRepository = sovleResultCodingRepository;
+    }
+
+    @Override
+    public void sendGradeRequest(long probId, long submitterId, long submissionId) {
+        SolveSubmission submission = solveSubmissionRepository.findById(submissionId)
+            .orElseThrow(() -> new RuntimeException("제출 정보가 없습니다."));
+        SolveSubmissionCoding submissionCoding = solveSubmissionCodingRepository.findById(submissionId)
+            .orElseThrow(() -> new RuntimeException("코딩형 제출 정보가 없습니다."));
+
+        log.info(
+            "[Mock] 코딩 채점 요청 생략 - probId: {}, submitterId: {}, submissionId: {}, language: {}",
+            probId,
+            submitterId,
+            submissionId,
+            submissionCoding.getLanguage()
+        );
+
+        SovleResultState resultState = getMockResultState(submissionCoding.getLanguage());
+        SovleResult result = new SovleResult(
+            submission,
+            resultState,
+            getMockMessage(resultState)
+        );
+        solveResultRepository.save(result);
+
+        SovleResultCoding resultCoding = new SovleResultCoding(
+            result,
+            getMockScore(resultState),
+            0,
+            0,
+            submissionCoding.getAnswer().length()
+        );
+        sovleResultCodingRepository.save(resultCoding);
+
+        submission.setSubmissionState(SubmissionState.COMPLETED);
+    }
+
+    private SovleResultState getMockResultState(String language) {
+        if ("python".equals(language)) {
+            return SovleResultState.CORRECT;
+        }
+        return SovleResultState.WRONG_ANSWER;
+    }
+
+    private String getMockMessage(SovleResultState resultState) {
+        if (resultState == SovleResultState.CORRECT) {
+            return "[Mock] 정답입니다.";
+        }
+        return "[Mock] python 외 언어는 오답으로 처리됩니다.";
+    }
+
+    private Short getMockScore(SovleResultState resultState) {
+        if (resultState == SovleResultState.CORRECT) {
+            return 100;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeAsyncService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeAsyncService.java
@@ -64,6 +64,7 @@ public class SubmissionGradeAsyncService {
     private final SolveSubmissionPracticeRepository solveSubmissionPracticeRepository;
 
     private final SolveResultRepository solveResultRepository;
+    private final CodingGradeQueueService codingGradeQueueService;
 
     public SubmissionGradeAsyncService(UserRepository userRepository,
         ProblemRepository problemRepository,
@@ -74,7 +75,8 @@ public class SubmissionGradeAsyncService {
         SolveSubmissionObjectiveRepository solveSubmissionObjectiveRepository,
         SolveSubmissionCodingRepository solveSubmissionCodingRepository,
         SolveSubmissionPracticeRepository solveSubmissionPracticeRepository,
-        SolveResultRepository solveResultRepository
+        SolveResultRepository solveResultRepository,
+        CodingGradeQueueService codingGradeQueueService
     ){
         this.userRepository = userRepository;
         this.problemRepository = problemRepository;
@@ -87,6 +89,7 @@ public class SubmissionGradeAsyncService {
         this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
         this.solveSubmissionPracticeRepository = solveSubmissionPracticeRepository;
         this.solveSubmissionObjectiveRepository = solveSubmissionObjectiveRepository;
+        this.codingGradeQueueService = codingGradeQueueService;
     }
 
 
@@ -206,7 +209,7 @@ public class SubmissionGradeAsyncService {
         long submitterId, 
         long submissionId
     ){
-        
+        codingGradeQueueService.sendGradeRequest(probId, submitterId, submissionId);
     }
 
     private String hashFlag(String flag) {

--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeStarterService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeStarterService.java
@@ -19,6 +19,7 @@ import net.diveon.backend.domain.grade.repository.SolveSubmissionObjectiveReposi
 import net.diveon.backend.domain.grade.repository.SolveSubmissionPracticeRepository;
 import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
 import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.entity.ProblemCoding;
 import net.diveon.backend.domain.problem.repository.ProblemCodingRepository;
 import net.diveon.backend.domain.problem.repository.ProblemObjectiveRepository;
 import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
@@ -120,7 +121,31 @@ public class SubmissionGradeStarterService {
                 throw new RuntimeException("객관식 정답 리스트 형식 변환에 문제가 있습니다.");
             }
         }else if(problemType.equals("coding")){
+            if (request.getAnswer() instanceof String) {
+                String answer = (String) request.getAnswer();
+                String language = request.getLanguage();
 
+                if (answer.isBlank()) {
+                    throw new RuntimeException("코딩형 정답 문자열이 비어 있습니다.");
+                }
+
+                if (language == null || language.isBlank()) {
+                    throw new RuntimeException("코딩형 문제는 언어 정보가 필요합니다.");
+                }
+
+                ProblemCoding problemCoding = problemCodingRepository.findById(probId)
+                    .orElseThrow(() -> new RuntimeException("코딩형 문제가 없습니다."));
+
+                if (!problemCoding.getAllowedLanguages().contains(language)) {
+                    throw new RuntimeException("허용되지 않은 언어입니다.");
+                }
+
+                SolveSubmissionCoding submissionCoding = new SolveSubmissionCoding(submission, answer, language);
+                solveSubmissionCodingRepository.save(submissionCoding);
+            }else{
+                //TODO : exception must be improved
+                throw new RuntimeException("코딩형 정답 문자열 형식 변환에 문제가 있습니다.");
+            }
         }else if(problemType.equals("practice")){
             if (request.getAnswer() instanceof String) {
                 String answer = (String) request.getAnswer();
@@ -156,6 +181,6 @@ public class SubmissionGradeStarterService {
 
 
         // 그냥 오류 방지용, 바꿔야함
-        return new SubmissionGradeResponse(submission.getId(), probId, SubmissionState.PENDING.name());
+        return new SubmissionGradeResponse(submission.getId(), probId, SubmissionState.PENDING.name(), problemType);
     }
 }


### PR DESCRIPTION
…ackend/domain/grade/dto/message/

        src/main/java/net/diveon/backend/domain/grade/entity/SovleResultCoding.java
        src/main/java/net/diveon/backend/domain/grade/repository/SovleResultCodingRepository.java
        src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueService.java
        src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceImpl.java
        src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceMock.java 이거 수정함
        
## 주요 변경사항
1. 엔티티 수정
2. 엔티티 수정은, Result가 CodingResult로 분화됨
3. 내부용 메세지 dto 추가, 경로는 grade/dto/message인데, 수정해야할 듯합니다.
4. 채점용 서비스 3개(1 인터페이스, 1MOCK 서비스, 1실제용서비스)
5. 다만 서비스는 목으로만 로컬테스트된것이고, 실제로는 해봐야함.