### PR TITLE
[feat] 그룹 설정 수정 API 구현 (#185)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -8,6 +8,8 @@ import net.diveon.backend.domain.group.dto.GroupDetailResponse;
 import net.diveon.backend.domain.group.dto.GroupListResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
+import net.diveon.backend.domain.group.dto.GroupUpdateRequest;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import net.diveon.backend.domain.group.service.GroupService;
 import net.diveon.backend.global.response.ApiResponse;
@@ -94,6 +96,16 @@ public class GroupController {
             @RequestBody GroupAddProblemsRequest request) {
         groupService.addProblems(groupId, Long.parseLong(userId), request);
         return ResponseEntity.status(201).body(ApiResponse.created("문제가 그룹에 추가되었습니다.", null));
+    }
+
+    // 그룹 설정 수정
+    @PatchMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<Void>> updateGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody GroupUpdateRequest request) {
+        groupService.updateGroup(groupId, Long.parseLong(userId), request);
+        return ResponseEntity.ok(ApiResponse.success("그룹 설정이 수정되었습니다.", null));
     }
 
     // 그룹 삭제

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupUpdateRequest.java
@@ -1,0 +1,29 @@
+package net.diveon.backend.domain.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public class GroupUpdateRequest {
+
+    @NotBlank
+    private String title;
+
+    private String description;
+
+    private List<String> tags;
+
+    @NotNull
+    private Boolean isPrivate;
+
+    @NotNull
+    private Boolean isAutoApprove;
+
+    public GroupUpdateRequest() {}
+
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public List<String> getTags() { return tags; }
+    public Boolean getIsPrivate() { return isPrivate; }
+    public Boolean getIsAutoApprove() { return isAutoApprove; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/entity/Group.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/Group.java
@@ -81,4 +81,11 @@ public class Group {
     public Boolean getIsPrivate() { return isPrivate; }
     public Boolean getIsAutoApprove() { return isAutoApprove; }
     public String getInvitationCode() { return invitationCode; }
+
+    public void update(String title, String description, Boolean isPrivate, Boolean isAutoApprove) {
+        this.title = title;
+        this.description = description;
+        this.isPrivate = isPrivate;
+        this.isAutoApprove = isAutoApprove;
+    }
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
@@ -9,4 +9,5 @@ import net.diveon.backend.domain.group.entity.GroupTag;
 public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
     List<GroupTag> findAllByGroupId(Long groupId);
     List<GroupTag> findAllByGroupIdIn(List<Long> groupIds);
+    void deleteAllByGroupId(Long groupId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -142,7 +142,7 @@ public class GroupService {
 
         group.update(request.getTitle(), request.getDescription(), request.getIsPrivate(), request.getIsAutoApprove());
 
-        // 태그 전체 교체: 기존 태그 삭제 후 새로 저장
+        // 태그 전체 교체 (기존 태그 삭제 후 새로 저장)
         groupTagRepository.deleteAllByGroupId(groupId);
         List<String> tags = request.getTags();
         if (tags != null) {

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -1,6 +1,7 @@
 package net.diveon.backend.domain.group.service;
 
 import net.diveon.backend.domain.group.dto.GroupAddProblemsRequest;
+import net.diveon.backend.domain.group.dto.GroupUpdateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
@@ -124,6 +125,31 @@ public class GroupService {
                 )).toList();
 
         return new GroupListResponse(groupPage.getTotalElements(), groupPage.getTotalPages(), page, groups);
+    }
+
+    // 그룹 설정 수정
+    @Transactional
+    public void updateGroup(Long groupId, Long userId, GroupUpdateRequest request) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupAccessDeniedException::new);
+
+        if (groupUser.getRole() != GroupUser.GroupRole.LEADER) {
+            throw new GroupAccessDeniedException();
+        }
+
+        group.update(request.getTitle(), request.getDescription(), request.getIsPrivate(), request.getIsAutoApprove());
+
+        // 태그 전체 교체: 기존 태그 삭제 후 새로 저장
+        groupTagRepository.deleteAllByGroupId(groupId);
+        List<String> tags = request.getTags();
+        if (tags != null) {
+            for (String tag : tags) {
+                groupTagRepository.save(new GroupTag(group, tag));
+            }
+        }
     }
 
     // 그룹 삭제


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `PATCH /api/groups/{groupId}` 구현
- 그룹장 권한 필수, 미인증 시 401 / 권한 없음 시 403 반환
- 수정 가능 항목: 그룹 이름, 소개, 태그, 비공개 여부, 자동 승인 여부
- 태그는 전체 교체 방식 (기존 태그 삭제 후 새로 저장)

## 관련 이슈
Closes #185 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
