### PR TITLE
[feat] 대회 목록 조회 API 구현 (#220)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -9,11 +9,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
 import net.diveon.backend.domain.contest.service.ContestService;
 import net.diveon.backend.global.response.ApiResponse;
 
@@ -25,6 +27,20 @@ public class ContestController {
 
     public ContestController(ContestService contestService) {
         this.contestService = contestService;
+    }
+
+    // 대회 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<ContestListResponse>> getContestList(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Boolean onlyJoined,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal String userId) {
+        Long parsedUserId = userId != null ? Long.parseLong(userId) : null;
+        ContestListResponse response = contestService.getContestList(keyword, status, onlyJoined, page, size, parsedUserId);
+        return ResponseEntity.ok(ApiResponse.success("대회 목록 조회 성공", response));
     }
 
     // 대회 상세 조회

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestCreateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestCreateRequest.java
@@ -33,6 +33,7 @@ public class ContestCreateRequest {
     @NotBlank
     private String rules;
 
+    private String prizeDescription;
     private List<String> tags;
 
     public String getTitle() { return title; }
@@ -43,5 +44,6 @@ public class ContestCreateRequest {
     public LocalDateTime getStartTime() { return startTime; }
     public LocalDateTime getEndTime() { return endTime; }
     public String getRules() { return rules; }
+    public String getPrizeDescription() { return prizeDescription; }
     public List<String> getTags() { return tags; }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestListResponse.java
@@ -1,0 +1,64 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ContestListResponse {
+
+    private Long totalContests;
+    private Integer currentPage;
+    private Integer totalPages;
+    private List<ContestItem> contests;
+
+    public ContestListResponse(Long totalContests, Integer currentPage, Integer totalPages, List<ContestItem> contests) {
+        this.totalContests = totalContests;
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.contests = contests;
+    }
+
+    public Long getTotalContests() { return totalContests; }
+    public Integer getCurrentPage() { return currentPage; }
+    public Integer getTotalPages() { return totalPages; }
+    public List<ContestItem> getContests() { return contests; }
+
+    public static class ContestItem {
+        private Long contestId;
+        private String title;
+        private Long participants;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private String type;
+        private String prize;
+        private String status;
+        private Boolean isHot;
+        private Boolean isJoined;
+
+        public ContestItem(Long contestId, String title, Long participants,
+                           LocalDateTime startTime, LocalDateTime endTime,
+                           String type, String prize, String status,
+                           Boolean isHot, Boolean isJoined) {
+            this.contestId = contestId;
+            this.title = title;
+            this.participants = participants;
+            this.startTime = startTime;
+            this.endTime = endTime;
+            this.type = type;
+            this.prize = prize;
+            this.status = status;
+            this.isHot = isHot;
+            this.isJoined = isJoined;
+        }
+
+        public Long getContestId() { return contestId; }
+        public String getTitle() { return title; }
+        public Long getParticipants() { return participants; }
+        public LocalDateTime getStartTime() { return startTime; }
+        public LocalDateTime getEndTime() { return endTime; }
+        public String getType() { return type; }
+        public String getPrize() { return prize; }
+        public String getStatus() { return status; }
+        public Boolean getIsHot() { return isHot; }
+        public Boolean getIsJoined() { return isJoined; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
@@ -1,7 +1,33 @@
 package net.diveon.backend.domain.contest.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
 
 public interface ContestRepository extends JpaRepository<Contest, Long> {
+
+    @Query("SELECT c FROM Contest c WHERE " +
+           "(:keyword IS NULL OR LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
+           "(:statusFilter = 'ALL' OR " +
+           "  (:statusFilter = 'UPCOMING' AND c.startTime > :now) OR " +
+           "  (:statusFilter = 'ONGOING' AND c.startTime <= :now AND c.endTime >= :now) OR " +
+           "  (:statusFilter = 'ENDED' AND c.endTime < :now)) AND " +
+           "(:joinedUserId IS NULL OR EXISTS (SELECT p FROM ContestParticipant p WHERE p.contest = c AND p.user.id = :joinedUserId))")
+           
+    Page<Contest> findContestsByFilter(@Param("keyword") String keyword,
+                                       @Param("statusFilter") String statusFilter,
+                                       @Param("now") LocalDateTime now,
+                                       @Param("joinedUserId") Long joinedUserId,
+                                       Pageable pageable);
+
+    @Query("SELECT p.contest.id FROM ContestParticipant p WHERE p.user.id = :userId")
+    List<Long> findJoinedContestIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -1,7 +1,10 @@
 package net.diveon.backend.domain.contest.service;
 
 import java.util.List;
+import java.util.Set;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +14,7 @@ import java.time.temporal.ChronoUnit;
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
 import net.diveon.backend.domain.contest.entity.ContestTag;
@@ -38,6 +42,38 @@ public class ContestService {
         this.contestParticipantRepository = contestParticipantRepository;
         this.contestTagRepository = contestTagRepository;
         this.userRepository = userRepository;
+    }
+
+    // 대회 목록 조회
+    @Transactional(readOnly = true)
+    public ContestListResponse getContestList(String keyword, String status, Boolean onlyJoined, int page, int size, Long userId) {
+        String statusFilter = (status == null) ? "ALL" : status.toUpperCase();
+        Long joinedUserId = (onlyJoined != null && onlyJoined && userId != null) ? userId : null; // 참여한 대회만
+
+        Page<Contest> contestPage = contestRepository.findContestsByFilter(
+                keyword, statusFilter, LocalDateTime.now(), joinedUserId, PageRequest.of(page - 1, size));
+
+        Set<Long> joinedIds = (userId != null)
+                ? Set.copyOf(contestRepository.findJoinedContestIdsByUserId(userId))
+                : Set.of();
+
+        List<ContestListResponse.ContestItem> items = contestPage.getContent().stream().map(c -> {
+            String contestStatus = switch (c.getStatus()) {
+                case UPCOMING -> "접수 중";
+                case ONGOING -> "진행 중";
+                case ENDED -> "종료";
+            };
+            String type = c.getParticipationType() == Contest.ParticipationType.INDIVIDUAL ? "개인전" : "팀전";
+            long participants = contestParticipantRepository.countByContestId(c.getId());
+            return new ContestListResponse.ContestItem(
+                    c.getId(), c.getTitle(), participants,
+                    c.getStartTime(), c.getEndTime(),
+                    type, c.getPrizeDescription(), contestStatus,
+                    c.getIsHot(), joinedIds.contains(c.getId())
+            );
+        }).toList();
+
+        return new ContestListResponse(contestPage.getTotalElements(), page, contestPage.getTotalPages(), items);
     }
 
     // 대회 상세 조회
@@ -96,7 +132,7 @@ public class ContestService {
                 request.getTitle(), request.getDescription(),
                 request.getContestType(), request.getParticipationType(), request.getVisibility(),
                 request.getStartTime(), request.getEndTime(),
-                request.getRules(), null, null
+                request.getRules(), request.getPrizeDescription(), null
         );
         contestRepository.save(contest);
 


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 대회 목록 조회 API 구현 (GET /api/contests)
- keyword, status, onlyJoined, page, size 필터 지원
- status는 DB 컬럼 없이 start_time/end_time 기반 동적 계산으로 필터링
- 비로그인 허용, 로그인 시 isJoined 반환
- 대회 생성 request에 prizeDescription 추가

## 설계 결정
- Contest status는 DB 컬럼 대신 start_time/end_time 기반 동적 계산 방식 채택
- 이유: 스케줄러 없이 항상 정확한 상태 반영 가능, 현재 규모에서 성능 충분

## 관련 이슈
Closes #220 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
