### PR TITLE
[fix] 그룹 태그 교체 시 unique 제약 위반 오류 수정 (#194)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupTagRepository.java
@@ -3,11 +3,17 @@ package net.diveon.backend.domain.group.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import net.diveon.backend.domain.group.entity.GroupTag;
 
 public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
     List<GroupTag> findAllByGroupId(Long groupId);
     List<GroupTag> findAllByGroupIdIn(List<Long> groupIds);
-    void deleteAllByGroupId(Long groupId);
+
+    @Modifying
+    @Query("DELETE FROM GroupTag gt WHERE gt.group.id = :groupId")
+    void deleteAllByGroupId(@Param("groupId") Long groupId);
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 그룹 설정 수정 시 태그 전체 교체 과정에서 unique 제약 위반 오류 수정
- `deleteAllByGroupId`에 `@Modifying` + `@Query` 적용하여 DELETE 쿼리 즉시 실행되도록 변경

## 관련 이슈
Closes #194 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
