### PR TITLE
[feat] ContestParticipant role 컬럼 추가 (#211)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestParticipant.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestParticipant.java
@@ -7,6 +7,8 @@ import org.hibernate.annotations.OnDeleteAction;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -26,6 +28,10 @@ import net.diveon.backend.domain.user.entity.User;
 )
 public class ContestParticipant {
 
+    public enum ContestRole {
+        ADMIN, PARTICIPANT
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -41,6 +47,10 @@ public class ContestParticipant {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private ContestRole role;
+
     @Column(name = "joined_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime joinedAt;
 
@@ -55,9 +65,10 @@ public class ContestParticipant {
 
     public ContestParticipant() {}
 
-    public ContestParticipant(Contest contest, User user) {
+    public ContestParticipant(Contest contest, User user, ContestRole role) {
         this.contest = contest;
         this.user = user;
+        this.role = role;
         this.joinedAt = LocalDateTime.now();
         this.isBanned = false;
         this.score = 0;
@@ -66,6 +77,7 @@ public class ContestParticipant {
     public Long getId() { return id; }
     public Contest getContest() { return contest; }
     public User getUser() { return user; }
+    public ContestRole getRole() { return role; }
     public LocalDateTime getJoinedAt() { return joinedAt; }
     public Boolean getIsBanned() { return isBanned; }
     public Integer getScore() { return score; }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- ContestParticipant 엔티티에 role 컬럼 추가 (ADMIN / PARTICIPANT)
- 대회 내 다양한 역할 확장 대비

## 관련 이슈
Closes #211


<!-- 주석은 제외되고 올라가니 무시하세요 -->
