### PR TITLE
[feat] 코딩형 채점 보드 조회 API 구현 (#119)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardCodingResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardCodingResponse.java
@@ -5,7 +5,7 @@ import net.diveon.backend.domain.grade.dto.response.interfaces.GradeBoardRespons
 
 import java.util.List;
 
-public class GradeBoardPracticeResponse implements GradeBoardResponse {
+public class GradeBoardCodingResponse implements GradeBoardResponse {
 
     @JsonProperty("prob_id")
     private Long probId;
@@ -14,7 +14,7 @@ public class GradeBoardPracticeResponse implements GradeBoardResponse {
 
     private List<SubmissionItem> submissions;
 
-    public GradeBoardPracticeResponse(Long probId, Long total, List<SubmissionItem> submissions) {
+    public GradeBoardCodingResponse(Long probId, Long total, List<SubmissionItem> submissions) {
         this.probId = probId;
         this.total = total;
         this.submissions = submissions;
@@ -31,8 +31,20 @@ public class GradeBoardPracticeResponse implements GradeBoardResponse {
 
         private String nickname;
 
+        private String language;
+
         @JsonProperty("is_correct")
         private Boolean isCorrect;
+
+        private Short score;
+
+        private Integer runtime;
+
+        @JsonProperty("memory_usage")
+        private Integer memoryUsage;
+
+        @JsonProperty("code_size")
+        private Integer codeSize;
 
         @JsonProperty("submitted_at")
         private String submittedAt;
@@ -40,18 +52,29 @@ public class GradeBoardPracticeResponse implements GradeBoardResponse {
         @JsonProperty("judged_at")
         private String judgedAt;
 
-        public SubmissionItem(Long submissionId, String nickname, Boolean isCorrect,
+        public SubmissionItem(Long submissionId, String nickname, String language, Boolean isCorrect,
+                              Short score, Integer runtime, Integer memoryUsage, Integer codeSize,
                               String submittedAt, String judgedAt) {
             this.submissionId = submissionId;
             this.nickname = nickname;
+            this.language = language;
             this.isCorrect = isCorrect;
+            this.score = score;
+            this.runtime = runtime;
+            this.memoryUsage = memoryUsage;
+            this.codeSize = codeSize;
             this.submittedAt = submittedAt;
             this.judgedAt = judgedAt;
         }
 
         public Long getSubmissionId() { return submissionId; }
         public String getNickname() { return nickname; }
+        public String getLanguage() { return language; }
         public Boolean getIsCorrect() { return isCorrect; }
+        public Short getScore() { return score; }
+        public Integer getRuntime() { return runtime; }
+        public Integer getMemoryUsage() { return memoryUsage; }
+        public Integer getCodeSize() { return codeSize; }
         public String getSubmittedAt() { return submittedAt; }
         public String getJudgedAt() { return judgedAt; }
     }

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardObjectiveResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/GradeBoardObjectiveResponse.java
@@ -34,8 +34,6 @@ public class GradeBoardObjectiveResponse implements GradeBoardResponse {
         @JsonProperty("is_correct")
         private Boolean isCorrect;
 
-        private Short score;
-
         @JsonProperty("submitted_at")
         private String submittedAt;
 
@@ -43,11 +41,10 @@ public class GradeBoardObjectiveResponse implements GradeBoardResponse {
         private String judgedAt;
 
         public SubmissionItem(Long submissionId, String nickname, Boolean isCorrect,
-                              Short score, String submittedAt, String judgedAt) {
+                              String submittedAt, String judgedAt) {
             this.submissionId = submissionId;
             this.nickname = nickname;
             this.isCorrect = isCorrect;
-            this.score = score;
             this.submittedAt = submittedAt;
             this.judgedAt = judgedAt;
         }
@@ -55,7 +52,6 @@ public class GradeBoardObjectiveResponse implements GradeBoardResponse {
         public Long getSubmissionId() { return submissionId; }
         public String getNickname() { return nickname; }
         public Boolean getIsCorrect() { return isCorrect; }
-        public Short getScore() { return score; }
         public String getSubmittedAt() { return submittedAt; }
         public String getJudgedAt() { return judgedAt; }
     }

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/interfaces/GradeBoardResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/interfaces/GradeBoardResponse.java
@@ -1,5 +1,6 @@
 package net.diveon.backend.domain.grade.dto.response.interfaces;
 
 // 채점 보드 응답 타입을 묶는 마커 인터페이스 (objective / practice / coding)
+// 나중에 필드 확정되면, 추가될 수도
 public interface GradeBoardResponse {
 }

--- a/src/main/java/net/diveon/backend/domain/grade/entity/SolveSubmissionObjective.java
+++ b/src/main/java/net/diveon/backend/domain/grade/entity/SolveSubmissionObjective.java
@@ -18,7 +18,7 @@ public class SolveSubmissionObjective {
 
     //@GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
-    @Column(name = "submission_id")
+    @Column(name = "id")
     private long id;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/net/diveon/backend/domain/grade/service/GradeBoardService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/GradeBoardService.java
@@ -1,12 +1,17 @@
 package net.diveon.backend.domain.grade.service;
 
+import net.diveon.backend.domain.grade.dto.response.GradeBoardCodingResponse;
 import net.diveon.backend.domain.grade.dto.response.GradeBoardObjectiveResponse;
 import net.diveon.backend.domain.grade.dto.response.GradeBoardPracticeResponse;
 import net.diveon.backend.domain.grade.dto.response.interfaces.GradeBoardResponse;
 import net.diveon.backend.domain.grade.entity.SolveSubmission;
 import net.diveon.backend.domain.grade.entity.SovleResult;
+import net.diveon.backend.domain.grade.entity.SovleResultCoding;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
 import net.diveon.backend.domain.grade.repository.SolveResultRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionCodingRepository;
 import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.grade.repository.SovleResultCodingRepository;
 import net.diveon.backend.domain.problem.entity.Problem;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import org.springframework.data.domain.Page;
@@ -23,14 +28,20 @@ import java.util.List;
 public class GradeBoardService {
 
     private final SolveSubmissionRepository solveSubmissionRepository;
+    private final SolveSubmissionCodingRepository solveSubmissionCodingRepository;
     private final SolveResultRepository solveResultRepository;
+    private final SovleResultCodingRepository solveResultCodingRepository;
     private final ProblemRepository problemRepository;
 
     public GradeBoardService(SolveSubmissionRepository solveSubmissionRepository,
+                             SolveSubmissionCodingRepository solveSubmissionCodingRepository,
                              SolveResultRepository solveResultRepository,
+                             SovleResultCodingRepository solveResultCodingRepository,
                              ProblemRepository problemRepository) {
         this.solveSubmissionRepository = solveSubmissionRepository;
+        this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
         this.solveResultRepository = solveResultRepository;
+        this.solveResultCodingRepository = solveResultCodingRepository;
         this.problemRepository = problemRepository;
     }
 
@@ -46,19 +57,22 @@ public class GradeBoardService {
 
         String type = problem.getType();
 
+
+        // 유형별 분기
         if (type.equals("objective")) {
             return buildObjectiveBoard(probId, pageable, result);
         } else if (type.equals("practice")) {
             return buildPracticeBoard(probId, pageable, result);
+        } else if (type.equals("coding")) {
+            return buildCodingBoard(probId, pageable, result);
         }
 
         throw new RuntimeException("지원하지 않는 문제 유형입니다.");
     }
 
-    // 객, 코, 실 유형별로 응답 필드가 달라질 수 있어 메소드 분리
+    // 객관식, 코딩형, 실습형 유형별로 응답 필드가 달라질 수 있어 메소드 분리한 것.
 
     // 객관식
-
     private GradeBoardObjectiveResponse buildObjectiveBoard(Long probId, Pageable pageable, String result) {
         Page<SolveSubmission> submissionPage = solveSubmissionRepository.findCompletedByProbId(probId, pageable);
         Long total = solveSubmissionRepository.countCompletedByProbId(probId);
@@ -68,15 +82,14 @@ public class GradeBoardService {
                     SovleResult solveResult = solveResultRepository.findBySubmissionId(submission.getId()).orElse(null);
 
                     Boolean isCorrect = null;
-                    Short score = null;
                     String judgedAt = null;
 
                     if (solveResult != null) {
                         isCorrect = solveResult.getResultState() == SovleResult.SovleResultState.CORRECT;
-                        score = solveResult.getScore();
                         judgedAt = solveResult.getCreatedAt().toString();
                     }
 
+                    // 채점 보드에서 정답/오답 필터링하는 로직 (프론트에서 정답만 보기, 오답만 보기 선택했을때 필터링)
                     if (!result.equals("all")) {
                         boolean wantCorrect = result.equals("correct");
                         if (isCorrect == null || isCorrect != wantCorrect) return null;
@@ -86,7 +99,6 @@ public class GradeBoardService {
                             submission.getId(),
                             submission.getUser().getNickname(),
                             isCorrect,
-                            score,
                             submission.getSubmittedAt().toString(),
                             judgedAt
                     );
@@ -98,7 +110,6 @@ public class GradeBoardService {
     }
 
     // 실습형
-
     private GradeBoardPracticeResponse buildPracticeBoard(Long probId, Pageable pageable, String result) {
         Page<SolveSubmission> submissionPage = solveSubmissionRepository.findCompletedByProbId(probId, pageable);
         Long total = solveSubmissionRepository.countCompletedByProbId(probId);
@@ -108,15 +119,14 @@ public class GradeBoardService {
                     SovleResult solveResult = solveResultRepository.findBySubmissionId(submission.getId()).orElse(null);
 
                     Boolean isCorrect = null;
-                    Short score = null;
                     String judgedAt = null;
 
                     if (solveResult != null) {
                         isCorrect = solveResult.getResultState() == SovleResult.SovleResultState.CORRECT;
-                        score = solveResult.getScore();
                         judgedAt = solveResult.getCreatedAt().toString();
                     }
 
+                    // 채점 보드에서 정답/오답 필터링하는 로직 (프론트에서 정답만 보기, 오답만 보기 선택했을때 필터링)
                     if (!result.equals("all")) {
                         boolean wantCorrect = result.equals("correct");
                         if (isCorrect == null || isCorrect != wantCorrect) return null;
@@ -126,7 +136,6 @@ public class GradeBoardService {
                             submission.getId(),
                             submission.getUser().getNickname(),
                             isCorrect,
-                            score,
                             submission.getSubmittedAt().toString(),
                             judgedAt
                     );
@@ -135,5 +144,61 @@ public class GradeBoardService {
                 .toList();
 
         return new GradeBoardPracticeResponse(probId, total, items);
+    }
+
+    // 코딩형
+    private GradeBoardCodingResponse buildCodingBoard(Long probId, Pageable pageable, String result) {
+        Page<SolveSubmission> submissionPage = solveSubmissionRepository.findCompletedByProbId(probId, pageable);
+        Long total = solveSubmissionRepository.countCompletedByProbId(probId);
+
+        List<GradeBoardCodingResponse.SubmissionItem> items = submissionPage.getContent().stream()
+                .map(submission -> {
+                    SovleResult solveResult = solveResultRepository.findBySubmissionId(submission.getId()).orElse(null);
+                    SolveSubmissionCoding submissionCoding = solveSubmissionCodingRepository.findById(submission.getId()).orElse(null);
+
+                    Boolean isCorrect = null;
+                    String judgedAt = null;
+                    Short score = null;
+                    Integer runtime = null;
+                    Integer memoryUsage = null;
+                    Integer codeSize = null;
+                    String language = submissionCoding != null ? submissionCoding.getLanguage() : null;
+
+                    if (solveResult != null) {
+                        isCorrect = solveResult.getResultState() == SovleResult.SovleResultState.CORRECT; // CORRECT면 true
+                        judgedAt = solveResult.getCreatedAt().toString(); // 채점 완료 시각
+
+                        SovleResultCoding codingResult = solveResultCodingRepository.findById(solveResult.getId()).orElse(null);
+                        if (codingResult != null) {
+                            score = codingResult.getScore();
+                            runtime = codingResult.getRuntime();
+                            memoryUsage = codingResult.getMemoryUsage();
+                            codeSize = codingResult.getCodeSize();
+                        }
+                    }
+
+                    // 채점 보드에서 정답/오답 필터링하는 로직 (프론트에서 정답만 보기, 오답만 보기 선택했을때 필터링)
+                    if (!result.equals("all")) {
+                        boolean wantCorrect = result.equals("correct");
+                        if (isCorrect == null || isCorrect != wantCorrect) return null;
+                    }
+
+                    return new GradeBoardCodingResponse.SubmissionItem(
+                            submission.getId(),
+                            submission.getUser().getNickname(),
+                            language,
+                            isCorrect,
+                            score,
+                            runtime,
+                            memoryUsage,
+                            codeSize,
+                            submission.getSubmittedAt().toString(),
+                            judgedAt
+                    );
+                })
+                .filter(item -> item != null) // null 제거 후 리스트로
+                .toList();
+
+        return new GradeBoardCodingResponse(probId, total, items);
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
@@ -7,6 +7,17 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public class ProblemCreatePracticeRequest {
+    /*
+    실습형 문제 생성의 경우, 현재는 파일 업로드(.zip)가 필요해서 multipart/form-data형식으로만 가능.
+    근데 이 형식은 @ModelAttribute로 받는데, 이건 @JsonProperty 무시하고 Java 필드명 그대로 매핑
+    그래서 osImage, allowedCommands, cpuLimit, memoryLimit 전부 camelCase로 보내야 함
+    다른 API들은 JSON이라 snake_case인데 이 API만 예외
+
+    -> 이후 zip파일을 직접 올리는 방식이아니라, 자동 생성 방식으로 고도화 되면 아마 form-data형식을 버리게 될 거 같아서
+       그땐 다시 snake_case로 가능할듯합니다.
+
+    */
+    
 
     @NotBlank
     private String title;

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
@@ -136,7 +136,7 @@ public class ProblemCreateService {
                 request.getAllowedCommands(),
                 request.getCpuLimit(),
                 request.getMemoryLimit(),
-                hashFlag(request.getFlag()),
+                hashFlag(request.getFlag().trim()),
                 null
         );
         problemPracticeRepository.save(problemPractice);


### PR DESCRIPTION
Closes #119

## 구현 내용
- `GET /api/problems/{prob_id}/board` 에서 코딩형 문제 채점 보드 조회 지원
- 응답 필드: submission_id, nickname, language, is_correct, score, runtime, memory_usage, code_size, submitted_at, judged_at
- `language` 는 `SolveSubmissionCoding` 에서 조회 (제출 시 저장된 언어)
- 실습형 flag 저장 시 공백 trim 처리 추가 (버그 수정)