### PR TITLE
[feat] 문제 목록 조회 API visibility 필터 추가 (#164)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
@@ -31,14 +31,16 @@ public class ProblemController {
         @RequestParam(defaultValue = "1") int page,
         @RequestParam(required = false) String title,
         @RequestParam(required = false) String category,
-        @RequestParam(required = false) String difficulty
+        @RequestParam(required = false) String difficulty,
+        @RequestParam(required = false) String visibility
     ) {
         ProblemListResponse responseData = problemListService.listProblems(
             Long.parseLong(userId),
             page,
             title,
             category,
-            difficulty
+            difficulty,
+            visibility
         );
 
         return ResponseEntity.status(200)

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
@@ -34,7 +34,8 @@ public class ProblemListService {
         int page,
         String title,
         String category,
-        String difficulty
+        String difficulty,
+        String visibility
     ) {
         userRepository.findById(userId).orElseThrow();
 
@@ -44,7 +45,7 @@ public class ProblemListService {
             Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        Specification<Problem> spec = buildSpecification(title, category, difficulty);
+        Specification<Problem> spec = buildSpecification(title, category, difficulty, visibility);
         Page<Problem> problemPage = problemRepository.findAll(spec, pageable);
 
         List<ProblemListItemResponse> problemList = problemPage.getContent()
@@ -55,7 +56,7 @@ public class ProblemListService {
         return ProblemListResponse.of(problemPage, problemList);
     }
 
-    private Specification<Problem> buildSpecification(String title, String category, String difficulty) {
+    private Specification<Problem> buildSpecification(String title, String category, String difficulty, String visibility) {
         return (root, query, cb) -> {
             var predicates = new java.util.ArrayList<>();
 
@@ -69,6 +70,10 @@ public class ProblemListService {
 
             if (difficulty != null && !difficulty.isEmpty()) {
                 predicates.add(cb.equal(root.get("difficulty"), difficulty));
+            }
+
+            if (visibility != null && !visibility.isEmpty()) {
+                predicates.add(cb.equal(root.get("visibility"), visibility));
             }
 
             return cb.and(predicates.toArray(new Predicate[0]));


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `GET /api/problems`에 `visibility` 쿼리 파라미터 추가
- `?visibility=public` 으로 공개 문제만 필터링 가능
- 파라미터 없을 경우 기존과 동일하게 전체 목록 반환

## 관련 이슈
Closes #164


<!-- 주석은 제외되고 올라가니 무시하세요 -->
