### PR TITLE
[feat] 채점 상세 결과 조회 API 구현 (#149)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/controller/SubmissionGradeController.java
+++ b/src/main/java/net/diveon/backend/domain/grade/controller/SubmissionGradeController.java
@@ -6,9 +6,11 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import net.diveon.backend.domain.grade.dto.request.SubmissionGradeReqeust;
 import net.diveon.backend.domain.grade.dto.response.SubmissionGradeResponse;
+import net.diveon.backend.domain.grade.dto.response.SubmissionResultResponse;
 import net.diveon.backend.domain.grade.dto.response.SubmissionStatusResponse;
 import net.diveon.backend.domain.grade.service.SubmissionGradeAsyncService;
 import net.diveon.backend.domain.grade.service.SubmissionGradeStarterService;
+import net.diveon.backend.domain.grade.service.SubmissionResultService;
 import net.diveon.backend.domain.grade.service.SubmissionStatusService;
 import net.diveon.backend.global.response.ApiResponse;
 
@@ -26,15 +28,18 @@ public class SubmissionGradeController {
     private final SubmissionGradeAsyncService submissionGradeAsyncService;
     private final SubmissionGradeStarterService submissionGradeStarterService;
     private final SubmissionStatusService submissionStatusService;
+    private final SubmissionResultService submissionResultService;
 
     public SubmissionGradeController(
         SubmissionGradeAsyncService submissionGradeAsyncService,
         SubmissionGradeStarterService submissionGradeStarterService,
-        SubmissionStatusService submissionStatusService
+        SubmissionStatusService submissionStatusService,
+        SubmissionResultService submissionResultService
     ){
         this.submissionGradeAsyncService = submissionGradeAsyncService;
         this.submissionGradeStarterService = submissionGradeStarterService;
         this.submissionStatusService = submissionStatusService;
+        this.submissionResultService = submissionResultService;
     }
 
 
@@ -63,6 +68,7 @@ public class SubmissionGradeController {
         return ResponseEntity.status(200).body(ApiResponse.success("접수되었습니다.", initResponse));
     }
 
+    // 채점 상태 폴링 API
     @GetMapping("/{submissionId}/status")
     public ResponseEntity<ApiResponse<SubmissionStatusResponse>> getStatus(
         @AuthenticationPrincipal String userId,
@@ -71,5 +77,15 @@ public class SubmissionGradeController {
         SubmissionStatusResponse response = submissionStatusService.getStatus(Long.parseLong(userId), submissionId);
         return ResponseEntity.ok(ApiResponse.success("채점 상태 조회에 성공하였습니다.", response));
     }
-    
+
+    // 상세 채점 결과 확인 API
+    @GetMapping("/{submissionId}/result")
+    public ResponseEntity<ApiResponse<SubmissionResultResponse>> getResult(
+        @AuthenticationPrincipal String userId,
+        @PathVariable("submissionId") Long submissionId
+    ) {
+        SubmissionResultResponse response = submissionResultService.getResult(Long.parseLong(userId), submissionId);
+        return ResponseEntity.ok(ApiResponse.success("채점 결과 조회에 성공하였습니다.", response));
+    }
+
 }

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultCodingResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultCodingResponse.java
@@ -2,6 +2,7 @@ package net.diveon.backend.domain.grade.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SubmissionResultCodingResponse implements SubmissionResultResponse {
@@ -73,6 +74,7 @@ public class SubmissionResultCodingResponse implements SubmissionResultResponse 
     public long getSubmissionId() { return submissionId; }
     public long getProbId() { return probId; }
     public String getLanguage() { return language; }
+    @JsonIgnore
     public boolean isCorrect() { return isCorrect; }
     public short getScore() { return score; }
     public int getRuntime() { return runtime; }

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultCodingResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultCodingResponse.java
@@ -1,0 +1,84 @@
+package net.diveon.backend.domain.grade.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SubmissionResultCodingResponse implements SubmissionResultResponse {
+
+    @JsonProperty("submissionId")
+    private final long submissionId;
+
+    @JsonProperty("probId")
+    private final long probId;
+
+    @JsonProperty("probType")
+    private final String probType = "coding";
+
+    @JsonProperty("language")
+    private final String language;
+
+    @JsonProperty("isCorrect")
+    private final boolean isCorrect;
+
+    @JsonProperty("score")
+    private final short score;
+
+    @JsonProperty("runtime")
+    private final int runtime;
+
+    @JsonProperty("memoryUsage")
+    private final int memoryUsage;
+
+    @JsonProperty("codeSize")
+    private final int codeSize;
+
+    @JsonProperty("submittedAt")
+    private final LocalDateTime submittedAt;
+
+    @JsonProperty("judgedAt")
+    private final LocalDateTime judgedAt;
+
+    @JsonProperty("code")
+    private final String code;
+
+    public SubmissionResultCodingResponse(
+        long submissionId,
+        long probId,
+        String language,
+        boolean isCorrect,
+        short score,
+        int runtime,
+        int memoryUsage,
+        int codeSize,
+        LocalDateTime submittedAt,
+        LocalDateTime judgedAt,
+        String code
+    ) {
+        this.submissionId = submissionId;
+        this.probId = probId;
+        this.language = language;
+        this.isCorrect = isCorrect;
+        this.score = score;
+        this.runtime = runtime;
+        this.memoryUsage = memoryUsage;
+        this.codeSize = codeSize;
+        this.submittedAt = submittedAt;
+        this.judgedAt = judgedAt;
+        this.code = code;
+    }
+
+    @Override
+    public String getProbType() { return probType; }
+    public long getSubmissionId() { return submissionId; }
+    public long getProbId() { return probId; }
+    public String getLanguage() { return language; }
+    public boolean isCorrect() { return isCorrect; }
+    public short getScore() { return score; }
+    public int getRuntime() { return runtime; }
+    public int getMemoryUsage() { return memoryUsage; }
+    public int getCodeSize() { return codeSize; }
+    public LocalDateTime getSubmittedAt() { return submittedAt; }
+    public LocalDateTime getJudgedAt() { return judgedAt; }
+    public String getCode() { return code; }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultObjectiveResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultObjectiveResponse.java
@@ -3,6 +3,7 @@ package net.diveon.backend.domain.grade.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SubmissionResultObjectiveResponse implements SubmissionResultResponse {
@@ -48,6 +49,7 @@ public class SubmissionResultObjectiveResponse implements SubmissionResultRespon
     public String getProbType() { return probType; }
     public long getSubmissionId() { return submissionId; }
     public long getProbId() { return probId; }
+    @JsonIgnore
     public boolean isCorrect() { return isCorrect; }
     public List<Integer> getSelectedAnswers() { return selectedAnswers; }
     public LocalDateTime getSubmittedAt() { return submittedAt; }

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultObjectiveResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultObjectiveResponse.java
@@ -1,0 +1,55 @@
+package net.diveon.backend.domain.grade.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SubmissionResultObjectiveResponse implements SubmissionResultResponse {
+
+    @JsonProperty("submissionId")
+    private final long submissionId;
+
+    @JsonProperty("probId")
+    private final long probId;
+
+    @JsonProperty("probType")
+    private final String probType = "objective";
+
+    @JsonProperty("isCorrect")
+    private final boolean isCorrect;
+
+    @JsonProperty("selectedAnswers")
+    private final List<Integer> selectedAnswers;
+
+    @JsonProperty("submittedAt")
+    private final LocalDateTime submittedAt;
+
+    @JsonProperty("judgedAt")
+    private final LocalDateTime judgedAt;
+
+    public SubmissionResultObjectiveResponse(
+        long submissionId,
+        long probId,
+        boolean isCorrect,
+        List<Integer> selectedAnswers,
+        LocalDateTime submittedAt,
+        LocalDateTime judgedAt
+    ) {
+        this.submissionId = submissionId;
+        this.probId = probId;
+        this.isCorrect = isCorrect;
+        this.selectedAnswers = selectedAnswers;
+        this.submittedAt = submittedAt;
+        this.judgedAt = judgedAt;
+    }
+
+    @Override
+    public String getProbType() { return probType; }
+    public long getSubmissionId() { return submissionId; }
+    public long getProbId() { return probId; }
+    public boolean isCorrect() { return isCorrect; }
+    public List<Integer> getSelectedAnswers() { return selectedAnswers; }
+    public LocalDateTime getSubmittedAt() { return submittedAt; }
+    public LocalDateTime getJudgedAt() { return judgedAt; }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultPracticeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultPracticeResponse.java
@@ -2,6 +2,7 @@ package net.diveon.backend.domain.grade.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SubmissionResultPracticeResponse implements SubmissionResultResponse {
@@ -42,6 +43,7 @@ public class SubmissionResultPracticeResponse implements SubmissionResultRespons
     public String getProbType() { return probType; }
     public long getSubmissionId() { return submissionId; }
     public long getProbId() { return probId; }
+    @JsonIgnore
     public boolean isCorrect() { return isCorrect; }
     public LocalDateTime getSubmittedAt() { return submittedAt; }
     public LocalDateTime getJudgedAt() { return judgedAt; }

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultPracticeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultPracticeResponse.java
@@ -1,0 +1,48 @@
+package net.diveon.backend.domain.grade.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SubmissionResultPracticeResponse implements SubmissionResultResponse {
+
+    @JsonProperty("submissionId")
+    private final long submissionId;
+
+    @JsonProperty("probId")
+    private final long probId;
+
+    @JsonProperty("probType")
+    private final String probType = "practice";
+
+    @JsonProperty("isCorrect")
+    private final boolean isCorrect;
+
+    @JsonProperty("submittedAt")
+    private final LocalDateTime submittedAt;
+
+    @JsonProperty("judgedAt")
+    private final LocalDateTime judgedAt;
+
+    public SubmissionResultPracticeResponse(
+        long submissionId,
+        long probId,
+        boolean isCorrect,
+        LocalDateTime submittedAt,
+        LocalDateTime judgedAt
+    ) {
+        this.submissionId = submissionId;
+        this.probId = probId;
+        this.isCorrect = isCorrect;
+        this.submittedAt = submittedAt;
+        this.judgedAt = judgedAt;
+    }
+
+    @Override
+    public String getProbType() { return probType; }
+    public long getSubmissionId() { return submissionId; }
+    public long getProbId() { return probId; }
+    public boolean isCorrect() { return isCorrect; }
+    public LocalDateTime getSubmittedAt() { return submittedAt; }
+    public LocalDateTime getJudgedAt() { return judgedAt; }
+}

--- a/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultResponse.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/response/SubmissionResultResponse.java
@@ -1,0 +1,5 @@
+package net.diveon.backend.domain.grade.dto.response;
+
+public interface SubmissionResultResponse {
+    String getProbType();
+}

--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionResultService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionResultService.java
@@ -1,0 +1,140 @@
+package net.diveon.backend.domain.grade.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.grade.dto.response.SubmissionResultCodingResponse;
+import net.diveon.backend.domain.grade.dto.response.SubmissionResultObjectiveResponse;
+import net.diveon.backend.domain.grade.dto.response.SubmissionResultPracticeResponse;
+import net.diveon.backend.domain.grade.dto.response.SubmissionResultResponse;
+import net.diveon.backend.domain.grade.entity.SolveResult;
+import net.diveon.backend.domain.grade.entity.SolveResultCoding;
+import net.diveon.backend.domain.grade.entity.SolveSubmission;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionObjective;
+import net.diveon.backend.domain.grade.repository.SolveResultCodingRepository;
+import net.diveon.backend.domain.grade.repository.SolveResultRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionCodingRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionObjectiveRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.global.exception.InvalidProblemTypeException;
+import net.diveon.backend.global.exception.SubmissionAccessDeniedException;
+import net.diveon.backend.global.exception.SubmissionNotFoundException;
+import net.diveon.backend.global.exception.SubmissionNotCompletedException;
+
+
+// 상세 채점 결과 조회
+@Service
+public class SubmissionResultService {
+
+    private final SolveSubmissionRepository solveSubmissionRepository;
+    private final SolveResultRepository solveResultRepository;
+    private final SolveSubmissionObjectiveRepository solveSubmissionObjectiveRepository;
+    private final SolveSubmissionCodingRepository solveSubmissionCodingRepository;
+    private final SolveResultCodingRepository solveResultCodingRepository;
+
+    public SubmissionResultService(
+        SolveSubmissionRepository solveSubmissionRepository,
+        SolveResultRepository solveResultRepository,
+        SolveSubmissionObjectiveRepository solveSubmissionObjectiveRepository,
+        SolveSubmissionCodingRepository solveSubmissionCodingRepository,
+        SolveResultCodingRepository solveResultCodingRepository
+    ) {
+        this.solveSubmissionRepository = solveSubmissionRepository;
+        this.solveResultRepository = solveResultRepository;
+        this.solveSubmissionObjectiveRepository = solveSubmissionObjectiveRepository;
+        this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
+        this.solveResultCodingRepository = solveResultCodingRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public SubmissionResultResponse getResult(long userId, long submissionId) {
+
+        // 1. 제출 조회 - 없으면 404
+        SolveSubmission submission = solveSubmissionRepository.findById(submissionId)
+            .orElseThrow(() -> new SubmissionNotFoundException("존재하지 않는 제출입니다."));
+
+        // 2. 본인 제출인지 확인 - 아니면 403
+        if (!submission.getUser().getId().equals(userId)) {
+            throw new SubmissionAccessDeniedException("본인의 제출만 조회할 수 있습니다.");
+        }
+
+        // 3. 채점 완료 확인 - 아니면 409
+        if (submission.getSubmissionState() != SolveSubmission.SubmissionState.COMPLETED) {
+            throw new SubmissionNotCompletedException("아직 채점이 완료되지 않은 제출입니다.");
+        }
+
+        // 4. 채점 결과 조회
+        SolveResult result = solveResultRepository.findBySubmissionId(submissionId)
+            .orElseThrow(() -> new SubmissionNotFoundException("채점 결과가 존재하지 않습니다."));
+
+        boolean isCorrect = result.getResultState() == SolveResult.SolveResultState.CORRECT;
+        String probType = submission.getProblem().getType();
+
+        // 5. probType에 따라 응답 빌드
+        return switch (probType) {
+            case "objective" -> buildObjectiveResponse(submission, result, isCorrect);
+            case "coding"    -> buildCodingResponse(submission, result, isCorrect);
+            case "practice"  -> buildPracticeResponse(submission, result, isCorrect);
+            default -> throw new InvalidProblemTypeException("유효하지 않은 문제 유형입니다: " + probType);
+        };
+    }
+
+    // 객관식
+    private SubmissionResultObjectiveResponse buildObjectiveResponse(
+        SolveSubmission submission, SolveResult result, boolean isCorrect
+    ) {
+        SolveSubmissionObjective submissionObjective = solveSubmissionObjectiveRepository
+            .findById(submission.getId())
+            .orElseThrow(() -> new SubmissionNotFoundException("객관식 제출 정보가 존재하지 않습니다."));
+
+        return new SubmissionResultObjectiveResponse(
+            submission.getId(),
+            submission.getProblem().getId(),
+            isCorrect,
+            submissionObjective.getAnswer(),
+            submission.getSubmittedAt(),
+            result.getCreatedAt()
+        );
+    }
+
+    // 코딩형
+    private SubmissionResultCodingResponse buildCodingResponse(
+        SolveSubmission submission, SolveResult result, boolean isCorrect
+    ) {
+        SolveSubmissionCoding submissionCoding = solveSubmissionCodingRepository
+            .findById(submission.getId())
+            .orElseThrow(() -> new SubmissionNotFoundException("코딩형 제출 정보가 존재하지 않습니다."));
+
+        SolveResultCoding resultCoding = solveResultCodingRepository
+            .findById(result.getId())
+            .orElseThrow(() -> new SubmissionNotFoundException("코딩형 채점 결과가 존재하지 않습니다."));
+
+        return new SubmissionResultCodingResponse(
+            submission.getId(),
+            submission.getProblem().getId(),
+            submissionCoding.getLanguage(),
+            isCorrect,
+            resultCoding.getScore(),
+            resultCoding.getRuntime(),
+            resultCoding.getMemoryUsage(),
+            resultCoding.getCodeSize(),
+            submission.getSubmittedAt(),
+            result.getCreatedAt(),
+            submissionCoding.getAnswer()
+        );
+    }
+
+    // 실습형
+    private SubmissionResultPracticeResponse buildPracticeResponse(
+        SolveSubmission submission, SolveResult result, boolean isCorrect
+    ) {
+        return new SubmissionResultPracticeResponse(
+            submission.getId(),
+            submission.getProblem().getId(),
+            isCorrect,
+            submission.getSubmittedAt(),
+            result.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -180,4 +180,46 @@ public class GlobalExceptionHandler {
                 );
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
         }
+
+        // 제출 없음 → 404
+        @ExceptionHandler(SubmissionNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleSubmissionNotFound(
+                SubmissionNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/submission-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
+        // 본인 제출 아님 → 403
+        @ExceptionHandler(SubmissionAccessDeniedException.class)
+        public ResponseEntity<ErrorResponse> handleSubmissionAccessDenied(
+                SubmissionAccessDeniedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/submission-access-denied",
+                        "Forbidden",
+                        403,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+        }
+
+        // 채점 미완료 → 409
+        @ExceptionHandler(SubmissionNotCompletedException.class)
+        public ResponseEntity<ErrorResponse> handleSubmissionNotCompleted(
+                SubmissionNotCompletedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/submission-not-completed",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
 }

--- a/src/main/java/net/diveon/backend/global/exception/SubmissionAccessDeniedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/SubmissionAccessDeniedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class SubmissionAccessDeniedException extends RuntimeException {
+    public SubmissionAccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/SubmissionNotCompletedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/SubmissionNotCompletedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class SubmissionNotCompletedException extends RuntimeException {
+    public SubmissionNotCompletedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/SubmissionNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/SubmissionNotFoundException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class SubmissionNotFoundException extends RuntimeException {
+    public SubmissionNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- GET /api/submissions/{submissionId}/result 엔드포인트 추가
- probType에 따라 응답 필드 분기 (objective / coding / practice)
- 403, 404, 409 에러 처리 추가

## 관련 이슈
Closes #149 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
