### PR TITLE
[feat] 공개 문제 그룹 추가 API 구현 (#169)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -1,6 +1,7 @@
 package net.diveon.backend.domain.group.controller;
 
 import jakarta.validation.Valid;
+import net.diveon.backend.domain.group.dto.GroupAddProblemsRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
@@ -44,6 +45,16 @@ public class GroupController {
         Long parsedUserId = (userId != null && !userId.equals("anonymousUser")) ? Long.parseLong(userId) : null;
         GroupDetailResponse response = groupService.getGroupDetail(groupId, parsedUserId);
         return ResponseEntity.ok(ApiResponse.success("그룹 상세 정보 조회 성공", response));
+    }
+
+    // 공개 문제 그룹에 추가
+    @PostMapping("/{groupId}/problems")
+    public ResponseEntity<ApiResponse<Void>> addProblems(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId,
+            @RequestBody GroupAddProblemsRequest request) {
+        groupService.addProblems(groupId, Long.parseLong(userId), request);
+        return ResponseEntity.status(201).body(ApiResponse.created("문제가 그룹에 추가되었습니다.", null));
     }
 
     // 그룹 생성

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupAddProblemsRequest.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupAddProblemsRequest.java
@@ -1,0 +1,12 @@
+package net.diveon.backend.domain.group.dto;
+
+public class GroupAddProblemsRequest {
+
+    private Long problemId;
+
+    public GroupAddProblemsRequest() {
+    }
+
+    public Long getProblemId() { return problemId; }
+    public void setProblemId(Long problemId) { this.problemId = problemId; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
@@ -6,4 +6,5 @@ import net.diveon.backend.domain.group.entity.GroupProblem;
 
 public interface GroupProblemRepository extends JpaRepository<GroupProblem, Long> {
     long countByGroupId(Long groupId);
+    boolean existsByGroupIdAndProblemId(Long groupId, Long problemId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -1,11 +1,13 @@
 package net.diveon.backend.domain.group.service;
 
+import net.diveon.backend.domain.group.dto.GroupAddProblemsRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.entity.Group;
 import net.diveon.backend.domain.group.entity.GroupAssignRequest.AssignRequestStatus;
+import net.diveon.backend.domain.group.entity.GroupProblem;
 import net.diveon.backend.domain.group.entity.GroupTag;
 import net.diveon.backend.domain.group.entity.GroupUser;
 import net.diveon.backend.domain.group.entity.GroupUser.GroupRole;
@@ -14,9 +16,13 @@ import net.diveon.backend.domain.group.repository.GroupProblemRepository;
 import net.diveon.backend.domain.group.repository.GroupRepository;
 import net.diveon.backend.domain.group.repository.GroupTagRepository;
 import net.diveon.backend.domain.group.repository.GroupUserRepository;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.GroupAccessDeniedException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
+import net.diveon.backend.global.exception.GroupProblemAlreadyExistsException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,18 +39,21 @@ public class GroupService {
     private final GroupAssignRequestRepository groupAssignRequestRepository;
     private final GroupProblemRepository groupProblemRepository;
     private final UserRepository userRepository;
+    private final ProblemRepository problemRepository;
 
     public GroupService(GroupRepository groupRepository, GroupTagRepository groupTagRepository,
                         GroupUserRepository groupUserRepository,
                         GroupAssignRequestRepository groupAssignRequestRepository,
                         GroupProblemRepository groupProblemRepository,
-                        UserRepository userRepository) {
+                        UserRepository userRepository,
+                        ProblemRepository problemRepository) {
         this.groupRepository = groupRepository;
         this.groupTagRepository = groupTagRepository;
         this.groupUserRepository = groupUserRepository;
         this.groupAssignRequestRepository = groupAssignRequestRepository;
         this.groupProblemRepository = groupProblemRepository;
         this.userRepository = userRepository;
+        this.problemRepository = problemRepository;
     }
 
     // 그룹 생성
@@ -77,6 +86,30 @@ public class GroupService {
         return new GroupCreateResponse(group.getId());
     }
 
+
+    // 공개 문제 그룹에 추가
+    @Transactional
+    public void addProblems(Long groupId, Long userId, GroupAddProblemsRequest request) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupAccessDeniedException::new);
+
+        Long problemId = request.getProblemId();
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new RuntimeException("문제를 찾을 수 없습니다."));
+
+        if (!"public".equals(problem.getVisibility())) {
+            throw new GroupAccessDeniedException();
+        }
+
+        if (groupProblemRepository.existsByGroupIdAndProblemId(groupId, problemId)) {
+            throw new GroupProblemAlreadyExistsException();
+        }
+
+        groupProblemRepository.save(new GroupProblem(problem, group));
+    }
 
     // 내가 속한 그룹 목록 조회
     /* findAllByUserId(userId) 로 내 userId로 조회하면 내가 속한 그룹들이 List<GroupUser> 형태로 나오고,

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -223,6 +223,34 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // 이미 그룹에 추가된 문제 → 409
+        @ExceptionHandler(GroupProblemAlreadyExistsException.class)
+        public ResponseEntity<ErrorResponse> handleGroupProblemAlreadyExists(
+                GroupProblemAlreadyExistsException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/conflict/group-problem-already-exists",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
+
+        // 그룹 멤버 아님 → 403
+        @ExceptionHandler(GroupAccessDeniedException.class)
+        public ResponseEntity<ErrorResponse> handleGroupAccessDenied(
+                GroupAccessDeniedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/group-access-denied",
+                        "Forbidden",
+                        403,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+        }
+
         // 채점 미완료 → 409
         @ExceptionHandler(SubmissionNotCompletedException.class)
         public ResponseEntity<ErrorResponse> handleSubmissionNotCompleted(

--- a/src/main/java/net/diveon/backend/global/exception/GroupAccessDeniedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GroupAccessDeniedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class GroupAccessDeniedException extends RuntimeException {
+    public GroupAccessDeniedException() {
+        super("그룹 멤버가 아닙니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GroupProblemAlreadyExistsException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GroupProblemAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class GroupProblemAlreadyExistsException extends RuntimeException {
+    public GroupProblemAlreadyExistsException() {
+        super("이미 그룹에 추가된 문제입니다.");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `POST /api/groups/{groupId}/problems` 엔드포인트 구현
- 요청한 유저가 그룹 멤버가 아니면 403 반환
- `visibility: "public"` 이 아닌 문제 추가 시 403 반환
- 이미 그룹에 추가된 문제 요청 시 409 반환
- `GroupAccessDeniedException`, `GroupProblemAlreadyExistsException` 추가

## 관련 이슈
Closes #169


<!-- 주석은 제외되고 올라가니 무시하세요 -->
