### PR TITLE
[feat] 그룹 삭제(폐쇄) API 구현 (#186)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -93,6 +94,15 @@ public class GroupController {
             @RequestBody GroupAddProblemsRequest request) {
         groupService.addProblems(groupId, Long.parseLong(userId), request);
         return ResponseEntity.status(201).body(ApiResponse.created("문제가 그룹에 추가되었습니다.", null));
+    }
+
+    // 그룹 삭제
+    @DeleteMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<Void>> deleteGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId) {
+        groupService.deleteGroup(groupId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("그룹이 성공적으로 삭제(폐쇄)되었습니다.", null));
     }
 
     // 그룹 생성

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -126,6 +126,22 @@ public class GroupService {
         return new GroupListResponse(groupPage.getTotalElements(), groupPage.getTotalPages(), page, groups);
     }
 
+    // 그룹 삭제
+    @Transactional
+    public void deleteGroup(Long groupId, Long userId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupAccessDeniedException::new);
+
+        if (groupUser.getRole() != GroupUser.GroupRole.LEADER) {
+            throw new GroupAccessDeniedException();
+        }
+
+        groupRepository.delete(group);
+    }
+
     // 그룹 생성
     @Transactional
     public GroupCreateResponse createGroup(Long userId, GroupCreateRequest request) {


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `DELETE /api/groups/{groupId}` 구현
- 그룹장 권한 필수, 미인증 시 401 / 권한 없음 시 403 반환
- 그룹 삭제 시 연쇄 삭제: `GroupUser`, `GroupTag`, `GroupProblem`, `GroupAssignRequest`, `GroupPost`, `GroupPostComment` (DB CASCADE)
- 문제(`Problem`) 자체는 삭제되지 않음, 그룹-문제 연결(`GroupProblem`)만 제거


## 관련 이슈
Closes #186 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
