### PR TITLE
[feat] 대회 설정 수정/삭제 API 구현 및 문제 삭제 정책 적용 (#224)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
+import net.diveon.backend.domain.contest.dto.request.ContestUpdateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
@@ -71,6 +73,25 @@ public class ContestController {
             @AuthenticationPrincipal String userId) {
         ContestJoinResponse response = contestService.leaveContest(contestId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("대회 참가 취소가 완료되었습니다.", response));
+    }
+
+    // 대회 설정 수정
+    @PatchMapping("/{contestId}")
+    public ResponseEntity<ApiResponse<Void>> updateContest(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody ContestUpdateRequest request) {
+        contestService.updateContest(contestId, Long.parseLong(userId), request);
+        return ResponseEntity.ok(ApiResponse.success("대회 설정이 저장되었습니다.", null));
+    }
+
+    // 대회 삭제
+    @DeleteMapping("/{contestId}")
+    public ResponseEntity<ApiResponse<Void>> deleteContest(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId) {
+        contestService.deleteContest(contestId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("대회가 성공적으로 삭제되었습니다.", null));
     }
 
     // 대회 생성

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestUpdateRequest.java
@@ -1,0 +1,26 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class ContestUpdateRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotNull
+    private LocalDateTime startTime;
+
+    @NotNull
+    private LocalDateTime endTime;
+
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public LocalDateTime getStartTime() { return startTime; }
+    public LocalDateTime getEndTime() { return endTime; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
@@ -147,20 +147,15 @@ public class Contest {
         this.isHot = isHot;
     }
 
-    public void update(String title, String description, ContestType contestType,
-                       ParticipationType participationType, Visibility visibility,
-                       LocalDateTime startTime, LocalDateTime endTime,
-                       String rules, String prizeDescription, String posterUrl) {
+    public void updateTitleAndDescription(String title, String description) {
         this.title = title;
         this.description = description;
-        this.contestType = contestType;
-        this.participationType = participationType;
-        this.visibility = visibility;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateTime(LocalDateTime startTime, LocalDateTime endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
-        this.rules = rules;
-        this.prizeDescription = prizeDescription;
-        this.posterUrl = posterUrl;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestProblemRepository.java
@@ -1,7 +1,10 @@
 package net.diveon.backend.domain.contest.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import net.diveon.backend.domain.contest.entity.ContestProblem;
 
 public interface ContestProblemRepository extends JpaRepository<ContestProblem, Long> {
+    List<ContestProblem> findAllByContestId(Long contestId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
+import net.diveon.backend.domain.contest.dto.request.ContestUpdateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
@@ -20,8 +21,10 @@ import net.diveon.backend.domain.contest.entity.Contest;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
 import net.diveon.backend.domain.contest.entity.ContestTag;
 import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestProblemRepository;
 import net.diveon.backend.domain.contest.repository.ContestRepository;
 import net.diveon.backend.domain.contest.repository.ContestTagRepository;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.ContestAccessDeniedException;
@@ -37,15 +40,21 @@ public class ContestService {
     private final ContestRepository contestRepository;
     private final ContestParticipantRepository contestParticipantRepository;
     private final ContestTagRepository contestTagRepository;
+    private final ContestProblemRepository contestProblemRepository;
+    private final ProblemRepository problemRepository;
     private final UserRepository userRepository;
 
     public ContestService(ContestRepository contestRepository,
                           ContestParticipantRepository contestParticipantRepository,
                           ContestTagRepository contestTagRepository,
+                          ContestProblemRepository contestProblemRepository,
+                          ProblemRepository problemRepository,
                           UserRepository userRepository) {
         this.contestRepository = contestRepository;
         this.contestParticipantRepository = contestParticipantRepository;
         this.contestTagRepository = contestTagRepository;
+        this.contestProblemRepository = contestProblemRepository;
+        this.problemRepository = problemRepository;
         this.userRepository = userRepository;
     }
 
@@ -179,6 +188,40 @@ public class ContestService {
         }
 
         return new ContestJoinResponse(true);
+    }
+
+    // 대회 설정 수정
+    @Transactional
+    public void updateContest(Long contestId, Long userId, ContestUpdateRequest request) {
+        Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+
+        contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .filter(p -> p.getRole() == ContestParticipant.ContestRole.ADMIN)
+                .orElseThrow(ContestAccessDeniedException::new);
+
+        contest.updateTitleAndDescription(request.getTitle(), request.getDescription());
+
+        if (contest.getStatus() == Contest.ContestStatus.UPCOMING) {
+            contest.updateTime(request.getStartTime(), request.getEndTime());
+        }
+    }
+
+    // 대회 삭제
+    @Transactional
+    public void deleteContest(Long contestId, Long userId) {
+        Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+
+        contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .filter(p -> p.getRole() == ContestParticipant.ContestRole.ADMIN)
+                .orElseThrow(ContestAccessDeniedException::new);
+
+        contestProblemRepository.findAllByContestId(contestId).forEach(cp -> {
+            if ("contest".equals(cp.getProblem().getVisibility())) {
+                problemRepository.delete(cp.getProblem());
+            }
+        });
+
+        contestRepository.delete(contest);
     }
 
     // 대회 참가 취소

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
@@ -1,5 +1,7 @@
 package net.diveon.backend.domain.group.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +12,5 @@ public interface GroupProblemRepository extends JpaRepository<GroupProblem, Long
     long countByGroupId(Long groupId);
     boolean existsByGroupIdAndProblemId(Long groupId, Long problemId);
     Page<GroupProblem> findAllByGroupId(Long groupId, Pageable pageable);
+    List<GroupProblem> findAllByGroupId(Long groupId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -165,6 +165,12 @@ public class GroupService {
             throw new GroupAccessDeniedException();
         }
 
+        groupProblemRepository.findAllByGroupId(groupId).forEach(gp -> {
+            if ("group".equals(gp.getProblem().getVisibility())) {
+                problemRepository.delete(gp.getProblem());
+            }
+        });
+
         groupRepository.delete(group);
     }
 

--- a/src/main/java/net/diveon/backend/domain/problem/entity/Problem.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/Problem.java
@@ -53,7 +53,7 @@ public class Problem {
 
     //변수명 오타, 수정해야함.
     @Column(name = "visibility", length = 10, nullable = false)
-    private String visibility; // public / private / group 
+    private String visibility; // public / private / group / contest
 
     @Column(name = "solved_count", nullable = false)
     private Integer solvedCount = 0; // 객체 생성시에 바로 0으로 되도록, 가능하면 생성자 통해서 하세용


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- PATCH /api/contests/{contestId} 대회 설정 수정 API 구현 (ADMIN 전용)
  - 제목/설명은 항상 수정 가능
  - 시작/종료 시간은 UPCOMING일 때만 반영
- DELETE /api/contests/{contestId} 대회 삭제 API 구현 (ADMIN 전용)
- Problem.visibility에 contest 타입 추가
- 대회 삭제 시 visibility = "contest" 문제 Problem 테이블에서도 삭제
- 그룹 삭제 시 visibility = "group" 문제 Problem 테이블에서도 삭제
- 공개 문제(visibility = "public")는 연결만 끊기고 Problem 유지

## 관련 이슈
Closes #224 

<!-- 주석은 제외되고 올라가니 무시하세요 -->
