### PR TITLE
[feat] 대회 생성 API 구현 (#216)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -1,0 +1,35 @@
+package net.diveon.backend.domain.contest.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
+import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
+import net.diveon.backend.domain.contest.service.ContestService;
+import net.diveon.backend.global.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/contests")
+public class ContestController {
+
+    private final ContestService contestService;
+
+    public ContestController(ContestService contestService) {
+        this.contestService = contestService;
+    }
+
+    // 대회 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<ContestCreateResponse>> createContest(
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody ContestCreateRequest request) {
+        ContestCreateResponse response = contestService.createContest(Long.parseLong(userId), request);
+        return ResponseEntity.status(201).body(ApiResponse.created("대회가 성공적으로 생성되었습니다.", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestCreateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestCreateRequest.java
@@ -1,0 +1,47 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import net.diveon.backend.domain.contest.entity.Contest;
+
+public class ContestCreateRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotNull
+    private Contest.ContestType contestType;
+
+    @NotNull
+    private Contest.ParticipationType participationType;
+
+    @NotNull
+    private Contest.Visibility visibility;
+
+    @NotNull
+    private LocalDateTime startTime;
+
+    @NotNull
+    private LocalDateTime endTime;
+
+    @NotBlank
+    private String rules;
+
+    private List<String> tags;
+
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public Contest.ContestType getContestType() { return contestType; }
+    public Contest.ParticipationType getParticipationType() { return participationType; }
+    public Contest.Visibility getVisibility() { return visibility; }
+    public LocalDateTime getStartTime() { return startTime; }
+    public LocalDateTime getEndTime() { return endTime; }
+    public String getRules() { return rules; }
+    public List<String> getTags() { return tags; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestCreateResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestCreateResponse.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+public class ContestCreateResponse {
+
+    private Long contestId;
+    private String title;
+
+    public ContestCreateResponse(Long contestId, String title) {
+        this.contestId = contestId;
+        this.title = title;
+    }
+
+    public Long getContestId() { return contestId; }
+    public String getTitle() { return title; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
@@ -49,9 +49,6 @@ public class ContestSubmission {
     @Column(name = "is_correct")
     private Boolean isCorrect;
 
-    @Column(name = "points_earned", nullable = false, columnDefinition = "INT DEFAULT 0")
-    private Integer pointsEarned = 0;
-
     @Column(name = "submitted_at", nullable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime submittedAt;
 
@@ -63,7 +60,6 @@ public class ContestSubmission {
         this.user = user;
         this.solveSubmission = solveSubmission;
         this.isCorrect = null;
-        this.pointsEarned = 0;
         this.submittedAt = LocalDateTime.now();
     }
 
@@ -73,11 +69,9 @@ public class ContestSubmission {
     public User getUser() { return user; }
     public SolveSubmission getSolveSubmission() { return solveSubmission; }
     public Boolean getIsCorrect() { return isCorrect; }
-    public Integer getPointsEarned() { return pointsEarned; }
     public LocalDateTime getSubmittedAt() { return submittedAt; }
 
-    public void updateResult(Boolean isCorrect, Integer pointsEarned) {
+    public void updateResult(Boolean isCorrect) {
         this.isCorrect = isCorrect;
-        this.pointsEarned = pointsEarned;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -1,0 +1,62 @@
+package net.diveon.backend.domain.contest.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
+import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
+import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.entity.ContestTag;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestRepository;
+import net.diveon.backend.domain.contest.repository.ContestTagRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.UserNotFoundException;
+
+@Service
+public class ContestService {
+
+    private final ContestRepository contestRepository;
+    private final ContestParticipantRepository contestParticipantRepository;
+    private final ContestTagRepository contestTagRepository;
+    private final UserRepository userRepository;
+
+    public ContestService(ContestRepository contestRepository,
+                          ContestParticipantRepository contestParticipantRepository,
+                          ContestTagRepository contestTagRepository,
+                          UserRepository userRepository) {
+        this.contestRepository = contestRepository;
+        this.contestParticipantRepository = contestParticipantRepository;
+        this.contestTagRepository = contestTagRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public ContestCreateResponse createContest(Long userId, ContestCreateRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        Contest contest = new Contest(
+                user, null,
+                request.getTitle(), request.getDescription(),
+                request.getContestType(), request.getParticipationType(), request.getVisibility(),
+                request.getStartTime(), request.getEndTime(),
+                request.getRules(), null, null
+        );
+        contestRepository.save(contest);
+
+        contestParticipantRepository.save(new ContestParticipant(contest, user, ContestParticipant.ContestRole.ADMIN));
+
+        if (request.getTags() != null && !request.getTags().isEmpty()) {
+            List<ContestTag> tags = request.getTags().stream()
+                    .map(tag -> new ContestTag(contest, tag))
+                    .toList();
+            contestTagRepository.saveAll(tags);
+        }
+
+        return new ContestCreateResponse(contest.getId(), contest.getTitle());
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 대회 생성 API 구현 (POST /api/contests)
- 대회 생성 시 생성자를 ADMIN으로 contest_participant에 자동 등록
- 태그 입력 시 contest_tag에 함께 저장
- ContestSubmission에서 points_earned 컬럼 제거

## 관련 이슈
Closes #216 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
