### PR TITLE
[fix] 게시글 조회에 게시일 및 공지 여부 추가(#196)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupPostController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupPostController.java
@@ -45,11 +45,11 @@ public class GroupPostController {
 
     // 게시글 상세 조회
     @GetMapping("/{groupId}/posts/{postId}")
-    public ResponseEntity<ApiResponse<GroupPostResponse.PostListItem>> getPostDetail(
+    public ResponseEntity<ApiResponse<GroupPostResponse.PostDetailItem>> getPostDetail(
             @PathVariable Long groupId,
             @PathVariable Long postId,
             @AuthenticationPrincipal String userId) {
-        GroupPostResponse.PostListItem response = groupPostService.getPostDetail(groupId, postId, Long.parseLong(userId));
+        GroupPostResponse.PostDetailItem response = groupPostService.getPostDetail(groupId, postId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("게시글 상세 조회 성공", response));
     }
 

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupPostResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupPostResponse.java
@@ -32,15 +32,47 @@ public class GroupPostResponse {
         public int getCurrentPage() { return currentPage; }
         public List<PostListItem> getPosts() { return posts; }
 
-        public static PostList of(Page<GroupPost> page, Long userId, Map<Long, List<GroupPostComment>> commentsMap) {
+        public static PostList of(Page<GroupPost> page) {
             List<PostListItem> posts = page.getContent().stream()
-                    .map(p -> PostListItem.of(p, userId, commentsMap.getOrDefault(p.getId(), List.of())))
+                    .map(PostListItem::of)
                     .collect(Collectors.toList());
             return new PostList(page.getTotalElements(), page.getTotalPages(), page.getNumber() + 1, posts);
         }
     }
 
     public static class PostListItem {
+        private final Long postId;
+        private final String type;
+        private final String title;
+        private final String author;
+        private final Integer viewCount;
+        private final String createdAt;
+
+        public PostListItem(Long postId, String type, String title, String author, Integer viewCount, String createdAt) {
+            this.postId = postId;
+            this.type = type;
+            this.title = title;
+            this.author = author;
+            this.viewCount = viewCount;
+            this.createdAt = createdAt;
+        }
+
+        public Long getPostId() { return postId; }
+        public String getType() { return type; }
+        public String getTitle() { return title; }
+        public String getAuthor() { return author; }
+        public Integer getViewCount() { return viewCount; }
+        public String getCreatedAt() { return createdAt; }
+
+        public static PostListItem of(GroupPost post) {
+            String type = post.getIsNotice() ? "notice" : "general";
+            String createdAtStr = post.getCreatedAt().format(DATE_FORMATTER);
+            return new PostListItem(post.getId(), type, post.getTitle(),
+                    post.getAuthor().getNickname(), post.getViewCount(), createdAtStr);
+        }
+    }
+
+    public static class PostDetailItem {
         private final Long postId;
         private final String type;
         private final String title;
@@ -51,8 +83,8 @@ public class GroupPostResponse {
         private final boolean isAuthor;
         private final List<CommentItem> comments;
 
-        public PostListItem(Long postId, String type, String title, String content, String author,
-                           String createdAt, boolean isAuthor, List<CommentItem> comments) {
+        public PostDetailItem(Long postId, String type, String title, String content, String author,
+                             String createdAt, boolean isAuthor, List<CommentItem> comments) {
             this.postId = postId;
             this.type = type;
             this.title = title;
@@ -72,14 +104,14 @@ public class GroupPostResponse {
         public boolean getIsAuthor() { return isAuthor; }
         public List<CommentItem> getComments() { return comments; }
 
-        public static PostListItem of(GroupPost post, Long userId, List<GroupPostComment> comments) {
+        public static PostDetailItem of(GroupPost post, Long userId, List<GroupPostComment> comments) {
             String type = post.getIsNotice() ? "notice" : "general";
             boolean isAuthor = post.getAuthor().getId().equals(userId);
             String createdAtStr = post.getCreatedAt().format(DATE_FORMATTER);
             List<CommentItem> commentItems = comments.stream()
                     .map(c -> CommentItem.of(c, userId))
                     .collect(Collectors.toList());
-            return new PostListItem(post.getId(), type, post.getTitle(), post.getContent(),
+            return new PostDetailItem(post.getId(), type, post.getTitle(), post.getContent(),
                     post.getAuthor().getNickname(), createdAtStr, isAuthor, commentItems);
         }
     }

--- a/src/main/java/net/diveon/backend/domain/group/entity/GroupPost.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/GroupPost.java
@@ -84,4 +84,8 @@ public class GroupPost {
         if (isNotice != null) this.isNotice = isNotice;
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupPostService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupPostService.java
@@ -24,9 +24,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class GroupPostService {
@@ -56,25 +54,21 @@ public class GroupPostService {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         Page<GroupPost> posts = groupPostRepository.findByGroup_Id(groupId, pageable);
 
-        Map<Long, List<GroupPostComment>> commentsMap = new HashMap<>();
-        for (GroupPost post : posts) {
-            List<GroupPostComment> comments = groupPostCommentRepository.findAllByPost_Id(post.getId());
-            commentsMap.put(post.getId(), comments);
-        }
-
-        return GroupPostResponse.PostList.of(posts, userId, commentsMap);
+        return GroupPostResponse.PostList.of(posts);
     }
 
-    @Transactional(readOnly = true)
-    public GroupPostResponse.PostListItem getPostDetail(Long groupId, Long postId, Long userId) {
+    @Transactional
+    public GroupPostResponse.PostDetailItem getPostDetail(Long groupId, Long postId, Long userId) {
         groupUserRepository.findByGroupIdAndUserId(groupId, userId)
                 .orElseThrow(GroupAccessDeniedException::new);
 
         GroupPost post = groupPostRepository.findById(postId)
                 .orElseThrow(GroupPostNotFoundException::new);
 
+        post.incrementViewCount();
+
         List<GroupPostComment> comments = groupPostCommentRepository.findAllByPost_Id(postId);
-        return GroupPostResponse.PostListItem.of(post, userId, comments);
+        return GroupPostResponse.PostDetailItem.of(post, userId, comments);
     }
 
     @Transactional


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 게시글 간단 조회에 게시일 및 공지 여부 추가



<!-- 주석은 제외되고 올라가니 무시하세요 -->
