### PR TITLE
[feat] 대회 상세 조회 API 구현 (#218)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -4,6 +4,8 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.service.ContestService;
 import net.diveon.backend.global.response.ApiResponse;
 
@@ -22,6 +25,16 @@ public class ContestController {
 
     public ContestController(ContestService contestService) {
         this.contestService = contestService;
+    }
+
+    // 대회 상세 조회
+    @GetMapping("/{contestId}")
+    public ResponseEntity<ApiResponse<ContestDetailResponse>> getContestDetail(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId) {
+        Long parsedUserId = userId != null ? Long.parseLong(userId) : null;
+        ContestDetailResponse response = contestService.getContestDetail(contestId, parsedUserId);
+        return ResponseEntity.ok(ApiResponse.success("대회 상세 정보 조회 성공", response));
     }
 
     // 대회 생성

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestDetailResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestDetailResponse.java
@@ -1,0 +1,60 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import java.time.LocalDateTime;
+
+public class ContestDetailResponse {
+
+    private Long contestId;
+    private String title;
+    private String description;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String status;
+    private Integer progress;
+    private Long totalUser;
+    private UserContext userContext;
+
+    public ContestDetailResponse(Long contestId, String title, String description,
+                                  LocalDateTime startTime, LocalDateTime endTime,
+                                  String status, Integer progress, Long totalUser,
+                                  UserContext userContext) {
+        this.contestId = contestId;
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+        this.progress = progress;
+        this.totalUser = totalUser;
+        this.userContext = userContext;
+    }
+
+    public Long getContestId() { return contestId; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public LocalDateTime getStartTime() { return startTime; }
+    public LocalDateTime getEndTime() { return endTime; }
+    public String getStatus() { return status; }
+    public Integer getProgress() { return progress; }
+    public Long getTotalUser() { return totalUser; }
+    public UserContext getUserContext() { return userContext; }
+
+    public static class UserContext {
+        private Boolean isJoined;
+        private Boolean isContestLeader;
+        private Integer myScore;
+        private Long myRank;
+
+        public UserContext(Boolean isJoined, Boolean isContestLeader, Integer myScore, Long myRank) {
+            this.isJoined = isJoined;
+            this.isContestLeader = isContestLeader;
+            this.myScore = myScore;
+            this.myRank = myRank;
+        }
+
+        public Boolean getIsJoined() { return isJoined; }
+        public Boolean getIsContestLeader() { return isContestLeader; }
+        public Integer getMyScore() { return myScore; }
+        public Long getMyRank() { return myRank; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
@@ -6,4 +6,6 @@ import net.diveon.backend.domain.contest.entity.ContestParticipant;
 
 public interface ContestParticipantRepository extends JpaRepository<ContestParticipant, Long> {
     Optional<ContestParticipant> findByContestIdAndUserId(Long contestId, Long userId);
+    long countByContestId(Long contestId);
+    long countByContestIdAndScoreGreaterThan(Long contestId, Integer score);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -5,8 +5,12 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
 import net.diveon.backend.domain.contest.entity.ContestTag;
@@ -15,6 +19,7 @@ import net.diveon.backend.domain.contest.repository.ContestRepository;
 import net.diveon.backend.domain.contest.repository.ContestTagRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ContestNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 
 @Service
@@ -35,6 +40,53 @@ public class ContestService {
         this.userRepository = userRepository;
     }
 
+    // 대회 상세 조회
+    @Transactional(readOnly = true)
+    public ContestDetailResponse getContestDetail(Long contestId, Long userId) {
+        Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+
+        String status = switch (contest.getStatus()) {
+            case UPCOMING -> "접수 중";
+            case ONGOING -> "진행 중";
+            case ENDED -> "종료";
+        };
+
+        int progress = 0; // UPCOMING
+        if (contest.getStatus() == Contest.ContestStatus.ONGOING) { // ONGOING
+            long total = ChronoUnit.SECONDS.between(contest.getStartTime(), contest.getEndTime()); // 대회 전체 시간 (초)
+            long elapsed = ChronoUnit.SECONDS.between(contest.getStartTime(), LocalDateTime.now()); // 대회 경과 시간 (초)
+            progress = (int) Math.min(100, elapsed * 100 / total); // 진행률 계산식 (혹시 100 넘어가도 최대 100으로 제한)
+        } else if (contest.getStatus() == Contest.ContestStatus.ENDED) {
+            progress = 100; // ENDED
+        }
+
+        long totalUser = contestParticipantRepository.countByContestId(contestId);
+
+        ContestDetailResponse.UserContext userContext = null; // 비로그인자면 그대로 null
+        if (userId != null) {
+            var participantOpt = contestParticipantRepository.findByContestIdAndUserId(contestId, userId);
+            if (participantOpt.isPresent()) { // 참가자인경우
+                var participant = participantOpt.get();
+                long myRank = contestParticipantRepository.countByContestIdAndScoreGreaterThan(contestId, participant.getScore()) + 1; // 나보다 점수 높은 사람 수 + 1 = 내 순위
+                userContext = new ContestDetailResponse.UserContext(
+                        true,
+                        participant.getRole() == ContestParticipant.ContestRole.ADMIN, // 관리자인지 그냥 참가자인지
+                        participant.getScore(),
+                        myRank
+                );
+            } else { // 참가자 아닌 경우
+                userContext = new ContestDetailResponse.UserContext(false, false, 0, 0L);
+            }
+        }
+
+        return new ContestDetailResponse(
+                contest.getId(), contest.getTitle(), contest.getDescription(),
+                contest.getStartTime(), contest.getEndTime(),
+                status, progress, totalUser, userContext
+        );
+    }
+
+    // 대회 생성
     @Transactional
     public ContestCreateResponse createContest(Long userId, ContestCreateRequest request) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 대회 상세 조회 API 구현 (GET /api/contests/{contestId})
- 비로그인 시 userContext null 반환
- 로그인 시 참가 여부, 관리자 여부, 점수, 순위 반환
- 대회 진행률(progress) 동적 계산


## 관련 이슈
Closes #218 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
