### PR TITLE
[feat] 그룹 기능 구현 (#172)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -2,6 +2,7 @@ package net.diveon.backend.domain.group.controller;
 
 import net.diveon.backend.domain.group.dto.GroupAssignDecisionRequest;
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
+import net.diveon.backend.domain.group.dto.GroupMemberListResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.dto.GroupPendingMemberListResponse;
 import net.diveon.backend.domain.group.service.GroupMemberService;
@@ -35,6 +36,17 @@ public class GroupMemberController {
             @AuthenticationPrincipal String userId) {
         GroupMemberCommonResponse response = groupMemberService.applyGroupMembership(groupId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("가입 신청이 완료되었습니다.", response));
+    }
+
+    // 그룹 멤버 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<GroupMemberListResponse>> getMembers(
+            @PathVariable Long groupId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String keyword) {
+        GroupMemberListResponse response = groupMemberService.getMembers(groupId, page, size, keyword);
+        return ResponseEntity.ok(ApiResponse.success("멤버 목록 조회 성공", response));
     }
 
     // 그룹 가입 대기자 목록 조회

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -1,6 +1,7 @@
 package net.diveon.backend.domain.group.controller;
 
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
+import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.service.GroupMemberService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -50,5 +51,19 @@ public class GroupMemberController {
             @AuthenticationPrincipal String userId) {
         GroupMemberCommonResponse response = groupMemberService.leaveGroup(groupId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("성공적으로 탈퇴(또는 신청 철회) 되었습니다.", response));
+    }
+
+    // 그룹 멤버 강제 퇴장
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<ApiResponse<GroupMemberKickResponse>> kickGroupMember(
+            @PathVariable Long groupId,
+            @PathVariable Long userId,
+            @AuthenticationPrincipal String requesterId) {
+        GroupMemberKickResponse response = groupMemberService.kickGroupMember(
+                groupId,
+                Long.parseLong(requesterId),
+                userId
+        );
+        return ResponseEntity.ok(ApiResponse.success("해당 멤버를 성공적으로 강퇴했습니다.", response));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -1,0 +1,31 @@
+package net.diveon.backend.domain.group.controller;
+
+import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
+import net.diveon.backend.domain.group.service.GroupMemberService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/groups/{groupId}/members")
+public class GroupMemberController {
+
+    private final GroupMemberService groupMemberService;
+
+    public GroupMemberController(GroupMemberService groupMemberService) {
+        this.groupMemberService = groupMemberService;
+    }
+
+    // 그룹 가입 신청
+    @PostMapping
+    public ResponseEntity<ApiResponse<GroupMemberCommonResponse>> applyGroupMembership(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId) {
+        GroupMemberCommonResponse response = groupMemberService.applyGroupMembership(groupId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("가입 신청이 완료되었습니다.", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -5,6 +5,7 @@ import net.diveon.backend.domain.group.service.GroupMemberService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +28,17 @@ public class GroupMemberController {
             @AuthenticationPrincipal String userId) {
         GroupMemberCommonResponse response = groupMemberService.applyGroupMembership(groupId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("가입 신청이 완료되었습니다.", response));
+    }
+
+    // 그룹 가입 신청 철회
+    @PatchMapping("/pending/me")
+    public ResponseEntity<ApiResponse<GroupMemberCommonResponse>> cancelPendingGroupMembership(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId) {
+        GroupMemberCommonResponse response = groupMemberService.cancelPendingGroupMembership(
+                groupId,
+                Long.parseLong(userId)
+        );
+        return ResponseEntity.ok(ApiResponse.success("성공적으로 철회 되었습니다.", response));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -5,6 +5,7 @@ import net.diveon.backend.domain.group.service.GroupMemberService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,5 +41,14 @@ public class GroupMemberController {
                 Long.parseLong(userId)
         );
         return ResponseEntity.ok(ApiResponse.success("성공적으로 철회 되었습니다.", response));
+    }
+
+    // 그룹 탈퇴
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<GroupMemberCommonResponse>> leaveGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId) {
+        GroupMemberCommonResponse response = groupMemberService.leaveGroup(groupId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("성공적으로 탈퇴(또는 신청 철회) 되었습니다.", response));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -81,6 +81,22 @@ public class GroupMemberController {
         return ResponseEntity.ok(ApiResponse.success("가입 요청이 승인되었습니다.", response));
     }
 
+    // 그룹 가입 신청 거절
+    @PatchMapping("/pending/{userId}/reject")
+    public ResponseEntity<ApiResponse<GroupMemberCommonResponse>> rejectPendingGroupMembership(
+            @PathVariable Long groupId,
+            @PathVariable Long userId,
+            @AuthenticationPrincipal String requesterId,
+            @RequestBody(required = false) GroupAssignDecisionRequest request) {
+        GroupMemberCommonResponse response = groupMemberService.rejectPendingGroupMembership(
+                groupId,
+                Long.parseLong(requesterId),
+                userId,
+                request
+        );
+        return ResponseEntity.ok(ApiResponse.success("가입 요청이 거절되었습니다.", response));
+    }
+
     // 그룹 탈퇴
     @DeleteMapping("/me")
     public ResponseEntity<ApiResponse<GroupMemberCommonResponse>> leaveGroup(

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -1,5 +1,6 @@
 package net.diveon.backend.domain.group.controller;
 
+import net.diveon.backend.domain.group.dto.GroupAssignDecisionRequest;
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.dto.GroupPendingMemberListResponse;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -61,6 +63,22 @@ public class GroupMemberController {
                 Long.parseLong(userId)
         );
         return ResponseEntity.ok(ApiResponse.success("성공적으로 철회 되었습니다.", response));
+    }
+
+    // 그룹 가입 신청 승인
+    @PatchMapping("/pending/{userId}/accept")
+    public ResponseEntity<ApiResponse<GroupMemberCommonResponse>> acceptPendingGroupMembership(
+            @PathVariable Long groupId,
+            @PathVariable Long userId,
+            @AuthenticationPrincipal String requesterId,
+            @RequestBody(required = false) GroupAssignDecisionRequest request) {
+        GroupMemberCommonResponse response = groupMemberService.acceptPendingGroupMembership(
+                groupId,
+                Long.parseLong(requesterId),
+                userId,
+                request
+        );
+        return ResponseEntity.ok(ApiResponse.success("가입 요청이 승인되었습니다.", response));
     }
 
     // 그룹 탈퇴

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupMemberController.java
@@ -2,14 +2,17 @@ package net.diveon.backend.domain.group.controller;
 
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
+import net.diveon.backend.domain.group.dto.GroupPendingMemberListResponse;
 import net.diveon.backend.domain.group.service.GroupMemberService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +33,22 @@ public class GroupMemberController {
             @AuthenticationPrincipal String userId) {
         GroupMemberCommonResponse response = groupMemberService.applyGroupMembership(groupId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("가입 신청이 완료되었습니다.", response));
+    }
+
+    // 그룹 가입 대기자 목록 조회
+    @GetMapping("/pending")
+    public ResponseEntity<ApiResponse<GroupPendingMemberListResponse>> getPendingMembers(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        GroupPendingMemberListResponse response = groupMemberService.getPendingMembers(
+                groupId,
+                Long.parseLong(userId),
+                page,
+                size
+        );
+        return ResponseEntity.ok(ApiResponse.success("가입 대기자 목록 조회 성공", response));
     }
 
     // 그룹 가입 신청 철회

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupAssignDecisionRequest.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupAssignDecisionRequest.java
@@ -1,0 +1,12 @@
+package net.diveon.backend.domain.group.dto;
+
+public class GroupAssignDecisionRequest {
+
+    private String decidedReason;
+
+    public GroupAssignDecisionRequest() {
+    }
+
+    public String getDecidedReason() { return decidedReason; }
+    public void setDecidedReason(String decidedReason) { this.decidedReason = decidedReason; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupMemberCommonResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupMemberCommonResponse.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.group.dto;
+
+public class GroupMemberCommonResponse {
+
+    private final Long userId;
+    private final String newStatus;
+
+    public GroupMemberCommonResponse(Long userId, String newStatus) {
+        this.userId = userId;
+        this.newStatus = newStatus;
+    }
+
+    public Long getUserId() { return userId; }
+    public String getNewStatus() { return newStatus; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupMemberKickResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupMemberKickResponse.java
@@ -1,0 +1,12 @@
+package net.diveon.backend.domain.group.dto;
+
+public class GroupMemberKickResponse {
+
+    private final Long kickedUserId;
+
+    public GroupMemberKickResponse(Long kickedUserId) {
+        this.kickedUserId = kickedUserId;
+    }
+
+    public Long getKickedUserId() { return kickedUserId; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupMemberListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupMemberListResponse.java
@@ -1,0 +1,43 @@
+package net.diveon.backend.domain.group.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GroupMemberListResponse {
+
+    private final long totalElements;
+    private final int totalPages;
+    private final int currentPage;
+    private final List<Member> members;
+
+    public GroupMemberListResponse(long totalElements, int totalPages, int currentPage, List<Member> members) {
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.currentPage = currentPage;
+        this.members = members;
+    }
+
+    public long getTotalElements() { return totalElements; }
+    public int getTotalPages() { return totalPages; }
+    public int getCurrentPage() { return currentPage; }
+    public List<Member> getMembers() { return members; }
+
+    public static class Member {
+        private final Long userId;
+        private final String nickname;
+        private final String role;
+        private final LocalDateTime joinedAt;
+
+        public Member(Long userId, String nickname, String role, LocalDateTime joinedAt) {
+            this.userId = userId;
+            this.nickname = nickname;
+            this.role = role;
+            this.joinedAt = joinedAt;
+        }
+
+        public Long getUserId() { return userId; }
+        public String getNickname() { return nickname; }
+        public String getRole() { return role; }
+        public LocalDateTime getJoinedAt() { return joinedAt; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupPendingMemberListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupPendingMemberListResponse.java
@@ -1,0 +1,41 @@
+package net.diveon.backend.domain.group.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GroupPendingMemberListResponse {
+
+    private final long totalElements;
+    private final int totalPages;
+    private final int currentPage;
+    private final List<PendingMember> pendingMembers;
+
+    public GroupPendingMemberListResponse(long totalElements, int totalPages, int currentPage,
+                                          List<PendingMember> pendingMembers) {
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.currentPage = currentPage;
+        this.pendingMembers = pendingMembers;
+    }
+
+    public long getTotalElements() { return totalElements; }
+    public int getTotalPages() { return totalPages; }
+    public int getCurrentPage() { return currentPage; }
+    public List<PendingMember> getPendingMembers() { return pendingMembers; }
+
+    public static class PendingMember {
+        private final Long userId;
+        private final String nickname;
+        private final LocalDateTime appliedAt;
+
+        public PendingMember(Long userId, String nickname, LocalDateTime appliedAt) {
+            this.userId = userId;
+            this.nickname = nickname;
+            this.appliedAt = appliedAt;
+        }
+
+        public Long getUserId() { return userId; }
+        public String getNickname() { return nickname; }
+        public LocalDateTime getAppliedAt() { return appliedAt; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/entity/GroupAssignRequest.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/GroupAssignRequest.java
@@ -79,6 +79,13 @@ public class GroupAssignRequest {
         this.decidedReason = decidedReason;
     }
 
+    public void reject(User decidedBy, String decidedReason) {
+        this.status = AssignRequestStatus.REJECTED;
+        this.decidedAt = LocalDateTime.now();
+        this.decidedBy = decidedBy;
+        this.decidedReason = decidedReason;
+    }
+
     public void cancel(String decidedReason) {
         this.status = AssignRequestStatus.CANCELED;
         this.decidedAt = LocalDateTime.now();

--- a/src/main/java/net/diveon/backend/domain/group/entity/GroupAssignRequest.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/GroupAssignRequest.java
@@ -72,6 +72,13 @@ public class GroupAssignRequest {
         this.appliedAt = LocalDateTime.now();
     }
 
+    public void approve(User decidedBy, String decidedReason) {
+        this.status = AssignRequestStatus.APPROVED;
+        this.decidedAt = LocalDateTime.now();
+        this.decidedBy = decidedBy;
+        this.decidedReason = decidedReason;
+    }
+
     public Long getId() { return id; }
     public Group getGroup() { return group; }
     public User getUser() { return user; }

--- a/src/main/java/net/diveon/backend/domain/group/entity/GroupAssignRequest.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/GroupAssignRequest.java
@@ -79,6 +79,14 @@ public class GroupAssignRequest {
         this.decidedReason = decidedReason;
     }
 
+    public void cancel(String decidedReason) {
+        this.status = AssignRequestStatus.CANCELED;
+        this.decidedAt = LocalDateTime.now();
+        // TODO: decidedBy = null 정책은 차후 수정이 필요합니다.
+        this.decidedBy = null;
+        this.decidedReason = decidedReason;
+    }
+
     public Long getId() { return id; }
     public Group getGroup() { return group; }
     public User getUser() { return user; }

--- a/src/main/java/net/diveon/backend/domain/group/entity/README.md
+++ b/src/main/java/net/diveon/backend/domain/group/entity/README.md
@@ -1,4 +1,4 @@
-### domain_group
+## domain_group
 
 | 컬럼명 | 타입 | 제약조건 | 컬럼설명 |
 | --- | --- | --- | --- |
@@ -12,14 +12,14 @@ DEFAULT CURRENT_TIMESTAMP | 그룹 생성 시점 |
 | limit_member_count | SMALL INT | NOT NULL,
 DEFAULT 50 | 최대 수용 그룹원 수 |
 | image | TEXT |  | 그룹 공식 이미지 경로 |
-| title | VARCHAR(100) | NOT NULL | 그룹의 이름 |
+| title | VARCHAR(100) | NOT NULL | 그룸의 이름 |
 | description | TEXT | NOT NULL | 그룹 설명 |
 | is_private | BOOLEAN | NOT NULL, 
 DEFAULT FALSE | 그룹 공개 여부 |
 | is_auto_approve | BOOLEAN | NOT NULL, 
 DEFAULT FALSE | 가입신청 자동 승인 여부 |
 | invitation_code | VARCHAR(50) | UNIQUE | 초대코드 |
-    
+
 
 ### group_tag
 
@@ -32,7 +32,7 @@ ON DELETE CASCADE |  |
 | tag | VARCHAR(50) | NOT NULL |  |
 | UNIQUE(group_id, tag) |  |  |  |
 
-### group_problem
+#### group_problem
 
 | 컬럼명 | 타입 | 제약조건 | 컬럼설명 |
 | --- | --- | --- | --- |

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
@@ -1,9 +1,16 @@
 package net.diveon.backend.domain.group.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.diveon.backend.domain.group.entity.GroupAssignRequest;
 
 public interface GroupAssignRequestRepository extends JpaRepository<GroupAssignRequest, Long> {
     boolean existsByGroupIdAndUserIdAndStatus(Long groupId, Long userId, GroupAssignRequest.AssignRequestStatus status);
+
+    // groupId와 userId를 함께 이용해 해당 유저가 해당 그룹에 남긴 가입 신청 기록 중 최신 1건을 조회한다.
+    // 과거 CANCELED/REJECTED 이력이 있을 수 있으므로 appliedAt desc, id desc 기준으로 가장 최근 기록을 선택한다.
+    // TODO: 동일 유저/그룹의 재신청 정책과 최신 신청 판별 기준에 대한 DB 관리 정책 변경이 필요하다.
+    Optional<GroupAssignRequest> findFirstByGroupIdAndUserIdOrderByAppliedAtDescIdDesc(Long groupId, Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
@@ -16,6 +16,12 @@ public interface GroupAssignRequestRepository extends JpaRepository<GroupAssignR
     // TODO: 동일 유저/그룹의 재신청 정책과 최신 신청 판별 기준에 대한 DB 관리 정책 변경이 필요하다.
     Optional<GroupAssignRequest> findFirstByGroupIdAndUserIdOrderByAppliedAtDescIdDesc(Long groupId, Long userId);
 
+    Optional<GroupAssignRequest> findByGroupIdAndUserIdAndStatus(
+            Long groupId,
+            Long userId,
+            GroupAssignRequest.AssignRequestStatus status
+    );
+
     Page<GroupAssignRequest> findByGroupIdAndStatus(
             Long groupId,
             GroupAssignRequest.AssignRequestStatus status,

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupAssignRequestRepository.java
@@ -2,6 +2,8 @@ package net.diveon.backend.domain.group.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.diveon.backend.domain.group.entity.GroupAssignRequest;
@@ -13,4 +15,10 @@ public interface GroupAssignRequestRepository extends JpaRepository<GroupAssignR
     // 과거 CANCELED/REJECTED 이력이 있을 수 있으므로 appliedAt desc, id desc 기준으로 가장 최근 기록을 선택한다.
     // TODO: 동일 유저/그룹의 재신청 정책과 최신 신청 판별 기준에 대한 DB 관리 정책 변경이 필요하다.
     Optional<GroupAssignRequest> findFirstByGroupIdAndUserIdOrderByAppliedAtDescIdDesc(Long groupId, Long userId);
+
+    Page<GroupAssignRequest> findByGroupIdAndStatus(
+            Long groupId,
+            GroupAssignRequest.AssignRequestStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
@@ -1,8 +1,17 @@
 package net.diveon.backend.domain.group.repository;
 
+import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import net.diveon.backend.domain.group.entity.Group;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select g from Group g where g.id = :groupId")
+    Optional<Group> findByIdForUpdate(@Param("groupId") Long groupId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
@@ -2,11 +2,32 @@ package net.diveon.backend.domain.group.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import net.diveon.backend.domain.group.entity.GroupUser;
 
 public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
     long countByGroupId(Long groupId);
     Optional<GroupUser> findByGroupIdAndUserId(Long groupId, Long userId);
+
+    @Query("""
+            select gu
+            from GroupUser gu
+            join gu.user u
+            where gu.group.id = :groupId
+              and (:keyword is null or :keyword = '' or lower(u.nickname) like lower(concat('%', :keyword, '%')))
+            order by
+              case when gu.role = net.diveon.backend.domain.group.entity.GroupUser$GroupRole.LEADER then 0 else 1 end,
+              gu.joinedAt asc,
+              gu.id asc
+            """)
+    Page<GroupUser> findMembersByGroupIdAndKeyword(
+            @Param("groupId") Long groupId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -1,9 +1,11 @@
 package net.diveon.backend.domain.group.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
+import net.diveon.backend.domain.group.dto.GroupPendingMemberListResponse;
 import net.diveon.backend.domain.group.entity.Group;
 import net.diveon.backend.domain.group.entity.GroupAssignRequest;
 import net.diveon.backend.domain.group.entity.GroupAssignRequest.AssignRequestStatus;
@@ -20,6 +22,9 @@ import net.diveon.backend.global.exception.GroupLeaderPermissionDeniedException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.GroupUserNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -141,6 +146,48 @@ public class GroupMemberService {
 
         groupUserRepository.delete(targetGroupUser);
         return new GroupMemberKickResponse(targetUserId);
+    }
+
+    // 그룹 가입 대기자 목록 조회
+    @Transactional(readOnly = true)
+    public GroupPendingMemberListResponse getPendingMembers(Long groupId, Long requesterId, int page, int size) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        userRepository.findById(requesterId)
+                .orElseThrow(UserNotFoundException::new);
+
+        GroupUser requesterGroupUser = groupUserRepository.findByGroupIdAndUserId(groupId, requesterId)
+                .orElseThrow(GroupLeaderPermissionDeniedException::new);
+        validateGroupLeader(group, requesterId, requesterGroupUser);
+
+        int currentPage = Math.max(page, 1);
+        int pageSize = Math.max(size, 1);
+        PageRequest pageRequest = PageRequest.of(
+                currentPage - 1,
+                pageSize,
+                Sort.by(Sort.Order.asc("appliedAt"), Sort.Order.asc("id"))
+        );
+        Page<GroupAssignRequest> pendingRequestPage = groupAssignRequestRepository.findByGroupIdAndStatus(
+                groupId,
+                AssignRequestStatus.PENDING,
+                pageRequest
+        );
+
+        List<GroupPendingMemberListResponse.PendingMember> pendingMembers = pendingRequestPage.getContent()
+                .stream()
+                .map(assignRequest -> new GroupPendingMemberListResponse.PendingMember(
+                        assignRequest.getUser().getId(),
+                        assignRequest.getUser().getNickname(),
+                        assignRequest.getAppliedAt()
+                ))
+                .toList();
+
+        return new GroupPendingMemberListResponse(
+                pendingRequestPage.getTotalElements(),
+                pendingRequestPage.getTotalPages(),
+                currentPage,
+                pendingMembers
+        );
     }
 
     private void validateGroupLeader(Group group, Long requesterId, GroupUser requesterGroupUser) {

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -3,6 +3,7 @@ package net.diveon.backend.domain.group.service;
 import java.util.List;
 import java.util.Optional;
 
+import net.diveon.backend.domain.group.dto.GroupAssignDecisionRequest;
 import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
 import net.diveon.backend.domain.group.dto.GroupPendingMemberListResponse;
@@ -148,6 +149,36 @@ public class GroupMemberService {
         return new GroupMemberKickResponse(targetUserId);
     }
 
+    // 그룹 가입 신청 승인
+    @Transactional
+    public GroupMemberCommonResponse acceptPendingGroupMembership(Long groupId, Long requesterId, Long targetUserId,
+                                                                  GroupAssignDecisionRequest request) {
+        Group group = groupRepository.findByIdForUpdate(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(UserNotFoundException::new);
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        GroupUser requesterGroupUser = groupUserRepository.findByGroupIdAndUserId(groupId, requesterId)
+                .orElseThrow(GroupLeaderPermissionDeniedException::new);
+        validateGroupLeader(group, requesterId, requesterGroupUser);
+
+        GroupAssignRequest assignRequest = groupAssignRequestRepository
+                .findByGroupIdAndUserIdAndStatus(groupId, targetUserId, AssignRequestStatus.PENDING)
+                .orElseThrow(GroupAssignRequestNotPendingException::new);
+
+        Optional<GroupUser> existingMember = groupUserRepository.findByGroupIdAndUserId(groupId, targetUserId);
+        if (existingMember.isPresent()) {
+            return new GroupMemberCommonResponse(targetUserId, "member");
+        }
+
+        validateGroupCapacity(groupId, group);
+        assignRequest.approve(requester, resolveDecisionReason(request));
+        groupUserRepository.save(new GroupUser(group, targetUser, GroupRole.MEMBER));
+        return new GroupMemberCommonResponse(targetUserId, "member");
+    }
+
     // 그룹 가입 대기자 목록 조회
     @Transactional(readOnly = true)
     public GroupPendingMemberListResponse getPendingMembers(Long groupId, Long requesterId, int page, int size) {
@@ -203,5 +234,12 @@ public class GroupMemberService {
         if (memberCount >= group.getLimitMemberCount()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "그룹 최대 인원수를 초과할 수 없습니다.");
         }
+    }
+
+    private String resolveDecisionReason(GroupAssignDecisionRequest request) {
+        if (request == null || request.getDecidedReason() == null || request.getDecidedReason().isBlank()) {
+            return "No Reason";
+        }
+        return request.getDecidedReason();
     }
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -179,6 +179,29 @@ public class GroupMemberService {
         return new GroupMemberCommonResponse(targetUserId, "member");
     }
 
+    // 그룹 가입 신청 거절
+    @Transactional
+    public GroupMemberCommonResponse rejectPendingGroupMembership(Long groupId, Long requesterId, Long targetUserId,
+                                                                  GroupAssignDecisionRequest request) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(UserNotFoundException::new);
+        userRepository.findById(targetUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        GroupUser requesterGroupUser = groupUserRepository.findByGroupIdAndUserId(groupId, requesterId)
+                .orElseThrow(GroupLeaderPermissionDeniedException::new);
+        validateGroupLeader(group, requesterId, requesterGroupUser);
+
+        GroupAssignRequest assignRequest = groupAssignRequestRepository
+                .findByGroupIdAndUserIdAndStatus(groupId, targetUserId, AssignRequestStatus.PENDING)
+                .orElseThrow(GroupAssignRequestNotPendingException::new);
+
+        assignRequest.reject(requester, resolveDecisionReason(request));
+        return new GroupMemberCommonResponse(targetUserId, "rejected");
+    }
+
     // 그룹 가입 대기자 목록 조회
     @Transactional(readOnly = true)
     public GroupPendingMemberListResponse getPendingMembers(Long groupId, Long requesterId, int page, int size) {

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -107,6 +107,7 @@ public class GroupMemberService {
         GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
                 .orElseThrow(GroupUserNotFoundException::new);
         //양도 만약에 생각하면 이게 더 좋은 검사인듯? 바꿀수는 있습니다 userId랑 그룹장 leaderId 검사하게
+        // 커밋용 추가
         if (groupUser.getRole() == GroupRole.LEADER) {
             throw new GroupLeaderCannotLeaveException();
         }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -2,6 +2,7 @@ package net.diveon.backend.domain.group.service;
 
 import java.util.Optional;
 
+import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
 import net.diveon.backend.domain.group.entity.Group;
 import net.diveon.backend.domain.group.entity.GroupAssignRequest;
@@ -15,6 +16,7 @@ import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.GroupAssignRequestNotPendingException;
 import net.diveon.backend.global.exception.GroupLeaderCannotLeaveException;
+import net.diveon.backend.global.exception.GroupLeaderPermissionDeniedException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.GroupUserNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
@@ -114,6 +116,39 @@ public class GroupMemberService {
 
         groupUserRepository.delete(groupUser);
         return new GroupMemberCommonResponse(userId, "none");
+    }
+
+    // 그룹 멤버 강제 퇴장
+    @Transactional
+    public GroupMemberKickResponse kickGroupMember(Long groupId, Long requesterId, Long targetUserId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        userRepository.findById(requesterId)
+                .orElseThrow(UserNotFoundException::new);
+        userRepository.findById(targetUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        GroupUser requesterGroupUser = groupUserRepository.findByGroupIdAndUserId(groupId, requesterId)
+                .orElseThrow(GroupLeaderPermissionDeniedException::new);
+        validateGroupLeader(group, requesterId, requesterGroupUser);
+
+        GroupUser targetGroupUser = groupUserRepository.findByGroupIdAndUserId(groupId, targetUserId)
+                .orElseThrow(GroupUserNotFoundException::new);
+
+        if (targetGroupUser.getRole() == GroupRole.LEADER) {
+            throw new GroupLeaderCannotLeaveException();
+        }
+
+        groupUserRepository.delete(targetGroupUser);
+        return new GroupMemberKickResponse(targetUserId);
+    }
+
+    private void validateGroupLeader(Group group, Long requesterId, GroupUser requesterGroupUser) {
+        boolean isGroupLeaderId = group.getLeader().getId().equals(requesterId);
+        boolean isLeaderRole = requesterGroupUser.getRole() == GroupRole.LEADER;
+        if (!isGroupLeaderId || !isLeaderRole) {
+            throw new GroupLeaderPermissionDeniedException();
+        }
     }
 
     private void validateGroupCapacity(Long groupId, Group group) {

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -13,6 +13,7 @@ import net.diveon.backend.domain.group.repository.GroupRepository;
 import net.diveon.backend.domain.group.repository.GroupUserRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.GroupAssignRequestNotPendingException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -71,6 +72,26 @@ public class GroupMemberService {
         }
 
         return new GroupMemberCommonResponse(userId, "pending");
+    }
+
+    // 그룹 가입 신청 철회
+    @Transactional
+    public GroupMemberCommonResponse cancelPendingGroupMembership(Long groupId, Long userId) {
+        groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        GroupAssignRequest assignRequest = groupAssignRequestRepository
+                .findFirstByGroupIdAndUserIdOrderByAppliedAtDescIdDesc(groupId, userId)
+                .orElseThrow(GroupAssignRequestNotPendingException::new);
+
+        if (assignRequest.getStatus() != AssignRequestStatus.PENDING) {
+            throw new GroupAssignRequestNotPendingException();
+        }
+
+        assignRequest.cancel("canceled by applicant");
+        return new GroupMemberCommonResponse(userId, "CANCELED");
     }
 
     private void validateGroupCapacity(Long groupId, Group group) {

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import net.diveon.backend.domain.group.dto.GroupAssignDecisionRequest;
+import net.diveon.backend.domain.group.dto.GroupMemberListResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
 import net.diveon.backend.domain.group.dto.GroupPendingMemberListResponse;
@@ -149,6 +150,39 @@ public class GroupMemberService {
         return new GroupMemberKickResponse(targetUserId);
     }
 
+    // 그룹 멤버 목록 조회
+    @Transactional(readOnly = true)
+    public GroupMemberListResponse getMembers(Long groupId, int page, int size, String keyword) {
+        groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        int currentPage = Math.max(page, 1);
+        int pageSize = Math.max(size, 1);
+        PageRequest pageRequest = PageRequest.of(currentPage - 1, pageSize);
+        Page<GroupUser> groupUserPage = groupUserRepository.findMembersByGroupIdAndKeyword(
+                groupId,
+                keyword,
+                pageRequest
+        );
+
+        List<GroupMemberListResponse.Member> members = groupUserPage.getContent()
+                .stream()
+                .map(groupUser -> new GroupMemberListResponse.Member(
+                        groupUser.getUser().getId(),
+                        groupUser.getUser().getNickname(),
+                        convertGroupRole(groupUser.getRole()),
+                        groupUser.getJoinedAt()
+                ))
+                .toList();
+
+        return new GroupMemberListResponse(
+                groupUserPage.getTotalElements(),
+                groupUserPage.getTotalPages(),
+                currentPage,
+                members
+        );
+    }
+
     // 그룹 가입 신청 승인
     @Transactional
     public GroupMemberCommonResponse acceptPendingGroupMembership(Long groupId, Long requesterId, Long targetUserId,
@@ -257,6 +291,13 @@ public class GroupMemberService {
         if (memberCount >= group.getLimitMemberCount()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "그룹 최대 인원수를 초과할 수 없습니다.");
         }
+    }
+
+    private String convertGroupRole(GroupRole role) {
+        if (role == GroupRole.LEADER) {
+            return "그룹장";
+        }
+        return "멤버";
     }
 
     private String resolveDecisionReason(GroupAssignDecisionRequest request) {

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -1,0 +1,82 @@
+package net.diveon.backend.domain.group.service;
+
+import java.util.Optional;
+
+import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
+import net.diveon.backend.domain.group.entity.Group;
+import net.diveon.backend.domain.group.entity.GroupAssignRequest;
+import net.diveon.backend.domain.group.entity.GroupAssignRequest.AssignRequestStatus;
+import net.diveon.backend.domain.group.entity.GroupUser;
+import net.diveon.backend.domain.group.entity.GroupUser.GroupRole;
+import net.diveon.backend.domain.group.repository.GroupAssignRequestRepository;
+import net.diveon.backend.domain.group.repository.GroupRepository;
+import net.diveon.backend.domain.group.repository.GroupUserRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.GroupNotFoundException;
+import net.diveon.backend.global.exception.UserNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class GroupMemberService {
+
+    private final GroupRepository groupRepository;
+    private final GroupUserRepository groupUserRepository;
+    private final GroupAssignRequestRepository groupAssignRequestRepository;
+    private final UserRepository userRepository;
+
+    public GroupMemberService(GroupRepository groupRepository,
+                              GroupUserRepository groupUserRepository,
+                              GroupAssignRequestRepository groupAssignRequestRepository,
+                              UserRepository userRepository) {
+        this.groupRepository = groupRepository;
+        this.groupUserRepository = groupUserRepository;
+        this.groupAssignRequestRepository = groupAssignRequestRepository;
+        this.userRepository = userRepository;
+    }
+
+    // 그룹 가입 신청
+    @Transactional
+    public GroupMemberCommonResponse applyGroupMembership(Long groupId, Long userId) {
+        Group group = groupRepository.findByIdForUpdate(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Optional<GroupUser> existingMember = groupUserRepository.findByGroupIdAndUserId(groupId, userId);
+        if (existingMember.isPresent()) {
+            return new GroupMemberCommonResponse(userId, "member");
+        }
+
+        boolean hasPendingRequest = groupAssignRequestRepository.existsByGroupIdAndUserIdAndStatus(
+                groupId,
+                userId,
+                AssignRequestStatus.PENDING
+        );
+        if (hasPendingRequest) {
+            return new GroupMemberCommonResponse(userId, "pending");
+        }
+
+        GroupAssignRequest assignRequest = new GroupAssignRequest(group, user);
+        groupAssignRequestRepository.save(assignRequest);
+
+        if (Boolean.TRUE.equals(group.getIsAutoApprove())) {
+            validateGroupCapacity(groupId, group);
+            assignRequest.approve(group.getLeader(), "auto approved");
+            groupUserRepository.save(new GroupUser(group, user, GroupRole.MEMBER));
+            return new GroupMemberCommonResponse(userId, "APPROVED");
+        }
+
+        return new GroupMemberCommonResponse(userId, "pending");
+    }
+
+    private void validateGroupCapacity(Long groupId, Group group) {
+        long memberCount = groupUserRepository.countByGroupId(groupId);
+        if (memberCount >= group.getLimitMemberCount()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "그룹 최대 인원수를 초과할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -14,6 +14,7 @@ import net.diveon.backend.domain.group.repository.GroupUserRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.GroupAssignRequestNotPendingException;
+import net.diveon.backend.global.exception.GroupLeaderCannotLeaveException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.GroupUserNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
@@ -105,6 +106,10 @@ public class GroupMemberService {
 
         GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
                 .orElseThrow(GroupUserNotFoundException::new);
+        //양도 만약에 생각하면 이게 더 좋은 검사인듯? 바꿀수는 있습니다 userId랑 그룹장 leaderId 검사하게
+        if (groupUser.getRole() == GroupRole.LEADER) {
+            throw new GroupLeaderCannotLeaveException();
+        }
 
         groupUserRepository.delete(groupUser);
         return new GroupMemberCommonResponse(userId, "none");

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -15,6 +15,7 @@ import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.GroupAssignRequestNotPendingException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
+import net.diveon.backend.global.exception.GroupUserNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -92,6 +93,21 @@ public class GroupMemberService {
 
         assignRequest.cancel("canceled by applicant");
         return new GroupMemberCommonResponse(userId, "CANCELED");
+    }
+
+    // 그룹 탈퇴
+    @Transactional
+    public GroupMemberCommonResponse leaveGroup(Long groupId, Long userId) {
+        groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupUserNotFoundException::new);
+
+        groupUserRepository.delete(groupUser);
+        return new GroupMemberCommonResponse(userId, "none");
     }
 
     private void validateGroupCapacity(Long groupId, Group group) {

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -76,7 +76,6 @@ public class GroupService {
         return new GroupCreateResponse(group.getId());
     }
 
-
     // 그룹 상세 조회
     @Transactional(readOnly = true)
     public GroupDetailResponse getGroupDetail(Long groupId, Long userId) {

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -223,6 +223,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // 가입 신청 철회 불가 → 409
+        @ExceptionHandler(GroupAssignRequestNotPendingException.class)
+        public ResponseEntity<ErrorResponse> handleGroupAssignRequestNotPending(
+                GroupAssignRequestNotPendingException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/conflict/group-assign-request-not-pending",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
+
         // 채점 미완료 → 409
         @ExceptionHandler(SubmissionNotCompletedException.class)
         public ResponseEntity<ErrorResponse> handleSubmissionNotCompleted(

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -237,6 +237,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // 그룹장 탈퇴 불가 → 403
+        @ExceptionHandler(GroupLeaderCannotLeaveException.class)
+        public ResponseEntity<ErrorResponse> handleGroupLeaderCannotLeave(
+                GroupLeaderCannotLeaveException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/group-leader-cannot-leave",
+                        "Forbidden",
+                        403,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+        }
+
         // 가입 신청 철회 불가 → 409
         @ExceptionHandler(GroupAssignRequestNotPendingException.class)
         public ResponseEntity<ErrorResponse> handleGroupAssignRequestNotPending(

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -223,6 +223,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // 그룹 유저 없음 → 404
+        @ExceptionHandler(GroupUserNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleGroupUserNotFound(
+                GroupUserNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/group-user-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
         // 가입 신청 철회 불가 → 409
         @ExceptionHandler(GroupAssignRequestNotPendingException.class)
         public ResponseEntity<ErrorResponse> handleGroupAssignRequestNotPending(

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -251,6 +251,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
         }
 
+        // 그룹장 권한 없음 → 403
+        @ExceptionHandler(GroupLeaderPermissionDeniedException.class)
+        public ResponseEntity<ErrorResponse> handleGroupLeaderPermissionDenied(
+                GroupLeaderPermissionDeniedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/group-leader-permission-denied",
+                        "Forbidden",
+                        403,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+        }
+
         // 가입 신청 철회 불가 → 409
         @ExceptionHandler(GroupAssignRequestNotPendingException.class)
         public ResponseEntity<ErrorResponse> handleGroupAssignRequestNotPending(

--- a/src/main/java/net/diveon/backend/global/exception/GroupAssignRequestNotPendingException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GroupAssignRequestNotPendingException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class GroupAssignRequestNotPendingException extends RuntimeException {
+
+    public GroupAssignRequestNotPendingException() {
+        super("Only pending group assign request can be canceled");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GroupLeaderCannotLeaveException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GroupLeaderCannotLeaveException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class GroupLeaderCannotLeaveException extends RuntimeException {
+
+    public GroupLeaderCannotLeaveException() {
+        super("그룹장은 탈퇴가 불가능합니다");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GroupLeaderPermissionDeniedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GroupLeaderPermissionDeniedException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class GroupLeaderPermissionDeniedException extends RuntimeException {
+
+    public GroupLeaderPermissionDeniedException() {
+        super("해당 그룹의 그룹장 권한이 없습니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GroupUserNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GroupUserNotFoundException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class GroupUserNotFoundException extends RuntimeException {
+
+    public GroupUserNotFoundException() {
+        super("존재하지 않는 그룹 유저입니다.");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 그룹 맴버 기능과 관련된 8가지 기능 구현
- 기능은 아래와 같음
1. 그룹 가입 신청
2. 그룹 가입 신청 철회
3. 그룹 탈퇴
4. 그룹 맴버 조회
5. 그룹 맴버 강퇴
6. 그룹 맴버 대기자 조회
7. 그룹 맴버 가입 승인
8. 그룹 맴버 가입 거절

### 작업자의 지능 이슈로 인해서
브랜치를 만들어 작업후, 그 브랜치에서 기능별로 브랜치를 새로 만들어가면서 작업을 했다는 문제로 인해서, 최종적으로 커밋후 완성된 마지막 커밋을 기반으로 PR 요청


## 관련 이슈
Closes (#173) (#174) (#175) (#176) (#177) (#178) (#179) (#180)
가장 마지막 커밋은 (#176) 이니 참고할 것.

<!-- 주석은 제외되고 올라가니 무시하세요 -->
