### PR TITLE
[feat] 대회 참가/취소 API 구현 (#222)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
 import net.diveon.backend.domain.contest.service.ContestService;
 import net.diveon.backend.global.response.ApiResponse;
@@ -51,6 +53,24 @@ public class ContestController {
         Long parsedUserId = userId != null ? Long.parseLong(userId) : null;
         ContestDetailResponse response = contestService.getContestDetail(contestId, parsedUserId);
         return ResponseEntity.ok(ApiResponse.success("대회 상세 정보 조회 성공", response));
+    }
+
+    // 대회 참가
+    @PostMapping("/{contestId}/join")
+    public ResponseEntity<ApiResponse<ContestJoinResponse>> joinContest(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId) {
+        ContestJoinResponse response = contestService.joinContest(contestId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("대회 참가가 완료되었습니다.", response));
+    }
+
+    // 대회 참가 취소
+    @DeleteMapping("/{contestId}/leave")
+    public ResponseEntity<ApiResponse<ContestJoinResponse>> leaveContest(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId) {
+        ContestJoinResponse response = contestService.leaveContest(contestId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("대회 참가 취소가 완료되었습니다.", response));
     }
 
     // 대회 생성

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestJoinResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestJoinResponse.java
@@ -1,0 +1,12 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+public class ContestJoinResponse {
+
+    private Boolean isJoined;
+
+    public ContestJoinResponse(Boolean isJoined) {
+        this.isJoined = isJoined;
+    }
+
+    public Boolean getIsJoined() { return isJoined; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
@@ -143,6 +143,10 @@ public class Contest {
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
 
+    public void updateIsHot(Boolean isHot) {
+        this.isHot = isHot;
+    }
+
     public void update(String title, String description, ContestType contestType,
                        ParticipationType participationType, Visibility visibility,
                        LocalDateTime startTime, LocalDateTime endTime,

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -14,6 +14,7 @@ import java.time.temporal.ChronoUnit;
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
@@ -23,7 +24,11 @@ import net.diveon.backend.domain.contest.repository.ContestRepository;
 import net.diveon.backend.domain.contest.repository.ContestTagRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ContestAccessDeniedException;
+import net.diveon.backend.global.exception.ContestAlreadyParticipatedException;
+import net.diveon.backend.global.exception.ContestAlreadyStartedException;
 import net.diveon.backend.global.exception.ContestNotFoundException;
+import net.diveon.backend.global.exception.ContestParticipantNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 
 @Service
@@ -146,5 +151,54 @@ public class ContestService {
         }
 
         return new ContestCreateResponse(contest.getId(), contest.getTitle());
+    }
+
+    // 대회 참가
+    @Transactional
+    public ContestJoinResponse joinContest(Long contestId, Long userId) {
+        Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        // 시작 전인 대회만
+        if (contest.getStatus() != Contest.ContestStatus.UPCOMING) {
+            throw new ContestAlreadyStartedException();
+        }
+
+        // 이미 참가 기록이 있는지
+        if (contestParticipantRepository.findByContestIdAndUserId(contestId, userId).isPresent()) {
+            throw new ContestAlreadyParticipatedException();
+        }
+
+        // 참가 기록 없으면
+        contestParticipantRepository.save(new ContestParticipant(contest, user, ContestParticipant.ContestRole.PARTICIPANT));
+
+        // 50명 넘는 대회는 Hot으로 표기 (임시)
+        long participantCount = contestParticipantRepository.countByContestId(contestId);
+        if (participantCount >= 50) {
+            contest.updateIsHot(true);
+        }
+
+        return new ContestJoinResponse(true);
+    }
+
+    // 대회 참가 취소
+    @Transactional
+    public ContestJoinResponse leaveContest(Long contestId, Long userId) {
+        Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+
+        if (contest.getStatus() != Contest.ContestStatus.UPCOMING) {
+            throw new ContestAlreadyStartedException();
+        }
+
+        ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        if (participant.getRole() == ContestParticipant.ContestRole.ADMIN) {
+            throw new ContestAccessDeniedException();
+        }
+
+        contestParticipantRepository.delete(participant);
+
+        return new ContestJoinResponse(false);
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -159,17 +159,17 @@ public class ContestService {
         Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
-        // 시작 전인 대회만
+        // 시작 전인 대회만 참가 가능
         if (contest.getStatus() != Contest.ContestStatus.UPCOMING) {
             throw new ContestAlreadyStartedException();
         }
 
-        // 이미 참가 기록이 있는지
+        // 이미 참가 중인지 확인
         if (contestParticipantRepository.findByContestIdAndUserId(contestId, userId).isPresent()) {
             throw new ContestAlreadyParticipatedException();
         }
 
-        // 참가 기록 없으면
+        // 참가
         contestParticipantRepository.save(new ContestParticipant(contest, user, ContestParticipant.ContestRole.PARTICIPANT));
 
         // 50명 넘는 대회는 Hot으로 표기 (임시)

--- a/src/main/java/net/diveon/backend/global/exception/ContestAlreadyStartedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestAlreadyStartedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestAlreadyStartedException extends RuntimeException {
+    public ContestAlreadyStartedException() {
+        super("이미 시작된 대회는 참가 신청 또는 취소가 불가능합니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -446,4 +446,18 @@ public class GlobalExceptionHandler {
                 );
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
+
+        // 이미 시작된 대회 참가/취소 불가 → 409
+        @ExceptionHandler(ContestAlreadyStartedException.class)
+        public ResponseEntity<ErrorResponse> handleContestAlreadyStarted(
+                ContestAlreadyStartedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/conflict/contest-already-started",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- POST /api/contests/{contestId}/join 참가 신청 API 구현
- DELETE /api/contests/{contestId}/leave 참가 취소 API 구현
- 대회 시작 전(UPCOMING)에만 참가 신청/취소 가능하도록 제한
- ADMIN(대회 생성자)은 참가 취소 불가
- ContestAlreadyStartedException 예외 추가

## 관련 이슈
Closes #222


<!-- 주석은 제외되고 올라가니 무시하세요 -->
