### PR TITLE
[feat] 대회 공지사항 CRUD API 구현 (#213)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestNoticeController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestNoticeController.java
@@ -1,0 +1,70 @@
+package net.diveon.backend.domain.contest.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.diveon.backend.domain.contest.dto.request.NoticeCreateRequest;
+import net.diveon.backend.domain.contest.dto.request.NoticeUpdateRequest;
+import net.diveon.backend.domain.contest.dto.response.NoticeListResponse;
+import net.diveon.backend.domain.contest.service.ContestNoticeService;
+import net.diveon.backend.global.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/contests/{contestId}/notices")
+public class ContestNoticeController {
+
+    private final ContestNoticeService contestNoticeService;
+
+    public ContestNoticeController(ContestNoticeService contestNoticeService) {
+        this.contestNoticeService = contestNoticeService;
+    }
+
+    // 9-1. 공지 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<NoticeListResponse>> getNoticeList(
+            @PathVariable Long contestId) {
+        NoticeListResponse response = contestNoticeService.getNoticeList(contestId);
+        return ResponseEntity.ok(ApiResponse.success("공지사항 목록 조회 성공", response));
+    }
+
+    // 9-2. 공지 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createNotice(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody NoticeCreateRequest request) {
+        contestNoticeService.createNotice(contestId, Long.parseLong(userId), request);
+        return ResponseEntity.status(201).body(ApiResponse.created("공지사항이 등록되었습니다.", null));
+    }
+
+    // 9-3. 공지 수정
+    @PatchMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<Void>> updateNotice(
+            @PathVariable Long contestId,
+            @PathVariable Long noticeId,
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody NoticeUpdateRequest request) {
+        contestNoticeService.updateNotice(contestId, noticeId, Long.parseLong(userId), request);
+        return ResponseEntity.ok(ApiResponse.success("공지사항이 수정되었습니다.", null));
+    }
+
+    // 9-4. 공지 삭제
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(
+            @PathVariable Long contestId,
+            @PathVariable Long noticeId,
+            @AuthenticationPrincipal String userId) {
+        contestNoticeService.deleteNotice(contestId, noticeId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("공지사항이 삭제되었습니다.", null));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/NoticeCreateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/NoticeCreateRequest.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class NoticeCreateRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+
+    public String getTitle() { return title; }
+    public String getContent() { return content; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/NoticeUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/NoticeUpdateRequest.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class NoticeUpdateRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+
+    public String getTitle() { return title; }
+    public String getContent() { return content; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/NoticeListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/NoticeListResponse.java
@@ -1,0 +1,43 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import net.diveon.backend.domain.contest.entity.ContestNotice;
+
+public class NoticeListResponse {
+
+    private List<NoticeItem> notices;
+
+    public NoticeListResponse(List<NoticeItem> notices) {
+        this.notices = notices;
+    }
+
+    public List<NoticeItem> getNotices() { return notices; }
+
+    public static class NoticeItem {
+        private Long id;
+        private String title;
+        private String content;
+        private String createdBy;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static NoticeItem of(ContestNotice notice) {
+            NoticeItem item = new NoticeItem();
+            item.id = notice.getId();
+            item.title = notice.getTitle();
+            item.content = notice.getContent();
+            item.createdBy = notice.getCreatedBy().getNickname();
+            item.createdAt = notice.getCreatedAt();
+            item.updatedAt = notice.getUpdatedAt();
+            return item;
+        }
+
+        public Long getId() { return id; }
+        public String getTitle() { return title; }
+        public String getContent() { return content; }
+        public String getCreatedBy() { return createdBy; }
+        public LocalDateTime getCreatedAt() { return createdAt; }
+        public LocalDateTime getUpdatedAt() { return updatedAt; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestNoticeRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestNoticeRepository.java
@@ -1,7 +1,11 @@
 package net.diveon.backend.domain.contest.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import net.diveon.backend.domain.contest.entity.ContestNotice;
 
 public interface ContestNoticeRepository extends JpaRepository<ContestNotice, Long> {
+    List<ContestNotice> findAllByContestIdOrderByCreatedAtDesc(Long contestId);
+    Optional<ContestNotice> findByIdAndContestId(Long id, Long contestId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestNoticeService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestNoticeService.java
@@ -1,0 +1,94 @@
+package net.diveon.backend.domain.contest.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.contest.dto.request.NoticeCreateRequest;
+import net.diveon.backend.domain.contest.dto.request.NoticeUpdateRequest;
+import net.diveon.backend.domain.contest.dto.response.NoticeListResponse;
+import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestNotice;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.repository.ContestNoticeRepository;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ContestAccessDeniedException;
+import net.diveon.backend.global.exception.ContestNotFoundException;
+import net.diveon.backend.global.exception.ContestNoticeNotFoundException;
+import net.diveon.backend.global.exception.ContestParticipantNotFoundException;
+import net.diveon.backend.global.exception.UserNotFoundException;
+
+@Service
+public class ContestNoticeService {
+
+    private final ContestRepository contestRepository;
+    private final ContestNoticeRepository contestNoticeRepository;
+    private final ContestParticipantRepository contestParticipantRepository;
+    private final UserRepository userRepository;
+
+    public ContestNoticeService(ContestRepository contestRepository,
+                                ContestNoticeRepository contestNoticeRepository,
+                                ContestParticipantRepository contestParticipantRepository,
+                                UserRepository userRepository) {
+        this.contestRepository = contestRepository;
+        this.contestNoticeRepository = contestNoticeRepository;
+        this.contestParticipantRepository = contestParticipantRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeListResponse getNoticeList(Long contestId) {
+        contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        List<ContestNotice> notices = contestNoticeRepository.findAllByContestIdOrderByCreatedAtDesc(contestId);
+        List<NoticeListResponse.NoticeItem> items = notices.stream().map(NoticeListResponse.NoticeItem::of).toList();
+        return new NoticeListResponse(items);
+    }
+
+    @Transactional
+    public void createNotice(Long contestId, Long userId, NoticeCreateRequest request) {
+        Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        if (participant.getRole() != ContestParticipant.ContestRole.ADMIN) {
+            throw new ContestAccessDeniedException();
+        }
+
+        contestNoticeRepository.save(new ContestNotice(contest, user, request.getTitle(), request.getContent()));
+    }
+
+    @Transactional
+    public void updateNotice(Long contestId, Long noticeId, Long userId, NoticeUpdateRequest request) {
+        contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        ContestNotice notice = contestNoticeRepository.findByIdAndContestId(noticeId, contestId)
+                .orElseThrow(ContestNoticeNotFoundException::new);
+        ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        if (participant.getRole() != ContestParticipant.ContestRole.ADMIN) {
+            throw new ContestAccessDeniedException();
+        }
+
+        notice.update(request.getTitle(), request.getContent());
+    }
+
+    @Transactional
+    public void deleteNotice(Long contestId, Long noticeId, Long userId) {
+        contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        ContestNotice notice = contestNoticeRepository.findByIdAndContestId(noticeId, contestId)
+                .orElseThrow(ContestNoticeNotFoundException::new);
+        ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        if (participant.getRole() != ContestParticipant.ContestRole.ADMIN) {
+            throw new ContestAccessDeniedException();
+        }
+
+        contestNoticeRepository.delete(notice);
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/ContestNoticeNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestNoticeNotFoundException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestNoticeNotFoundException extends RuntimeException {
+    public ContestNoticeNotFoundException() {
+        super("공지사항을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -432,4 +432,18 @@ public class GlobalExceptionHandler {
                 );
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
+
+        // 공지사항 없음 → 404
+        @ExceptionHandler(ContestNoticeNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleContestNoticeNotFound(
+                ContestNoticeNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/contest-notice-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 공지 목록 조회, 생성, 수정, 삭제 4개 API 구현
- 관리자 권한 체크 (ADMIN role)
- ContestNoticeNotFoundException 추가 및 GlobalExceptionHandler 등록

## 관련 이슈
Closes #213 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
