### PR TITLE
[feat] 그룹 목록 조회 API 구현 (#183)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -5,6 +5,7 @@ import net.diveon.backend.domain.group.dto.GroupAddProblemsRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
+import net.diveon.backend.domain.group.dto.GroupListResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,6 +30,19 @@ public class GroupController {
 
     public GroupController(GroupService groupService) {
         this.groupService = groupService;
+    }
+
+    // 그룹 목록 조회
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<GroupListResponse>> getGroupList(
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(required = false) String tag,
+            @RequestParam(required = false) Boolean isJoined) {
+        Long parsedUserId = (userId != null && !userId.equals("anonymousUser")) ? Long.parseLong(userId) : null;
+        GroupListResponse response = groupService.getGroupList(parsedUserId, page, size, tag, isJoined);
+        return ResponseEntity.ok(ApiResponse.success("그룹 목록 조회에 성공하였습니다.", response));
     }
 
     // 내가 속한 그룹 목록 조회

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupListResponse.java
@@ -1,0 +1,51 @@
+package net.diveon.backend.domain.group.dto;
+
+import java.util.List;
+
+public class GroupListResponse {
+
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+    private List<GroupItem> groups;
+
+    public GroupListResponse(long totalElements, int totalPages, int currentPage, List<GroupItem> groups) {
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.currentPage = currentPage;
+        this.groups = groups;
+    }
+
+    public long getTotalElements() { return totalElements; }
+    public int getTotalPages() { return totalPages; }
+    public int getCurrentPage() { return currentPage; }
+    public List<GroupItem> getGroups() { return groups; }
+
+    public static class GroupItem {
+        private Long groupId;
+        private String title;
+        private String leader;
+        private int memberCount;
+        private int totalMembers;
+        private List<String> tags;
+        private boolean joined;
+
+        public GroupItem(Long groupId, String title, String leader, int memberCount, int totalMembers, List<String> tags, boolean joined) {
+            this.groupId = groupId;
+            this.title = title;
+            this.leader = leader;
+            this.memberCount = memberCount;
+            this.totalMembers = totalMembers;
+            this.tags = tags;
+            this.joined = joined;
+        }
+
+        public Long getGroupId() { return groupId; }
+        public String getTitle() { return title; }
+        public String getLeader() { return leader; }
+        public int getMemberCount() { return memberCount; }
+        public int getTotalMembers() { return totalMembers; }
+        public List<String> getTags() { return tags; }
+        public boolean isJoined() { return joined; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
@@ -1,8 +1,17 @@
 package net.diveon.backend.domain.group.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import net.diveon.backend.domain.group.entity.Group;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    @Query("SELECT g FROM Group g WHERE " +
+           "(:tag IS NULL OR EXISTS (SELECT gt FROM GroupTag gt WHERE gt.group = g AND gt.tag = :tag)) AND " +
+           "(:userId IS NULL OR EXISTS (SELECT gu FROM GroupUser gu WHERE gu.group = g AND gu.user.id = :userId))")
+    Page<Group> findAllWithFilters(@Param("tag") String tag, @Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
@@ -8,4 +8,5 @@ import net.diveon.backend.domain.group.entity.GroupTag;
 
 public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
     List<GroupTag> findAllByGroupId(Long groupId);
+    List<GroupTag> findAllByGroupIdIn(List<Long> groupIds);
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
@@ -12,4 +12,5 @@ public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
     long countByGroupId(Long groupId);
     Optional<GroupUser> findByGroupIdAndUserId(Long groupId, Long userId);
     List<GroupUser> findAllByUserId(Long userId);
+    List<GroupUser> findAllByGroupIdIn(List<Long> groupIds);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -4,6 +4,7 @@ import net.diveon.backend.domain.group.dto.GroupAddProblemsRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
+import net.diveon.backend.domain.group.dto.GroupListResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
 import org.springframework.data.domain.Page;
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -59,6 +61,61 @@ public class GroupService {
         this.groupProblemRepository = groupProblemRepository;
         this.userRepository = userRepository;
         this.problemRepository = problemRepository;
+    }
+
+    // 그룹 목록 조회
+    @Transactional(readOnly = true)
+    public GroupListResponse getGroupList(Long userId, int page, int size, String tag, Boolean isJoined) {
+        // 비 로그인자가 '내 그룹만 보기' 버튼 누르면 401 오류 던짐
+        if (Boolean.TRUE.equals(isJoined) && userId == null) { 
+            throw new UserNotFoundException();
+        } 
+
+        // isJoined=true면 내 그룹만, 아니면 전체 조회
+        Long filterUserId = Boolean.TRUE.equals(isJoined) ? userId : null;
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+
+        // 태그/isJoined 필터 적용해서 그룹 목록 가져오고, 그룹 ID 목록만 뽑기
+        Page<Group> groupPage = groupRepository.findAllWithFilters(tag, filterUserId, pageable);
+        List<Long> groupIds = groupPage.getContent().stream().map(Group::getId).toList();
+
+        // // N+1 방지: groupIds로 태그/멤버/joined 여부 일괄 조회 (쿼리수 줄이기 위해)
+        // 1. 태그 목록
+        Map<Long, List<String>> tagMap = groupTagRepository.findAllByGroupIdIn(groupIds).stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        gt -> gt.getGroup().getId(),
+                        java.util.stream.Collectors.mapping(GroupTag::getTag, java.util.stream.Collectors.toList())
+                ));
+
+        List<GroupUser> allGroupUsers = groupUserRepository.findAllByGroupIdIn(groupIds);
+
+        // 2. 멤버수
+        Map<Long, Long> memberCountMap = allGroupUsers.stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        gu -> gu.getGroup().getId(),
+                        java.util.stream.Collectors.counting()
+                ));
+
+        // 3. 내가 속한 그룹 ID 목록        
+        java.util.Set<Long> joinedGroupIds = userId == null ? java.util.Set.of() :
+                allGroupUsers.stream()
+                        .filter(gu -> gu.getUser().getId().equals(userId))
+                        .map(gu -> gu.getGroup().getId())
+                        .collect(java.util.stream.Collectors.toSet());
+
+        List<GroupListResponse.GroupItem> groups = groupPage.getContent().stream()
+                .map(group -> new GroupListResponse.GroupItem(
+                        group.getId(),
+                        group.getTitle(),
+                        group.getLeader().getNickname(),
+                        memberCountMap.getOrDefault(group.getId(), 0L).intValue(),
+                        group.getLimitMemberCount(),
+                        tagMap.getOrDefault(group.getId(), List.of()),
+                        joinedGroupIds.contains(group.getId())
+                )).toList();
+
+        return new GroupListResponse(groupPage.getTotalElements(), groupPage.getTotalPages(), page, groups);
     }
 
     // 그룹 생성


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `GET /api/groups` 엔드포인트 구현
- `tag` 파라미터로 태그 필터링
- `isJoined=true` 파라미터로 내 그룹만 보기 (비로그인 시 401)
- 페이지네이션 (기본값: page=1, size=5)
- 응답: groupId, title, leader, memberCount, totalMembers, tags, joined
- N+1 방지: 태그/멤버수/joined 여부 groupIds로 일괄 조회


## 관련 이슈
Closes #183


<!-- 주석은 제외되고 올라가니 무시하세요 -->
