### PR TITLE
[feat] 그룹 전용 대회 기능 구현 (#236)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestCreateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestCreateRequest.java
@@ -35,6 +35,7 @@ public class ContestCreateRequest {
 
     private String prizeDescription;
     private List<String> tags;
+    private Long groupId;
 
     public String getTitle() { return title; }
     public String getDescription() { return description; }
@@ -46,4 +47,5 @@ public class ContestCreateRequest {
     public String getRules() { return rules; }
     public String getPrizeDescription() { return prizeDescription; }
     public List<String> getTags() { return tags; }
+    public Long getGroupId() { return groupId; }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/GroupContestListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/GroupContestListResponse.java
@@ -1,0 +1,51 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GroupContestListResponse {
+
+    private Integer currentPage;
+    private Integer totalPages;
+    private List<ContestItem> contests;
+
+    public GroupContestListResponse(Integer currentPage, Integer totalPages, List<ContestItem> contests) {
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.contests = contests;
+    }
+
+    public Integer getCurrentPage() { return currentPage; }
+    public Integer getTotalPages() { return totalPages; }
+    public List<ContestItem> getContests() { return contests; }
+
+    public static class ContestItem {
+        private Long contestId;
+        private String title;
+        private String host;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private String status;
+        private Long participantCount;
+
+        public ContestItem(Long contestId, String title, String host,
+                           LocalDateTime startTime, LocalDateTime endTime,
+                           String status, Long participantCount) {
+            this.contestId = contestId;
+            this.title = title;
+            this.host = host;
+            this.startTime = startTime;
+            this.endTime = endTime;
+            this.status = status;
+            this.participantCount = participantCount;
+        }
+
+        public Long getContestId() { return contestId; }
+        public String getTitle() { return title; }
+        public String getHost() { return host; }
+        public LocalDateTime getStartTime() { return startTime; }
+        public LocalDateTime getEndTime() { return endTime; }
+        public String getStatus() { return status; }
+        public Long getParticipantCount() { return participantCount; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
@@ -15,6 +15,7 @@ import net.diveon.backend.domain.contest.entity.ContestParticipant;
 public interface ContestRepository extends JpaRepository<Contest, Long> {
 
     @Query("SELECT c FROM Contest c WHERE " +
+           "c.visibility = net.diveon.backend.domain.contest.entity.Contest$Visibility.PUBLIC AND " +
            "(:keyword = '' OR LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
            "(:statusFilter = 'ALL' OR " +
            "  (:statusFilter = 'UPCOMING' AND c.startTime > :now) OR " +
@@ -30,4 +31,7 @@ public interface ContestRepository extends JpaRepository<Contest, Long> {
 
     @Query("SELECT p.contest.id FROM ContestParticipant p WHERE p.user.id = :userId")
     List<Long> findJoinedContestIdsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT c FROM Contest c WHERE c.group.id = :groupId AND c.visibility = net.diveon.backend.domain.contest.entity.Contest$Visibility.GROUP")
+    Page<Contest> findGroupContestsByGroupId(@Param("groupId") Long groupId, Pageable pageable);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -17,6 +17,7 @@ import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
+import net.diveon.backend.domain.contest.dto.response.GroupContestListResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
 import net.diveon.backend.domain.contest.entity.ContestTag;
@@ -24,10 +25,14 @@ import net.diveon.backend.domain.contest.repository.ContestParticipantRepository
 import net.diveon.backend.domain.contest.repository.ContestProblemRepository;
 import net.diveon.backend.domain.contest.repository.ContestRepository;
 import net.diveon.backend.domain.contest.repository.ContestTagRepository;
+import net.diveon.backend.domain.group.entity.Group;
+import net.diveon.backend.domain.group.repository.GroupRepository;
+import net.diveon.backend.domain.group.repository.GroupUserRepository;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.ContestAccessDeniedException;
+import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.ContestAlreadyParticipatedException;
 import net.diveon.backend.global.exception.ContestAlreadyStartedException;
 import net.diveon.backend.global.exception.ContestNotFoundException;
@@ -43,19 +48,25 @@ public class ContestService {
     private final ContestProblemRepository contestProblemRepository;
     private final ProblemRepository problemRepository;
     private final UserRepository userRepository;
+    private final GroupUserRepository groupUserRepository;
+    private final GroupRepository groupRepository;
 
     public ContestService(ContestRepository contestRepository,
                           ContestParticipantRepository contestParticipantRepository,
                           ContestTagRepository contestTagRepository,
                           ContestProblemRepository contestProblemRepository,
                           ProblemRepository problemRepository,
-                          UserRepository userRepository) {
+                          UserRepository userRepository,
+                          GroupUserRepository groupUserRepository,
+                          GroupRepository groupRepository) {
         this.contestRepository = contestRepository;
         this.contestParticipantRepository = contestParticipantRepository;
         this.contestTagRepository = contestTagRepository;
         this.contestProblemRepository = contestProblemRepository;
         this.problemRepository = problemRepository;
         this.userRepository = userRepository;
+        this.groupUserRepository = groupUserRepository;
+        this.groupRepository = groupRepository;
     }
 
     // 대회 목록 조회
@@ -95,6 +106,13 @@ public class ContestService {
     @Transactional(readOnly = true)
     public ContestDetailResponse getContestDetail(Long contestId, Long userId) {
         Contest contest = contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
+
+        if (contest.getVisibility() == Contest.Visibility.GROUP) {
+            if (userId == null || contest.getGroup() == null ||
+                groupUserRepository.findByGroupIdAndUserId(contest.getGroup().getId(), userId).isEmpty()) {
+                throw new ContestAccessDeniedException();
+            }
+        }
 
         String status = switch (contest.getStatus()) {
             case UPCOMING -> "접수 중";
@@ -142,8 +160,15 @@ public class ContestService {
     public ContestCreateResponse createContest(Long userId, ContestCreateRequest request) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
+        Group group = null;
+        if (request.getGroupId() != null) {
+            group = groupRepository.findById(request.getGroupId()).orElseThrow(GroupNotFoundException::new);
+            groupUserRepository.findByGroupIdAndUserId(request.getGroupId(), userId)
+                    .orElseThrow(ContestAccessDeniedException::new);
+        }
+
         Contest contest = new Contest(
-                user, null,
+                user, group,
                 request.getTitle(), request.getDescription(),
                 request.getContestType(), request.getParticipationType(), request.getVisibility(),
                 request.getStartTime(), request.getEndTime(),
@@ -172,6 +197,14 @@ public class ContestService {
         // 시작 전인 대회만 참가 가능
         if (contest.getStatus() != Contest.ContestStatus.UPCOMING) {
             throw new ContestAlreadyStartedException();
+        }
+
+        // 그룹 전용 대회면 그룹원인지 확인
+        if (contest.getVisibility() == Contest.Visibility.GROUP) {
+            if (contest.getGroup() == null ||
+                groupUserRepository.findByGroupIdAndUserId(contest.getGroup().getId(), userId).isEmpty()) {
+                throw new ContestAccessDeniedException();
+            }
         }
 
         // 이미 참가 중인지 확인
@@ -244,5 +277,31 @@ public class ContestService {
         contestParticipantRepository.delete(participant);
 
         return new ContestJoinResponse(false);
+    }
+
+    // 그룹 전용 대회 목록 조회
+    @Transactional(readOnly = true)
+    public GroupContestListResponse getGroupContestList(Long groupId, Long userId, int page, int size) {
+        groupRepository.findById(groupId).orElseThrow(GroupNotFoundException::new);
+
+        groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(ContestAccessDeniedException::new);
+
+        Page<Contest> contestPage = contestRepository.findGroupContestsByGroupId(groupId, PageRequest.of(page - 1, size));
+
+        List<GroupContestListResponse.ContestItem> items = contestPage.getContent().stream().map(c -> {
+            String status = switch (c.getStatus()) {
+                case UPCOMING -> "접수 중";
+                case ONGOING -> "진행 중";
+                case ENDED -> "종료";
+            };
+            long participantCount = contestParticipantRepository.countByContestId(c.getId());
+            return new GroupContestListResponse.ContestItem(
+                    c.getId(), c.getTitle(), c.getCreatedBy().getNickname(),
+                    c.getStartTime(), c.getEndTime(), status, participantCount
+            );
+        }).toList();
+
+        return new GroupContestListResponse(page, contestPage.getTotalPages(), items);
     }
 }

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -11,6 +11,8 @@ import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
 import net.diveon.backend.domain.group.dto.GroupUpdateRequest;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import net.diveon.backend.domain.contest.dto.response.GroupContestListResponse;
+import net.diveon.backend.domain.contest.service.ContestService;
 import net.diveon.backend.domain.group.service.GroupService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -30,9 +32,11 @@ import java.util.List;
 public class GroupController {
 
     private final GroupService groupService;
+    private final ContestService contestService;
 
-    public GroupController(GroupService groupService) {
+    public GroupController(GroupService groupService, ContestService contestService) {
         this.groupService = groupService;
+        this.contestService = contestService;
     }
 
     // 그룹 검색
@@ -115,6 +119,17 @@ public class GroupController {
             @AuthenticationPrincipal String userId) {
         groupService.deleteGroup(groupId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("그룹이 성공적으로 삭제(폐쇄)되었습니다.", null));
+    }
+
+    // 그룹 전용 대회 목록 조회
+    @GetMapping("/{groupId}/contests")
+    public ResponseEntity<ApiResponse<GroupContestListResponse>> getGroupContests(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        GroupContestListResponse response = contestService.getGroupContestList(groupId, Long.parseLong(userId), page, size);
+        return ResponseEntity.ok(ApiResponse.success("그룹 전용 대회 목록 조회 성공", response));
     }
 
     // 그룹 생성


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `POST /api/contests` — groupId 필드 추가, GROUP 대회 생성 시 그룹 연결 및 그룹원 검증
- `GET /api/contests` — PUBLIC 대회만 노출, GROUP 대회 목록에서 제외
- `GET /api/contests/{contestId}` — GROUP 대회 상세 조회 시 그룹원 여부 검증
- `POST /api/contests/{contestId}/join` — GROUP 대회 참가 시 그룹원 여부 검증
- `GET /api/groups/{groupId}/contests` — 그룹 전용 대회 목록 조회 신규 API


## 관련 이슈
Closes #236 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
