### PR TITLE
[fix] Security 설정 및 키워드 검색 버그 수정 (#226)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
@@ -15,7 +15,7 @@ import net.diveon.backend.domain.contest.entity.ContestParticipant;
 public interface ContestRepository extends JpaRepository<Contest, Long> {
 
     @Query("SELECT c FROM Contest c WHERE " +
-           "(:keyword IS NULL OR LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
+           "(:keyword = '' OR LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
            "(:statusFilter = 'ALL' OR " +
            "  (:statusFilter = 'UPCOMING' AND c.startTime > :now) OR " +
            "  (:statusFilter = 'ONGOING' AND c.startTime <= :now AND c.endTime >= :now) OR " +

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -61,11 +61,12 @@ public class ContestService {
     // 대회 목록 조회
     @Transactional(readOnly = true)
     public ContestListResponse getContestList(String keyword, String status, Boolean onlyJoined, int page, int size, Long userId) {
+        String keywordFilter = (keyword == null) ? "" : keyword;
         String statusFilter = (status == null) ? "ALL" : status.toUpperCase();
         Long joinedUserId = (onlyJoined != null && onlyJoined && userId != null) ? userId : null; // 참여한 대회만
 
         Page<Contest> contestPage = contestRepository.findContestsByFilter(
-                keyword, statusFilter, LocalDateTime.now(), joinedUserId, PageRequest.of(page - 1, size));
+                keywordFilter, statusFilter, LocalDateTime.now(), joinedUserId, PageRequest.of(page - 1, size));
 
         Set<Long> joinedIds = (userId != null)
                 ? Set.copyOf(contestRepository.findJoinedContestIdsByUserId(userId))

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -46,6 +46,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/posts/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/contests").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/contests/*").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- GET /api/contests, GET /api/contests/{contestId} 비로그인 허용 (permitAll 추가)
- 대회 목록 조회 시 keyword가 null일 때 PostgreSQL lower(bytea) 오류 수정

## 관련 이슈
Closes #226


<!-- 주석은 제외되고 올라가니 무시하세요 -->
