### PR TITLE
[feat] 그룹 이름 검색 API 구현 (#184)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -32,6 +32,18 @@ public class GroupController {
         this.groupService = groupService;
     }
 
+    // 그룹 검색
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<GroupListResponse>> searchGroups(
+            @AuthenticationPrincipal String userId,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "5") int size) {
+        Long parsedUserId = (userId != null && !userId.equals("anonymousUser")) ? Long.parseLong(userId) : null;
+        GroupListResponse response = groupService.searchGroups(parsedUserId, keyword, page, size);
+        return ResponseEntity.ok(ApiResponse.success("그룹 검색에 성공하였습니다.", response));
+    }
+
     // 그룹 목록 조회
     @GetMapping("")
     public ResponseEntity<ApiResponse<GroupListResponse>> getGroupList(

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
@@ -14,4 +14,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
            "(:tag IS NULL OR EXISTS (SELECT gt FROM GroupTag gt WHERE gt.group = g AND gt.tag = :tag)) AND " +
            "(:userId IS NULL OR EXISTS (SELECT gu FROM GroupUser gu WHERE gu.group = g AND gu.user.id = :userId))")
     Page<Group> findAllWithFilters(@Param("tag") String tag, @Param("userId") Long userId, Pageable pageable);
+
+    Page<Group> findByTitleContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -67,20 +67,28 @@ public class GroupService {
     @Transactional(readOnly = true)
     public GroupListResponse getGroupList(Long userId, int page, int size, String tag, Boolean isJoined) {
         // 비 로그인자가 '내 그룹만 보기' 버튼 누르면 401 오류 던짐
-        if (Boolean.TRUE.equals(isJoined) && userId == null) { 
+        if (Boolean.TRUE.equals(isJoined) && userId == null) {
             throw new UserNotFoundException();
-        } 
-
+        }
         // isJoined=true면 내 그룹만, 아니면 전체 조회
         Long filterUserId = Boolean.TRUE.equals(isJoined) ? userId : null;
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-
-
-        // 태그/isJoined 필터 적용해서 그룹 목록 가져오고, 그룹 ID 목록만 뽑기
         Page<Group> groupPage = groupRepository.findAllWithFilters(tag, filterUserId, pageable);
+        return buildGroupListResponse(groupPage, userId, page);
+    }
+
+    // 그룹 검색
+    @Transactional(readOnly = true)
+    public GroupListResponse searchGroups(Long userId, String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Group> groupPage = groupRepository.findByTitleContainingIgnoreCase(keyword, pageable);
+        return buildGroupListResponse(groupPage, userId, page);
+    }
+
+    // N+1 방지: groupIds로 태그/멤버/joined 여부 일괄 조회 후 응답 조립
+    private GroupListResponse buildGroupListResponse(Page<Group> groupPage, Long userId, int page) {
         List<Long> groupIds = groupPage.getContent().stream().map(Group::getId).toList();
 
-        // // N+1 방지: groupIds로 태그/멤버/joined 여부 일괄 조회 (쿼리수 줄이기 위해)
         // 1. 태그 목록
         Map<Long, List<String>> tagMap = groupTagRepository.findAllByGroupIdIn(groupIds).stream()
                 .collect(java.util.stream.Collectors.groupingBy(
@@ -97,7 +105,7 @@ public class GroupService {
                         java.util.stream.Collectors.counting()
                 ));
 
-        // 3. 내가 속한 그룹 ID 목록        
+        // 3. 내가 속한 그룹 ID 목록
         java.util.Set<Long> joinedGroupIds = userId == null ? java.util.Set.of() :
                 allGroupUsers.stream()
                         .filter(gu -> gu.getUser().getId().equals(userId))


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `GET /api/groups/search?keyword=기사단&page=1&size=5` 구현
- 키워드 기반 그룹 제목 부분일치 검색 (대소문자 구분 없음)
- 페이지네이션 지원 (기본값: page=1, size=5)
- 비로그인 시에도 조회 가능, 로그인 시 `joined` 여부 포함
- N+1 방지: 태그/멤버수/joined 여부 groupIds로 일괄 조회
- 공통 응답 조립 로직 `buildGroupListResponse`로 목록 조회와 통합


## 관련 이슈
Closes #184 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
