### PR TITLE
[feat] 내가 속한 그룹 목록 조회 API 구현 (#168)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
+import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.service.GroupService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/groups")
 public class GroupController {
@@ -23,6 +26,14 @@ public class GroupController {
 
     public GroupController(GroupService groupService) {
         this.groupService = groupService;
+    }
+
+    // 내가 속한 그룹 목록 조회
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<GroupMyListResponse>>> getMyGroups(
+            @AuthenticationPrincipal String userId) {
+        List<GroupMyListResponse> response = groupService.getMyGroups(Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("내 그룹 목록 조회 성공", response));
     }
 
     // 그룹 상세 조회

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupMyListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupMyListResponse.java
@@ -1,0 +1,24 @@
+package net.diveon.backend.domain.group.dto;
+
+import net.diveon.backend.domain.group.entity.GroupUser;
+
+public class GroupMyListResponse {
+
+    private Long groupId;
+    private String title;
+
+    public GroupMyListResponse(Long groupId, String title) {
+        this.groupId = groupId;
+        this.title = title;
+    }
+
+    public static GroupMyListResponse of(GroupUser groupUser) {
+        return new GroupMyListResponse(
+                groupUser.getGroup().getId(),
+                groupUser.getGroup().getTitle()
+        );
+    }
+
+    public Long getGroupId() { return groupId; }
+    public String getTitle() { return title; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.diveon.backend.domain.group.entity.GroupUser;
 
+import java.util.List;
+
 public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
     long countByGroupId(Long groupId);
     Optional<GroupUser> findByGroupIdAndUserId(Long groupId, Long userId);
+    List<GroupUser> findAllByUserId(Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -3,6 +3,7 @@ package net.diveon.backend.domain.group.service;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
+import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.entity.Group;
 import net.diveon.backend.domain.group.entity.GroupAssignRequest.AssignRequestStatus;
 import net.diveon.backend.domain.group.entity.GroupTag;
@@ -76,6 +77,17 @@ public class GroupService {
         return new GroupCreateResponse(group.getId());
     }
 
+
+    // 내가 속한 그룹 목록 조회
+    /* findAllByUserId(userId) 로 내 userId로 조회하면 내가 속한 그룹들이 List<GroupUser> 형태로 나오고,
+      각각에서 group.getId(), group.getTitle() 뽑아서 반환 */
+    @Transactional(readOnly = true)
+    public List<GroupMyListResponse> getMyGroups(Long userId) {
+        List<GroupUser> groupUsers = groupUserRepository.findAllByUserId(userId);
+        return groupUsers.stream()
+                .map(GroupMyListResponse::of)
+                .toList(); 
+    }
 
     // 그룹 상세 조회
     @Transactional(readOnly = true)

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/ad/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/groups/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members/pending").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/problems").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members").authenticated()


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `GET /api/groups/me` 엔드포인트 구현
- JWT 토큰으로 userId 식별, 내가 속한 그룹 목록 반환
- 응답: groupId, title
- `GET /api/groups/me` SecurityConfig authenticated 규칙 추가

## 관련 이슈
Closes #168 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
