### PR TITLE
[feat] 그룹 메인 조회 API 구현 (#160)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -30,7 +30,7 @@ public class GroupController {
     public ResponseEntity<ApiResponse<GroupDetailResponse>> getGroupDetail(
             @PathVariable Long groupId,
             @AuthenticationPrincipal String userId) {
-        Long parsedUserId = userId != null ? Long.parseLong(userId) : null; // 로그인 안 해도 그룹 상세는 접근 가능
+        Long parsedUserId = (userId != null && !userId.equals("anonymousUser")) ? Long.parseLong(userId) : null;
         GroupDetailResponse response = groupService.getGroupDetail(groupId, parsedUserId);
         return ResponseEntity.ok(ApiResponse.success("그룹 상세 정보 조회 성공", response));
     }

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -3,10 +3,13 @@ package net.diveon.backend.domain.group.controller;
 import jakarta.validation.Valid;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
+import net.diveon.backend.domain.group.dto.GroupDetailResponse;
 import net.diveon.backend.domain.group.service.GroupService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +25,17 @@ public class GroupController {
         this.groupService = groupService;
     }
 
+    // 그룹 상세 조회
+    @GetMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<GroupDetailResponse>> getGroupDetail(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId) {
+        Long parsedUserId = userId != null ? Long.parseLong(userId) : null; // 로그인 안 해도 그룹 상세는 접근 가능
+        GroupDetailResponse response = groupService.getGroupDetail(groupId, parsedUserId);
+        return ResponseEntity.ok(ApiResponse.success("그룹 상세 정보 조회 성공", response));
+    }
+
+    // 그룹 생성
     @PostMapping
     public ResponseEntity<ApiResponse<GroupCreateResponse>> createGroup(
             @AuthenticationPrincipal String userId,

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupDetailResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupDetailResponse.java
@@ -1,0 +1,72 @@
+package net.diveon.backend.domain.group.dto;
+
+import java.util.List;
+
+public class GroupDetailResponse {
+
+    private final Long groupId;
+    private final String title;
+    private final String description;
+    private final List<String> tags;
+    private final Stats stats;
+    private final Settings settings;
+    private final UserContext userContext;
+
+    public GroupDetailResponse(Long groupId, String title, String description, List<String> tags,
+                               Stats stats, Settings settings, UserContext userContext) {
+        this.groupId = groupId;
+        this.title = title;
+        this.description = description;
+        this.tags = tags;
+        this.stats = stats;
+        this.settings = settings;
+        this.userContext = userContext;
+    }
+
+    public Long getGroupId() { return groupId; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public List<String> getTags() { return tags; }
+    public Stats getStats() { return stats; }
+    public Settings getSettings() { return settings; }
+    public UserContext getUserContext() { return userContext; }
+
+    public static class Stats {
+        private final int memberCount;
+        private final int problemCount;
+
+        public Stats(int memberCount, int problemCount) {
+            this.memberCount = memberCount;
+            this.problemCount = problemCount;
+        }
+
+        public int getMemberCount() { return memberCount; }
+        public int getProblemCount() { return problemCount; }
+    }
+
+    public static class Settings {
+        private final boolean isPrivate;
+        private final boolean isAutoApprove;
+
+        public Settings(boolean isPrivate, boolean isAutoApprove) {
+            this.isPrivate = isPrivate;
+            this.isAutoApprove = isAutoApprove;
+        }
+
+        public boolean getIsPrivate() { return isPrivate; }
+        public boolean getIsAutoApprove() { return isAutoApprove; }
+    }
+
+    public static class UserContext {
+        private final String myStatus;
+        private final boolean isLeader;
+
+        public UserContext(String myStatus, boolean isLeader) {
+            this.myStatus = myStatus;
+            this.isLeader = isLeader;
+        }
+
+        public String getMyStatus() { return myStatus; }
+        public boolean getIsLeader() { return isLeader; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import net.diveon.backend.domain.group.entity.GroupAssignRequest;
 
 public interface GroupAssignRequestRepository extends JpaRepository<GroupAssignRequest, Long> {
+    boolean existsByGroupIdAndUserIdAndStatus(Long groupId, Long userId, GroupAssignRequest.AssignRequestStatus status);
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import net.diveon.backend.domain.group.entity.GroupProblem;
 
 public interface GroupProblemRepository extends JpaRepository<GroupProblem, Long> {
+    long countByGroupId(Long groupId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
@@ -1,8 +1,11 @@
 package net.diveon.backend.domain.group.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.diveon.backend.domain.group.entity.GroupTag;
 
 public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
+    List<GroupTag> findAllByGroupId(Long groupId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
@@ -1,8 +1,12 @@
 package net.diveon.backend.domain.group.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.diveon.backend.domain.group.entity.GroupUser;
 
 public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
+    long countByGroupId(Long groupId);
+    Optional<GroupUser> findByGroupIdAndUserId(Long groupId, Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -2,20 +2,26 @@ package net.diveon.backend.domain.group.service;
 
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
+import net.diveon.backend.domain.group.dto.GroupDetailResponse;
 import net.diveon.backend.domain.group.entity.Group;
+import net.diveon.backend.domain.group.entity.GroupAssignRequest.AssignRequestStatus;
 import net.diveon.backend.domain.group.entity.GroupTag;
 import net.diveon.backend.domain.group.entity.GroupUser;
 import net.diveon.backend.domain.group.entity.GroupUser.GroupRole;
+import net.diveon.backend.domain.group.repository.GroupAssignRequestRepository;
+import net.diveon.backend.domain.group.repository.GroupProblemRepository;
 import net.diveon.backend.domain.group.repository.GroupRepository;
 import net.diveon.backend.domain.group.repository.GroupTagRepository;
 import net.diveon.backend.domain.group.repository.GroupUserRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class GroupService {
@@ -23,16 +29,24 @@ public class GroupService {
     private final GroupRepository groupRepository;
     private final GroupTagRepository groupTagRepository;
     private final GroupUserRepository groupUserRepository;
+    private final GroupAssignRequestRepository groupAssignRequestRepository;
+    private final GroupProblemRepository groupProblemRepository;
     private final UserRepository userRepository;
 
     public GroupService(GroupRepository groupRepository, GroupTagRepository groupTagRepository,
-                        GroupUserRepository groupUserRepository, UserRepository userRepository) {
+                        GroupUserRepository groupUserRepository,
+                        GroupAssignRequestRepository groupAssignRequestRepository,
+                        GroupProblemRepository groupProblemRepository,
+                        UserRepository userRepository) {
         this.groupRepository = groupRepository;
         this.groupTagRepository = groupTagRepository;
         this.groupUserRepository = groupUserRepository;
+        this.groupAssignRequestRepository = groupAssignRequestRepository;
+        this.groupProblemRepository = groupProblemRepository;
         this.userRepository = userRepository;
     }
 
+    // 그룹 생성
     @Transactional
     public GroupCreateResponse createGroup(Long userId, GroupCreateRequest request) {
         User leader = userRepository.findById(userId)
@@ -60,5 +74,44 @@ public class GroupService {
         groupUserRepository.save(new GroupUser(group, leader, GroupRole.LEADER));
 
         return new GroupCreateResponse(group.getId());
+    }
+
+
+    // 그룹 상세 조회
+    @Transactional(readOnly = true)
+    public GroupDetailResponse getGroupDetail(Long groupId, Long userId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        List<String> tags = groupTagRepository.findAllByGroupId(groupId)
+                .stream().map(GroupTag::getTag).toList();
+
+        int memberCount = (int) groupUserRepository.countByGroupId(groupId);
+        int problemCount = (int) groupProblemRepository.countByGroupId(groupId); 
+        
+        // 로그인 안 했을 경우
+        String myStatus = "none";
+        boolean isLeader = false;
+
+        // 로그인 했을 경우
+        if (userId != null) {
+            Optional<GroupUser> groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId);
+            if (groupUser.isPresent()) {
+                myStatus = "member";
+                isLeader = groupUser.get().getRole() == GroupRole.LEADER;
+            } else if (groupAssignRequestRepository.existsByGroupIdAndUserIdAndStatus(groupId, userId, AssignRequestStatus.PENDING)) {
+                myStatus = "pending";
+            }
+        }
+
+        return new GroupDetailResponse(
+                group.getId(),
+                group.getTitle(),
+                group.getDescription(),
+                tags,
+                new GroupDetailResponse.Stats(memberCount, problemCount),
+                new GroupDetailResponse.Settings(group.getIsPrivate(), group.getIsAutoApprove()),
+                new GroupDetailResponse.UserContext(myStatus, isLeader)
+        );
     }
 }

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import net.diveon.backend.global.security.JwtFilter;
 import net.diveon.backend.global.security.JwtProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -39,6 +40,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/ad/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/groups/*/members/pending").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/groups/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -209,6 +209,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
         }
 
+        // 그룹 없음 → 404
+        @ExceptionHandler(GroupNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleGroupNotFound(
+                GroupNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/group-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
         // 채점 미완료 → 409
         @ExceptionHandler(SubmissionNotCompletedException.class)
         public ResponseEntity<ErrorResponse> handleSubmissionNotCompleted(

--- a/src/main/java/net/diveon/backend/global/exception/GroupNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GroupNotFoundException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class GroupNotFoundException extends RuntimeException {
+
+    public GroupNotFoundException() {
+        super("존재하지 않는 그룹입니다.");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `GET /api/groups/{groupId}` 구현
- 그룹 기본 정보 반환 (제목, 설명, 태그 목록)
- `Stats` - 멤버 수, 문제 수 반환
- `Settings` - 비공개 여부, 자동 승인 여부 반환
- `UserContext` - myStatus(none/pending/member), isLeader 반환
- 비로그인 사용자 접근 허용 (anonymousUser 처리)
- 존재하지 않는 그룹 요청 시 404 반환
- `GroupNotFoundException` 및 핸들러 추가
- `GroupTagRepository`, `GroupUserRepository`, `GroupAssignRequestRepository`, `GroupProblemRepository` 메서드 추가
- `SecurityConfig` - `GET /api/groups/**` permitAll, `GET /api/groups/*/members/pending` authenticated 처리

## 관련 이슈
Closes #160


<!-- 주석은 제외되고 올라가니 무시하세요 -->
