### PR TITLE
[refactor] Group 엔티티 컬럼명 통일 (#156)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/entity/Group.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/Group.java
@@ -40,8 +40,8 @@ public class Group {
     @Column(name = "image", columnDefinition = "TEXT")
     private String image;
 
-    @Column(name = "name", nullable = false, length = 100)
-    private String name;
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
 
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
@@ -49,8 +49,8 @@ public class Group {
     @Column(name = "is_private", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean isPrivate;
 
-    @Column(name = "auto_assign", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
-    private Boolean autoAssign;
+    @Column(name = "is_auto_approve", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean isAutoApprove;
 
     @Column(name = "invitation_code", unique = true, length = 50)
     private String invitationCode;
@@ -58,16 +58,16 @@ public class Group {
     public Group() {
     }
 
-    public Group(User leader, Short limitMemberCount, String image, String name, String description,
-                 Boolean isPrivate, Boolean autoAssign, String invitationCode) {
+    public Group(User leader, Short limitMemberCount, String image, String title, String description,
+                 Boolean isPrivate, Boolean isAutoApprove, String invitationCode) {
         this.leader = leader;
         this.createdAt = LocalDateTime.now();
         this.limitMemberCount = limitMemberCount != null ? limitMemberCount : 50;
         this.image = image;
-        this.name = name;
+        this.title = title;
         this.description = description;
         this.isPrivate = isPrivate != null ? isPrivate : false;
-        this.autoAssign = autoAssign != null ? autoAssign : false;
+        this.isAutoApprove = isAutoApprove != null ? isAutoApprove : false;
         this.invitationCode = invitationCode;
     }
 
@@ -76,9 +76,9 @@ public class Group {
     public LocalDateTime getCreatedAt() { return createdAt; }
     public Short getLimitMemberCount() { return limitMemberCount; }
     public String getImage() { return image; }
-    public String getName() { return name; }
+    public String getTitle() { return title; }
     public String getDescription() { return description; }
     public Boolean getIsPrivate() { return isPrivate; }
-    public Boolean getAutoAssign() { return autoAssign; }
+    public Boolean getIsAutoApprove() { return isAutoApprove; }
     public String getInvitationCode() { return invitationCode; }
 }

--- a/src/main/java/net/diveon/backend/domain/group/entity/README.md
+++ b/src/main/java/net/diveon/backend/domain/group/entity/README.md
@@ -12,11 +12,11 @@ DEFAULT CURRENT_TIMESTAMP | 그룹 생성 시점 |
 | limit_member_count | SMALL INT | NOT NULL,
 DEFAULT 50 | 최대 수용 그룹원 수 |
 | image | TEXT |  | 그룹 공식 이미지 경로 |
-| name | VARCHAR(100) | NOT NULL | 그룸의 이름 |
+| title | VARCHAR(100) | NOT NULL | 그룹의 이름 |
 | description | TEXT | NOT NULL | 그룹 설명 |
 | is_private | BOOLEAN | NOT NULL, 
 DEFAULT FALSE | 그룹 공개 여부 |
-| auto_assign | BOOLEAN | NOT NULL, 
+| is_auto_approve | BOOLEAN | NOT NULL, 
 DEFAULT FALSE | 가입신청 자동 승인 여부 |
 | invitation_code | VARCHAR(50) | UNIQUE | 초대코드 |
     


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `name` → `title` 컬럼명 변경
- `auto_assign` → `is_auto_approve` 컬럼명 변경

## 관련 이슈
Closes #156 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
