### PR TITLE
[fix] 객관식 문제 생성 & 수정 로직 보강 (#103)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
@@ -95,7 +95,7 @@ public class ProblemCreateService {
         // 아 그리고 지금 구조가 request.getObo().getSteps() 이런식이라 
         // 이건 request를 수정하든 다른 방식을추가해야할듯. 
         // 뻑나기 쉬워보임null.getSteps() 될거같음
-        if (request.getObo() != null && request.getObo().getSteps() != null && !request.getObo().getSteps().isEmpty()) {
+        if (Boolean.TRUE.equals(oboEnabled) && request.getObo() != null && request.getObo().getSteps() != null && !request.getObo().getSteps().isEmpty()) {
             List<OboStep> oboSteps = request.getObo().getSteps().stream()
                 .map(step -> toOboStep(savedProblem, step))
                 .toList();

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -102,7 +102,6 @@ public class ProblemUpdateService {
                     .toList();
                 oboStepRepository.saveAll(oboSteps);
             }
-
             return new ProblemUpdateObjectiveResponse(prodId, request.getCategory(), request.getTitle(), problem.getUpatedAt().toString());
     }
 

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -88,10 +88,15 @@ public class ProblemUpdateService {
              * 1. 현재 삭제 방식을 다듬어서, 값이 주어지지 않는다면, 삭제가 되지 않도록 하기
              * 2. 개별 삭제 기능을 구현할 것.
              */
-            oboStepRepository.deleteByProblem_Id(prodId);
+            boolean oboProvided = request.getObo() != null;
+            boolean oboDisabled = Boolean.FALSE.equals(request.getOboEnabled());
+
+            if (oboProvided || oboDisabled) {
+                oboStepRepository.deleteByProblem_Id(prodId);
+            }
 
             // 개별 업데이트 개선 필요
-            if (request.getObo() != null && request.getObo().getSteps() != null && !request.getObo().getSteps().isEmpty()) {
+            if (Boolean.TRUE.equals(problemObjective.getOboEnabled()) && oboProvided && request.getObo().getSteps() != null && !request.getObo().getSteps().isEmpty()) {
                 List<OboStep> oboSteps = request.getObo().getSteps().stream()
                     .map(step -> toOboStep(problem, step))
                     .toList();


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 객관식 문제 생성 및 수정에 있어서 로직을 보강
1. 객관식 문제 생성시 oboEnabled가 false임에도 obostep 정보가 주어진다면, DB에 저장되던 문제
2. 객관식 문제 수정시 무조건 obo step 정보가 사라지던 문제
3. 객관식 문제 수정시 만일 oboEnabled가 false로 변경되어도, 기존 obo step정보가 지워지지 않던 문제


를 수정함.


## 관련 이슈
Closes #103 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
