### PR TITLE
[feat] 코딩형 문제 채점-문제 생성시 테스트케이스 S3 저장 (#145)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
@@ -186,6 +186,7 @@ public class ProblemCreateService {
                 oboInitialImageUrl
         );
         problemCodingRepository.save(problemCoding);
+        s3Service.uploadCodingTestcases(savedProblem.getId(), request.getTestcases());
 
         return new ProblemCreateCodingResponse(
                 savedProblem.getId(),

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -37,19 +37,22 @@ public class ProblemUpdateService {
     private final ProblemCodingRepository problemCodingRepository;
     private final OboStepRepository oboStepRepository;
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     public ProblemUpdateService(ProblemRepository problemRepository,
         ProblemObjectiveRepository problemObjectiveRepository,
         ProblemPracticeRepository problemPracticeRepository,
         ProblemCodingRepository problemCodingRepository,
         OboStepRepository oboStepRepository,
-        UserRepository userRepository){
+        UserRepository userRepository,
+        S3Service s3Service){
             this.problemObjectiveRepository = problemObjectiveRepository;
             this.problemPracticeRepository = problemPracticeRepository;
             this.problemCodingRepository = problemCodingRepository;
             this.problemRepository = problemRepository;
             this.oboStepRepository = oboStepRepository;
             this.userRepository = userRepository;
+            this.s3Service = s3Service;
         }
 
     // 객관식형
@@ -123,6 +126,10 @@ public class ProblemUpdateService {
             obo != null ? obo.getEnabled() : null,
             obo != null ? obo.getInitialImageUrl() : null
         );
+
+        if (request.getTestcases() != null) {
+            s3Service.uploadCodingTestcases(probId, request.getTestcases());
+        }
 
         return new ProblemUpdateCodingResponse(
             probId,

--- a/src/main/java/net/diveon/backend/domain/problem/service/S3Service.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/S3Service.java
@@ -1,7 +1,12 @@
 package net.diveon.backend.domain.problem.service;
 
+import net.diveon.backend.domain.problem.others.ForDtoTestCase;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface S3Service {
     void uploadDockerfileZip(Long probId, MultipartFile file);
+
+    void uploadCodingTestcases(Long probId, List<ForDtoTestCase> testcases);
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceImpl.java
@@ -1,5 +1,6 @@
 package net.diveon.backend.domain.problem.service;
 
+import net.diveon.backend.domain.problem.others.ForDtoTestCase;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -7,6 +8,8 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.util.List;
 
 // 배포 환경용. 실제 S3에 .zip 파일을 올림
 @Service
@@ -17,6 +20,9 @@ public class S3ServiceImpl implements S3Service {
 
     @Value("${aws.s3.bucket-practice-dockerfile}")
     private String bucket;
+
+    @Value("${aws.s3.bucket-code}")
+    private String codeBucket;
 
     public S3ServiceImpl(S3Client s3Client) {
         this.s3Client = s3Client;
@@ -38,5 +44,36 @@ public class S3ServiceImpl implements S3Service {
         } catch (Exception e) {
             throw new RuntimeException("S3 업로드 실패: " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public void uploadCodingTestcases(Long probId, List<ForDtoTestCase> testcases) {
+        if (testcases == null || testcases.isEmpty()) {
+            return;
+        }
+
+        try {
+            for (int i = 0; i < testcases.size(); i++) {
+                int testcaseNumber = i + 1;
+                ForDtoTestCase testcase = testcases.get(i);
+                String prefix = "testcases/prob-" + probId + "/";
+
+                uploadTextFile(prefix + "input_" + testcaseNumber + ".txt", testcase.getInput());
+                uploadTextFile(prefix + "output_" + testcaseNumber + ".txt", testcase.getOutput());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("코딩형 테스트케이스 S3 업로드 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private void uploadTextFile(String key, String content) {
+        s3Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket(codeBucket)
+                        .key(key)
+                        .contentType("text/plain")
+                        .build(),
+                RequestBody.fromString(content != null ? content : "")
+        );
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceMock.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceMock.java
@@ -1,10 +1,13 @@
 package net.diveon.backend.domain.problem.service;
 
+import net.diveon.backend.domain.problem.others.ForDtoTestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 // 로컬 환경용. 실제 S3 연결 없이 로그만 찍고 끝
 @Service
@@ -16,5 +19,12 @@ public class S3ServiceMock implements S3Service {
     @Override
     public void uploadDockerfileZip(Long probId, MultipartFile file) {
         log.info("[Mock] S3 업로드 생략 - probId: {}, 파일명: {}", probId, file.getOriginalFilename());
+    }
+
+    @Override
+    public void uploadCodingTestcases(Long probId, List<ForDtoTestCase> testcases) {
+        int testcaseCount = testcases != null ? testcases.size() : 0;
+        log.info("[Mock] 코딩형 테스트케이스 S3 업로드 생략 - probId: {}, testcaseCount: {}, prefix: testcases/prob-{}/",
+                probId, testcaseCount, probId);
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 코딩형 문제 생성시, 모든 기존 DB를 건드리지 아니하고, S3영역에 testcase 관련 데이터를 저장한다.

다만 현재
주요 점검


삭제 시 S3 테스트케이스가 남습니다.

ProblemDeleteService.java (line 119)는 problem_coding, problem_summary DB 레코드만 삭제합니다.

따라서 testcases/prob-{problemId}/input_*.txt, output_*.txt는 S3에 계속 남습니다. 문제 삭제 이후 채점 요청은 없어야 하지만, 저장소 관점에서는 orphan 파일이 생깁니다.



수정 시 테스트케이스 개수가 줄어들면 예전 S3 파일이 남습니다.

ProblemUpdateService.java (line 130)에서 새 테스트케이스를 업로드하지만 기존 prefix 하위 파일을 삭제하지 않습니다.

예를 들어 기존 5개에서 3개로 수정하면 input_4.txt, output_4.txt, input_5.txt, output_5.txt가 S3에 남습니다. SQS의 testcaseCount는 DB의 testcases.size() 기준이라 채점기가 1..3만 읽는다면 당장 문제는 없지만, 운영상 혼란 가능성이 있습니다.



S3 업로드는 부분 성공 가능성이 있습니다.

S3ServiceImpl.java (line 55)에서 파일을 순차 업로드합니다. 중간에 실패하면 앞쪽 일부 파일은 S3에 이미 올라간 상태가 됩니다. DB 트랜잭션은 롤백되지만 S3는 롤백되지 않습니다.



생성 흐름에서 S3 실패 시 DB는 롤백됩니다.

ProblemCreateService.java (line 188)에서 DB 저장 후 S3 업로드를 호출하고, 메서드가 @Transactional입니다. S3 업로드 실패는 RuntimeException으로 감싸져 올라가므로 DB 트랜잭션은 롤백됩니다. 이 방향은 괜찮습니다.



개행 저장 형식은 지원됩니다.

RequestBody.fromString(content)가 문자열을 그대로 저장하므로, JSON에서 "3\n1 5\n2 3\n3 8"로 들어온 값은 S3 파일에 실제 줄바꿈으로 저장됩니다.



흐름별 분석

코딩형 문제 생성:


Problem 저장

ProblemCoding에 기존처럼 testcases JSONB 저장

S3에 testcases/prob-{problemId}/input_N.txt, output_N.txt 업로드

문제 가능성: S3 부분 업로드 후 실패 시 S3 orphan 일부 발생 가능


코딩형 문제 수정:


DB의 Problem, ProblemCoding 수정

testcases가 요청에 있으면 S3 재업로드

문제 가능성: 기존 파일 삭제가 없어 테스트케이스 개수 감소 시 잔여 파일 발생


코딩형 문제 삭제:


DB의 ProblemCoding, Problem 삭제

S3 파일 삭제 없음

문제 가능성: 삭제된 문제의 테스트케이스 파일이 S3에 계속 남음



### 와 같은 개선사항 존재하나 일단, S3에 저장되는게 우선이라 판단하여 PR요청

## 관련 이슈
Closes #112 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
