### PR TITLE
[feat] Contest 도메인 엔티티 및 레포지토리 구성 (#208)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
@@ -87,7 +87,7 @@ public class Contest {
     @Column(name = "is_hot", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean isHot = false;
 
-    @Column(name = "poster_url", length = 500)
+    @Column(name = "poster_url", length = 500) // 추후확장
     private String posterUrl;
 
     @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")

--- a/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
@@ -1,0 +1,162 @@
+package net.diveon.backend.domain.contest.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.diveon.backend.domain.group.entity.Group;
+import net.diveon.backend.domain.user.entity.User;
+
+@Entity
+@Table(name = "contest")
+public class Contest {
+
+    public enum ContestType {
+        OFFICIAL, GROUP, CLASS, INDIVIDUAL
+    }
+
+    public enum ParticipationType {
+        INDIVIDUAL, TEAM
+    }
+
+    public enum Visibility {
+        PUBLIC, GROUP
+    }
+
+    public enum ContestStatus {
+        UPCOMING, ONGOING, ENDED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User createdBy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private Group group;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contest_type", nullable = false, length = 20)
+    private ContestType contestType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "participation_type", nullable = false, length = 20)
+    private ParticipationType participationType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "visibility", nullable = false, length = 20)
+    private Visibility visibility;
+
+    @Column(name = "start_time", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime endTime;
+
+    @Column(name = "rules", columnDefinition = "TEXT")
+    private String rules;
+
+    @Column(name = "prize_description", length = 500)
+    private String prizeDescription;
+
+    @Column(name = "is_hot", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean isHot = false;
+
+    @Column(name = "poster_url", length = 500)
+    private String posterUrl;
+
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    public Contest() {}
+
+    public Contest(User createdBy, Group group, String title, String description,
+                   ContestType contestType, ParticipationType participationType, Visibility visibility,
+                   LocalDateTime startTime, LocalDateTime endTime,
+                   String rules, String prizeDescription, String posterUrl) {
+        this.createdBy = createdBy;
+        this.group = group;
+        this.title = title;
+        this.description = description;
+        this.contestType = contestType;
+        this.participationType = participationType;
+        this.visibility = visibility;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.rules = rules;
+        this.prizeDescription = prizeDescription;
+        this.posterUrl = posterUrl;
+        this.isHot = false;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    public ContestStatus getStatus() {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(startTime)) return ContestStatus.UPCOMING;
+        if (now.isAfter(endTime)) return ContestStatus.ENDED;
+        return ContestStatus.ONGOING;
+    }
+
+    public Long getId() { return id; }
+    public User getCreatedBy() { return createdBy; }
+    public Group getGroup() { return group; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public ContestType getContestType() { return contestType; }
+    public ParticipationType getParticipationType() { return participationType; }
+    public Visibility getVisibility() { return visibility; }
+    public LocalDateTime getStartTime() { return startTime; }
+    public LocalDateTime getEndTime() { return endTime; }
+    public String getRules() { return rules; }
+    public String getPrizeDescription() { return prizeDescription; }
+    public Boolean getIsHot() { return isHot; }
+    public String getPosterUrl() { return posterUrl; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+
+    public void update(String title, String description, ContestType contestType,
+                       ParticipationType participationType, Visibility visibility,
+                       LocalDateTime startTime, LocalDateTime endTime,
+                       String rules, String prizeDescription, String posterUrl) {
+        this.title = title;
+        this.description = description;
+        this.contestType = contestType;
+        this.participationType = participationType;
+        this.visibility = visibility;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.rules = rules;
+        this.prizeDescription = prizeDescription;
+        this.posterUrl = posterUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestNotice.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestNotice.java
@@ -1,0 +1,68 @@
+package net.diveon.backend.domain.contest.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.diveon.backend.domain.user.entity.User;
+
+@Entity
+@Table(name = "contest_notice")
+public class ContestNotice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Contest contest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User createdBy;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    public ContestNotice() {}
+
+    public ContestNotice(Contest contest, User createdBy, String title, String content) {
+        this.contest = contest;
+        this.createdBy = createdBy;
+        this.title = title;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public Contest getContest() { return contest; }
+    public User getCreatedBy() { return createdBy; }
+    public String getTitle() { return title; }
+    public String getContent() { return content; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestParticipant.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestParticipant.java
@@ -1,0 +1,81 @@
+package net.diveon.backend.domain.contest.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import net.diveon.backend.domain.user.entity.User;
+
+@Entity
+@Table(
+    name = "contest_participant",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UK_CONTEST_PARTICIPANT_UNIQUE", columnNames = {"contest_id", "user_id"})
+    }
+)
+public class ContestParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Contest contest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @Column(name = "joined_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime joinedAt;
+
+    @Column(name = "is_banned", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean isBanned = false;
+
+    @Column(name = "score", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer score = 0;
+
+    @Column(name = "last_solved_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime lastSolvedAt;
+
+    public ContestParticipant() {}
+
+    public ContestParticipant(Contest contest, User user) {
+        this.contest = contest;
+        this.user = user;
+        this.joinedAt = LocalDateTime.now();
+        this.isBanned = false;
+        this.score = 0;
+    }
+
+    public Long getId() { return id; }
+    public Contest getContest() { return contest; }
+    public User getUser() { return user; }
+    public LocalDateTime getJoinedAt() { return joinedAt; }
+    public Boolean getIsBanned() { return isBanned; }
+    public Integer getScore() { return score; }
+    public LocalDateTime getLastSolvedAt() { return lastSolvedAt; }
+
+    public void ban() { this.isBanned = true; }
+    public void unban() { this.isBanned = false; }
+
+    public void addScore(Integer points, LocalDateTime solvedAt) {
+        this.score += points;
+        this.lastSolvedAt = solvedAt;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestProblem.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestProblem.java
@@ -1,0 +1,61 @@
+package net.diveon.backend.domain.contest.entity;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import net.diveon.backend.domain.problem.entity.Problem;
+
+@Entity
+@Table(
+    name = "contest_problem",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UK_CONTEST_PROBLEM_UNIQUE", columnNames = {"contest_id", "problem_id"})
+    }
+)
+public class ContestProblem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Contest contest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Problem problem;
+
+    @Column(name = "points", nullable = false)
+    private Integer points;
+
+    public ContestProblem() {}
+
+    public ContestProblem(Contest contest, Problem problem, Integer points) {
+        this.contest = contest;
+        this.problem = problem;
+        this.points = points;
+    }
+
+    public Long getId() { return id; }
+    public Contest getContest() { return contest; }
+    public Problem getProblem() { return problem; }
+    public Integer getPoints() { return points; }
+
+    public void updatePoints(Integer points) {
+        this.points = points;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestQna.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestQna.java
@@ -1,0 +1,78 @@
+package net.diveon.backend.domain.contest.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.diveon.backend.domain.user.entity.User;
+
+@Entity
+@Table(name = "contest_qna")
+public class ContestQna {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Contest contest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "questioner_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User questioner;
+
+    @Column(name = "question", nullable = false, columnDefinition = "TEXT")
+    private String question;
+
+    @Column(name = "answer", columnDefinition = "TEXT")
+    private String answer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answered_by")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private User answeredBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "answered_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime answeredAt;
+
+    public ContestQna() {}
+
+    public ContestQna(Contest contest, User questioner, String question) {
+        this.contest = contest;
+        this.questioner = questioner;
+        this.question = question;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public Contest getContest() { return contest; }
+    public User getQuestioner() { return questioner; }
+    public String getQuestion() { return question; }
+    public String getAnswer() { return answer; }
+    public User getAnsweredBy() { return answeredBy; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getAnsweredAt() { return answeredAt; }
+
+    public void answer(User answeredBy, String answer) {
+        this.answeredBy = answeredBy;
+        this.answer = answer;
+        this.answeredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
@@ -1,0 +1,83 @@
+package net.diveon.backend.domain.contest.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.diveon.backend.domain.grade.entity.SolveSubmission;
+import net.diveon.backend.domain.user.entity.User;
+
+@Entity
+@Table(name = "contest_submission")
+public class ContestSubmission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Contest contest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_problem_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private ContestProblem contestProblem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "submission_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private SolveSubmission solveSubmission;
+
+    @Column(name = "is_correct")
+    private Boolean isCorrect;
+
+    @Column(name = "points_earned", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer pointsEarned = 0;
+
+    @Column(name = "submitted_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime submittedAt;
+
+    public ContestSubmission() {}
+
+    public ContestSubmission(Contest contest, ContestProblem contestProblem, User user, SolveSubmission solveSubmission) {
+        this.contest = contest;
+        this.contestProblem = contestProblem;
+        this.user = user;
+        this.solveSubmission = solveSubmission;
+        this.isCorrect = null;
+        this.pointsEarned = 0;
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public Contest getContest() { return contest; }
+    public ContestProblem getContestProblem() { return contestProblem; }
+    public User getUser() { return user; }
+    public SolveSubmission getSolveSubmission() { return solveSubmission; }
+    public Boolean getIsCorrect() { return isCorrect; }
+    public Integer getPointsEarned() { return pointsEarned; }
+    public LocalDateTime getSubmittedAt() { return submittedAt; }
+
+    public void updateResult(Boolean isCorrect, Integer pointsEarned) {
+        this.isCorrect = isCorrect;
+        this.pointsEarned = pointsEarned;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestTag.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestTag.java
@@ -1,0 +1,49 @@
+package net.diveon.backend.domain.contest.entity;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "contest_tag",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UK_CONTEST_TAG_UNIQUE", columnNames = {"contest_id", "tag"})
+    }
+)
+public class ContestTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Contest contest;
+
+    @Column(name = "tag", nullable = false, length = 50)
+    private String tag;
+
+    public ContestTag() {}
+
+    public ContestTag(Contest contest, String tag) {
+        this.contest = contest;
+        this.tag = tag;
+    }
+
+    public Long getId() { return id; }
+    public Contest getContest() { return contest; }
+    public String getTag() { return tag; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestNoticeRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestNoticeRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.diveon.backend.domain.contest.entity.ContestNotice;
+
+public interface ContestNoticeRepository extends JpaRepository<ContestNotice, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+
+public interface ContestParticipantRepository extends JpaRepository<ContestParticipant, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestProblemRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.diveon.backend.domain.contest.entity.ContestProblem;
+
+public interface ContestProblemRepository extends JpaRepository<ContestProblem, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestQnaRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestQnaRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.diveon.backend.domain.contest.entity.ContestQna;
+
+public interface ContestQnaRepository extends JpaRepository<ContestQna, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.diveon.backend.domain.contest.entity.Contest;
+
+public interface ContestRepository extends JpaRepository<Contest, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestSubmissionRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestSubmissionRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.diveon.backend.domain.contest.entity.ContestSubmission;
+
+public interface ContestSubmissionRepository extends JpaRepository<ContestSubmission, Long> {
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestTagRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestTagRepository.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.diveon.backend.domain.contest.entity.ContestTag;
+
+public interface ContestTagRepository extends JpaRepository<ContestTag, Long> {
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestAccessDeniedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestAccessDeniedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestAccessDeniedException extends RuntimeException {
+    public ContestAccessDeniedException() {
+        super("대회에 대한 권한이 없습니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestAlreadyParticipatedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestAlreadyParticipatedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestAlreadyParticipatedException extends RuntimeException {
+    public ContestAlreadyParticipatedException() {
+        super("이미 참가한 대회입니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestNotFoundException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestNotFoundException extends RuntimeException {
+    public ContestNotFoundException() {
+        super("존재하지 않는 대회입니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestNotOngoingException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestNotOngoingException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestNotOngoingException extends RuntimeException {
+    public ContestNotOngoingException() {
+        super("진행 중인 대회가 아닙니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestParticipantNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestParticipantNotFoundException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestParticipantNotFoundException extends RuntimeException {
+    public ContestParticipantNotFoundException() {
+        super("대회 참가자를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestProblemNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestProblemNotFoundException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestProblemNotFoundException extends RuntimeException {
+    public ContestProblemNotFoundException() {
+        super("존재하지 않는 대회 문제입니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -334,4 +334,88 @@ public class GlobalExceptionHandler {
                 );
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
         }
+
+        // 대회 없음 → 404
+        @ExceptionHandler(ContestNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleContestNotFound(
+                ContestNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/contest-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
+        // 대회 권한 없음 → 403
+        @ExceptionHandler(ContestAccessDeniedException.class)
+        public ResponseEntity<ErrorResponse> handleContestAccessDenied(
+                ContestAccessDeniedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/contest-access-denied",
+                        "Forbidden",
+                        403,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+        }
+
+        // 대회 문제 없음 → 404
+        @ExceptionHandler(ContestProblemNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleContestProblemNotFound(
+                ContestProblemNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/contest-problem-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
+        // 대회 참가자 없음 → 404
+        @ExceptionHandler(ContestParticipantNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleContestParticipantNotFound(
+                ContestParticipantNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/contest-participant-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
+        // 이미 참가한 대회 → 409
+        @ExceptionHandler(ContestAlreadyParticipatedException.class)
+        public ResponseEntity<ErrorResponse> handleContestAlreadyParticipated(
+                ContestAlreadyParticipatedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/conflict/contest-already-participated",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
+
+        // 진행 중인 대회 아님 → 409
+        @ExceptionHandler(ContestNotOngoingException.class)
+        public ResponseEntity<ErrorResponse> handleContestNotOngoing(
+                ContestNotOngoingException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/conflict/contest-not-ongoing",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- Contest 도메인 엔티티 7개 작성
  (Contest, ContestTag, ContestProblem, ContestParticipant, ContestSubmission, ContestNotice, ContestQna)
- Contest.getStatus(): start_time/end_time 기반 동적 상태 계산 (UPCOMING/ONGOING/ENDED)
- Repository 7개 작성
- 예외 클래스 6개 작성 및 GlobalExceptionHandler 등록
  (ContestNotFoundException, ContestAccessDeniedException, ContestProblemNotFoundException,
  ContestParticipantNotFoundException, ContestAlreadyParticipatedException, ContestNotOngoingException)


## 관련 이슈
Closes #208 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
