### PR TITLE
[feat] 대회 Q&A CRUD API 구현 (#210)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestQnaController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestQnaController.java
@@ -1,0 +1,81 @@
+package net.diveon.backend.domain.contest.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.diveon.backend.domain.contest.dto.request.QnaAnswerRequest;
+import net.diveon.backend.domain.contest.dto.request.QnaCreateRequest;
+import net.diveon.backend.domain.contest.dto.response.QnaListResponse;
+import net.diveon.backend.domain.contest.service.ContestQnaService;
+import net.diveon.backend.global.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/contests/{contestId}/qnas")
+public class ContestQnaController {
+
+    private final ContestQnaService contestQnaService;
+
+    public ContestQnaController(ContestQnaService contestQnaService) {
+        this.contestQnaService = contestQnaService;
+    }
+
+    // 8-1. Q&A 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<QnaListResponse>> getQnaList(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId) {
+        QnaListResponse response = contestQnaService.getQnaList(contestId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("Q&A 목록 조회 성공", response));
+    }
+
+    // 8-2. 질문 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createQuestion(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody QnaCreateRequest request) {
+        contestQnaService.createQuestion(contestId, Long.parseLong(userId), request);
+        return ResponseEntity.status(201).body(ApiResponse.created("질문이 등록되었습니다.", null));
+    }
+
+    // 8-3. 질문 삭제
+    @DeleteMapping("/{qnaId}")
+    public ResponseEntity<ApiResponse<Void>> deleteQuestion(
+            @PathVariable Long contestId,
+            @PathVariable Long qnaId,
+            @AuthenticationPrincipal String userId) {
+        contestQnaService.deleteQuestion(contestId, qnaId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("질문이 삭제되었습니다.", null));
+    }
+
+    // 8-4. 답변 생성
+    @PatchMapping("/{qnaId}/answer")
+    public ResponseEntity<ApiResponse<Void>> createAnswer(
+            @PathVariable Long contestId,
+            @PathVariable Long qnaId,
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody QnaAnswerRequest request) {
+        contestQnaService.createAnswer(contestId, qnaId, Long.parseLong(userId), request);
+        return ResponseEntity.ok(ApiResponse.success("답변이 등록되었습니다.", null));
+    }
+
+    // 8-5. 답변 삭제
+    @DeleteMapping("/{qnaId}/answer")
+    public ResponseEntity<ApiResponse<Void>> deleteAnswer(
+            @PathVariable Long contestId,
+            @PathVariable Long qnaId,
+            @AuthenticationPrincipal String userId) {
+        contestQnaService.deleteAnswer(contestId, qnaId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("답변이 삭제되었습니다.", null));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/QnaAnswerRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/QnaAnswerRequest.java
@@ -1,0 +1,13 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class QnaAnswerRequest {
+
+    @NotBlank
+    private String answer;
+
+    public QnaAnswerRequest() {}
+
+    public String getAnswer() { return answer; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/QnaCreateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/QnaCreateRequest.java
@@ -1,0 +1,13 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class QnaCreateRequest {
+
+    @NotBlank
+    private String question;
+
+    public QnaCreateRequest() {}
+
+    public String getQuestion() { return question; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/QnaListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/QnaListResponse.java
@@ -1,0 +1,49 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import net.diveon.backend.domain.contest.entity.ContestQna;
+
+public class QnaListResponse {
+
+    private final List<QnaItem> qnas;
+
+    public QnaListResponse(List<QnaItem> qnas) {
+        this.qnas = qnas;
+    }
+
+    public List<QnaItem> getQnas() { return qnas; }
+
+    public static class QnaItem {
+        private final Long qnaId;
+        private final String question;
+        private final String answer;
+        private final boolean isAnswered;
+        private final LocalDateTime createdAt;
+
+        public QnaItem(Long qnaId, String question, String answer, boolean isAnswered, LocalDateTime createdAt) {
+            this.qnaId = qnaId;
+            this.question = question;
+            this.answer = answer;
+            this.isAnswered = isAnswered;
+            this.createdAt = createdAt;
+        }
+
+        public static QnaItem of(ContestQna qna) {
+            return new QnaItem(
+                qna.getId(),
+                qna.getQuestion(),
+                qna.getAnswer(),
+                qna.getAnswer() != null,
+                qna.getCreatedAt()
+            );
+        }
+
+        public Long getQnaId() { return qnaId; }
+        public String getQuestion() { return question; }
+        public String getAnswer() { return answer; }
+        public boolean getIsAnswered() { return isAnswered; }
+        public LocalDateTime getCreatedAt() { return createdAt; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestNotice.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestNotice.java
@@ -44,6 +44,9 @@ public class ContestNotice {
     @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
     public ContestNotice() {}
 
     public ContestNotice(Contest contest, User createdBy, String title, String content) {
@@ -52,6 +55,7 @@ public class ContestNotice {
         this.title = title;
         this.content = content;
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
     }
 
     public Long getId() { return id; }
@@ -60,9 +64,11 @@ public class ContestNotice {
     public String getTitle() { return title; }
     public String getContent() { return content; }
     public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
 
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
@@ -1,7 +1,9 @@
 package net.diveon.backend.domain.contest.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
 
 public interface ContestParticipantRepository extends JpaRepository<ContestParticipant, Long> {
+    Optional<ContestParticipant> findByContestIdAndUserId(Long contestId, Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestQnaRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestQnaRepository.java
@@ -1,7 +1,11 @@
 package net.diveon.backend.domain.contest.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import net.diveon.backend.domain.contest.entity.ContestQna;
 
 public interface ContestQnaRepository extends JpaRepository<ContestQna, Long> {
+    List<ContestQna> findAllByContestIdOrderByCreatedAtDesc(Long contestId);
+    Optional<ContestQna> findByIdAndContestId(Long id, Long contestId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestQnaService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestQnaService.java
@@ -1,0 +1,117 @@
+package net.diveon.backend.domain.contest.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.contest.dto.request.QnaAnswerRequest;
+import net.diveon.backend.domain.contest.dto.request.QnaCreateRequest;
+import net.diveon.backend.domain.contest.dto.response.QnaListResponse;
+import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.entity.ContestQna;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestQnaRepository;
+import net.diveon.backend.domain.contest.repository.ContestRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ContestAccessDeniedException;
+import net.diveon.backend.global.exception.ContestNotFoundException;
+import net.diveon.backend.global.exception.ContestParticipantNotFoundException;
+import net.diveon.backend.global.exception.UserNotFoundException;
+import net.diveon.backend.global.exception.ContestQnaNotFoundException;
+
+@Service
+public class ContestQnaService {
+
+    private final ContestRepository contestRepository;
+    private final ContestQnaRepository contestQnaRepository;
+    private final ContestParticipantRepository contestParticipantRepository;
+    private final UserRepository userRepository;
+
+    public ContestQnaService(ContestRepository contestRepository,
+                             ContestQnaRepository contestQnaRepository,
+                             ContestParticipantRepository contestParticipantRepository,
+                             UserRepository userRepository) {
+        this.contestRepository = contestRepository;
+        this.contestQnaRepository = contestQnaRepository;
+        this.contestParticipantRepository = contestParticipantRepository;
+        this.userRepository = userRepository;
+    }
+
+    // Q&A 목록 조회 (참가자만)
+    @Transactional(readOnly = true)
+    public QnaListResponse getQnaList(Long contestId, Long userId) {
+        contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        List<ContestQna> qnas = contestQnaRepository.findAllByContestIdOrderByCreatedAtDesc(contestId);
+        List<QnaListResponse.QnaItem> items = qnas.stream().map(QnaListResponse.QnaItem::of).toList();
+        return new QnaListResponse(items);
+    }
+
+    // 질문 생성 (참가자)
+    @Transactional
+    public void createQuestion(Long contestId, Long userId, QnaCreateRequest request) {
+        Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        contestQnaRepository.save(new ContestQna(contest, user, request.getQuestion()));
+    }
+
+    // 질문 삭제 (관리자 또는 작성자)
+    @Transactional
+    public void deleteQuestion(Long contestId, Long qnaId, Long userId) {
+        contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        ContestQna qna = contestQnaRepository.findByIdAndContestId(qnaId, contestId)
+                .orElseThrow(ContestQnaNotFoundException::new);
+        ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        boolean isAdmin = participant.getRole() == ContestParticipant.ContestRole.ADMIN;
+        boolean isAuthor = qna.getQuestioner().getId().equals(userId);
+
+        if (!isAdmin && !isAuthor) {
+            throw new ContestAccessDeniedException();
+        }
+
+        contestQnaRepository.delete(qna);
+    }
+
+    // 답변 생성 (관리자)
+    @Transactional
+    public void createAnswer(Long contestId, Long qnaId, Long userId, QnaAnswerRequest request) {
+        contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        ContestQna qna = contestQnaRepository.findByIdAndContestId(qnaId, contestId)
+                .orElseThrow(ContestQnaNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        if (participant.getRole() != ContestParticipant.ContestRole.ADMIN) {
+            throw new ContestAccessDeniedException();
+        }
+
+        qna.answer(user, request.getAnswer());
+    }
+
+    // 답변 삭제 (관리자)
+    @Transactional
+    public void deleteAnswer(Long contestId, Long qnaId, Long userId) {
+        contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        ContestQna qna = contestQnaRepository.findByIdAndContestId(qnaId, contestId)
+                .orElseThrow(ContestQnaNotFoundException::new);
+        ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        if (participant.getRole() != ContestParticipant.ContestRole.ADMIN) {
+            throw new ContestAccessDeniedException();
+        }
+
+        qna.answer(null, null);
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestQnaNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestQnaNotFoundException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestQnaNotFoundException extends RuntimeException {
+    public ContestQnaNotFoundException() {
+        super("존재하지 않는 Q&A입니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -418,4 +418,18 @@ public class GlobalExceptionHandler {
                 );
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
         }
+
+        // Q&A 없음 → 404
+        @ExceptionHandler(ContestQnaNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleContestQnaNotFound(
+                ContestQnaNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/contest-qna-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- Q&A 목록 조회 (GET /api/contests/{contestId}/qnas)
- 질문 생성 (POST /api/contests/{contestId}/qnas)
- 질문 삭제 (DELETE /api/contests/{contestId}/qnas/{qnaId})
- 답변 생성 (PATCH /api/contests/{contestId}/qnas/{qnaId}/answer)
- 답변 삭제 (DELETE /api/contests/{contestId}/qnas/{qnaId}/answer)
- 관리자/참가자 권한 role 기반 체크
- ContestQnaNotFoundException 추가 및 GlobalExceptionHandler 등록

## 관련 이슈
Closes #210 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
