### PR TITLE
[feat] 그룹 문제 목록 조회 API 구현 (#170)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -6,6 +6,8 @@ import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
+import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
+import org.springframework.web.bind.annotation.RequestParam;
 import net.diveon.backend.domain.group.service.GroupService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +47,16 @@ public class GroupController {
         Long parsedUserId = (userId != null && !userId.equals("anonymousUser")) ? Long.parseLong(userId) : null;
         GroupDetailResponse response = groupService.getGroupDetail(groupId, parsedUserId);
         return ResponseEntity.ok(ApiResponse.success("그룹 상세 정보 조회 성공", response));
+    }
+
+    // 그룹 문제 목록 조회
+    @GetMapping("/{groupId}/problems")
+    public ResponseEntity<ApiResponse<GroupProblemListResponse>> getGroupProblems(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page) {
+        GroupProblemListResponse response = groupService.getGroupProblems(groupId, Long.parseLong(userId), page);
+        return ResponseEntity.ok(ApiResponse.success("그룹 문제 목록 조회 성공", response));
     }
 
     // 공개 문제 그룹에 추가

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupProblemListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupProblemListResponse.java
@@ -1,0 +1,58 @@
+package net.diveon.backend.domain.group.dto;
+
+import net.diveon.backend.domain.group.entity.GroupProblem;
+
+import java.util.List;
+
+public class GroupProblemListResponse {
+
+    private List<ProblemItem> problems;
+    private int currentPage;
+    private int totalPages;
+
+    public GroupProblemListResponse(List<ProblemItem> problems, int currentPage, int totalPages) {
+        this.problems = problems;
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+    }
+
+    public List<ProblemItem> getProblems() { return problems; }
+    public int getCurrentPage() { return currentPage; }
+    public int getTotalPages() { return totalPages; }
+
+    public static class ProblemItem {
+        private Long problemId;
+        private String title;
+        private String author;
+        private int solvedCount;
+        private String difficulty;
+        private String visibility;
+
+        public ProblemItem(Long problemId, String title, String author, int solvedCount, String difficulty, String visibility) {
+            this.problemId = problemId;
+            this.title = title;
+            this.author = author;
+            this.solvedCount = solvedCount;
+            this.difficulty = difficulty;
+            this.visibility = visibility;
+        }
+
+        public static ProblemItem of(GroupProblem groupProblem) {
+            return new ProblemItem(
+                    groupProblem.getProblem().getId(),
+                    groupProblem.getProblem().getTitle(),
+                    groupProblem.getProblem().getAuthor().getNickname(),
+                    groupProblem.getProblem().getSolvedCount(),
+                    groupProblem.getProblem().getDifficulty(),
+                    groupProblem.getProblem().getVisibility()
+            );
+        }
+
+        public Long getProblemId() { return problemId; }
+        public String getTitle() { return title; }
+        public String getAuthor() { return author; }
+        public int getSolvedCount() { return solvedCount; }
+        public String getDifficulty() { return difficulty; }
+        public String getVisibility() { return visibility; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
@@ -1,5 +1,7 @@
 package net.diveon.backend.domain.group.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.diveon.backend.domain.group.entity.GroupProblem;
@@ -7,4 +9,5 @@ import net.diveon.backend.domain.group.entity.GroupProblem;
 public interface GroupProblemRepository extends JpaRepository<GroupProblem, Long> {
     long countByGroupId(Long groupId);
     boolean existsByGroupIdAndProblemId(Long groupId, Long problemId);
+    Page<GroupProblem> findAllByGroupId(Long groupId, Pageable pageable);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -5,6 +5,11 @@ import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
+import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import net.diveon.backend.domain.group.entity.Group;
 import net.diveon.backend.domain.group.entity.GroupAssignRequest.AssignRequestStatus;
 import net.diveon.backend.domain.group.entity.GroupProblem;
@@ -86,6 +91,27 @@ public class GroupService {
         return new GroupCreateResponse(group.getId());
     }
 
+
+    // 그룹 문제 목록 조회
+    @Transactional(readOnly = true)
+    public GroupProblemListResponse getGroupProblems(Long groupId, Long userId, int page) {
+        groupRepository.findById(groupId).orElseThrow(GroupNotFoundException::new);
+        groupUserRepository.findByGroupIdAndUserId(groupId, userId).orElseThrow(GroupAccessDeniedException::new);
+
+        Pageable pageable = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "assignedAt"));
+        Page<GroupProblem> groupProblemPage = groupProblemRepository.findAllByGroupId(groupId, pageable);
+
+        List<GroupProblemListResponse.ProblemItem> problems = groupProblemPage.getContent()
+                .stream()
+                .map(GroupProblemListResponse.ProblemItem::of)
+                .toList();
+
+        return new GroupProblemListResponse(
+                problems,
+                page,
+                groupProblemPage.getTotalPages()
+        );
+    }
 
     // 공개 문제 그룹에 추가
     @Transactional


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `GET /api/groups/{groupId}/problems?page=1` 엔드포인트 구현
- 응답: `problems`, `currentPage`, `totalPages`
- 그룹 멤버가 아닌 경우 403 반환
- 최신 추가 순으로 정렬, 페이지당 10개

## 관련 이슈
Closes #170 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
