### PR TITLE
[feat] 그룹 생성 API 구현 (#158)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -1,0 +1,32 @@
+package net.diveon.backend.domain.group.controller;
+
+import jakarta.validation.Valid;
+import net.diveon.backend.domain.group.dto.GroupCreateRequest;
+import net.diveon.backend.domain.group.dto.GroupCreateResponse;
+import net.diveon.backend.domain.group.service.GroupService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/groups")
+public class GroupController {
+
+    private final GroupService groupService;
+
+    public GroupController(GroupService groupService) {
+        this.groupService = groupService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<GroupCreateResponse>> createGroup(
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody GroupCreateRequest request) {
+        GroupCreateResponse response = groupService.createGroup(Long.parseLong(userId), request);
+        return ResponseEntity.status(201).body(ApiResponse.created("그룹이 성공적으로 생성되었습니다.", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupCreateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupCreateRequest.java
@@ -1,0 +1,29 @@
+package net.diveon.backend.domain.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public class GroupCreateRequest {
+
+    @NotBlank
+    private String title;
+
+    private String description;
+
+    private List<String> tags;
+
+    @NotNull
+    private Boolean isPrivate;
+
+    @NotNull
+    private Boolean isAutoApprove;
+
+    public GroupCreateRequest() {}
+
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public List<String> getTags() { return tags; }
+    public Boolean getIsPrivate() { return isPrivate; }
+    public Boolean getIsAutoApprove() { return isAutoApprove; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupCreateResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupCreateResponse.java
@@ -1,0 +1,12 @@
+package net.diveon.backend.domain.group.dto;
+
+public class GroupCreateResponse {
+
+    private final Long groupId;
+
+    public GroupCreateResponse(Long groupId) {
+        this.groupId = groupId;
+    }
+
+    public Long getGroupId() { return groupId; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -1,0 +1,64 @@
+package net.diveon.backend.domain.group.service;
+
+import net.diveon.backend.domain.group.dto.GroupCreateRequest;
+import net.diveon.backend.domain.group.dto.GroupCreateResponse;
+import net.diveon.backend.domain.group.entity.Group;
+import net.diveon.backend.domain.group.entity.GroupTag;
+import net.diveon.backend.domain.group.entity.GroupUser;
+import net.diveon.backend.domain.group.entity.GroupUser.GroupRole;
+import net.diveon.backend.domain.group.repository.GroupRepository;
+import net.diveon.backend.domain.group.repository.GroupTagRepository;
+import net.diveon.backend.domain.group.repository.GroupUserRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.UserNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupTagRepository groupTagRepository;
+    private final GroupUserRepository groupUserRepository;
+    private final UserRepository userRepository;
+
+    public GroupService(GroupRepository groupRepository, GroupTagRepository groupTagRepository,
+                        GroupUserRepository groupUserRepository, UserRepository userRepository) {
+        this.groupRepository = groupRepository;
+        this.groupTagRepository = groupTagRepository;
+        this.groupUserRepository = groupUserRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public GroupCreateResponse createGroup(Long userId, GroupCreateRequest request) {
+        User leader = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Group group = new Group(
+                leader,
+                null, // limitMemberCount → 기본값 50
+                null, // image → 이미지 업로드 추후 구현
+                request.getTitle(),
+                request.getDescription(),
+                request.getIsPrivate(),
+                request.getIsAutoApprove(),
+                null // invitationCode → 초대코드 추후 구현
+        );
+        groupRepository.save(group);
+
+        List<String> tags = request.getTags();
+        if (tags != null) {
+            for (String tag : tags) {
+                groupTagRepository.save(new GroupTag(group, tag));
+            }
+        }
+
+        groupUserRepository.save(new GroupUser(group, leader, GroupRole.LEADER));
+
+        return new GroupCreateResponse(group.getId());
+    }
+}

--- a/src/main/java/net/diveon/backend/global/response/ApiResponse.java
+++ b/src/main/java/net/diveon/backend/global/response/ApiResponse.java
@@ -16,6 +16,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(200, message, data);
     }
 
+    public static <T> ApiResponse<T> created(String message, T data) {
+        return new ApiResponse<>(201, message, data);
+    }
+
     public int getStatus() { return status; }
     public String getMessage() { return message; }
     public T getData() { return data; }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `POST /api/groups` 엔드포인트 구현
- 그룹 생성 시 태그(`GroupTag`) 일괄 저장
- 그룹 생성자를 `GroupUser` LEADER로 자동 등록
- `ApiResponse.created()` 추가 (201 Created 응답 규격)

## 관련 이슈
Closes #158 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
