### PR TITLE
[feat] 대회 문제 제출 API 구현 (#238)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -15,12 +15,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import net.diveon.backend.domain.contest.dto.request.ContestCreateRequest;
+import net.diveon.backend.domain.contest.dto.request.ContestSubmitRequest;
 import net.diveon.backend.domain.contest.dto.request.ContestUpdateRequest;
 import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
 import net.diveon.backend.domain.contest.service.ContestService;
+import net.diveon.backend.domain.contest.service.ContestSubmitService;
 import net.diveon.backend.global.response.ApiResponse;
 
 @RestController
@@ -28,9 +30,11 @@ import net.diveon.backend.global.response.ApiResponse;
 public class ContestController {
 
     private final ContestService contestService;
+    private final ContestSubmitService contestSubmitService;
 
-    public ContestController(ContestService contestService) {
+    public ContestController(ContestService contestService, ContestSubmitService contestSubmitService) {
         this.contestService = contestService;
+        this.contestSubmitService = contestSubmitService;
     }
 
     // 대회 목록 조회
@@ -101,5 +105,15 @@ public class ContestController {
             @Valid @RequestBody ContestCreateRequest request) {
         ContestCreateResponse response = contestService.createContest(Long.parseLong(userId), request);
         return ResponseEntity.status(201).body(ApiResponse.created("대회가 성공적으로 생성되었습니다.", response));
+    }
+
+    // 대회 문제 제출
+    @PostMapping("/{contestId}/problems/{contestProblemId}/submit")
+    public ResponseEntity<ApiResponse<?>> submitContestProblem(
+            @PathVariable Long contestId,
+            @PathVariable Long contestProblemId,
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody ContestSubmitRequest request) {
+        return contestSubmitService.submitContestProblem(contestId, contestProblemId, Long.parseLong(userId), request);
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestSubmitRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestSubmitRequest.java
@@ -1,0 +1,31 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ContestSubmitRequest {
+
+    public enum SubmissionType {
+        OBJECTIVE, PRACTICE, CODING
+    }
+
+    @NotNull
+    @JsonProperty("submissionType")
+    private SubmissionType submissionType;
+
+    @JsonProperty("answer")
+    private String answer;
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("language")
+    private String language;
+
+    public ContestSubmitRequest() {}
+
+    public SubmissionType getSubmissionType() { return submissionType; }
+    public String getAnswer() { return answer; }
+    public String getCode() { return code; }
+    public String getLanguage() { return language; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitAsyncResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitAsyncResponse.java
@@ -1,0 +1,22 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ContestSubmitAsyncResponse {
+
+    @JsonProperty("submissionId")
+    private Long submissionId;
+
+    @JsonProperty("status")
+    private String status;
+
+    public ContestSubmitAsyncResponse() {}
+
+    public ContestSubmitAsyncResponse(Long submissionId, String status) {
+        this.submissionId = submissionId;
+        this.status = status;
+    }
+
+    public Long getSubmissionId() { return submissionId; }
+    public String getStatus() { return status; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitImmediateResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitImmediateResponse.java
@@ -1,0 +1,22 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ContestSubmitImmediateResponse {
+
+    @JsonProperty("isCorrect")
+    private Boolean isCorrect;
+
+    @JsonProperty("score")
+    private Integer score;
+
+    public ContestSubmitImmediateResponse() {}
+
+    public ContestSubmitImmediateResponse(Boolean isCorrect, Integer score) {
+        this.isCorrect = isCorrect;
+        this.score = score;
+    }
+
+    public Boolean getIsCorrect() { return isCorrect; }
+    public Integer getScore() { return score; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
@@ -42,9 +42,12 @@ public class ContestSubmission {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "submission_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "submission_id")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private SolveSubmission solveSubmission;
+
+    @Column(name = "submission_status", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT 'COMPLETED'")
+    private String submissionStatus;
 
     @Column(name = "is_correct")
     private Boolean isCorrect;
@@ -54,11 +57,22 @@ public class ContestSubmission {
 
     public ContestSubmission() {}
 
-    public ContestSubmission(Contest contest, ContestProblem contestProblem, User user, SolveSubmission solveSubmission) {
+    public ContestSubmission(Contest contest, ContestProblem contestProblem, User user) {
         this.contest = contest;
         this.contestProblem = contestProblem;
         this.user = user;
-        this.solveSubmission = solveSubmission;
+        this.solveSubmission = null;
+        this.submissionStatus = "COMPLETED";
+        this.isCorrect = null;
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public ContestSubmission(Contest contest, ContestProblem contestProblem, User user, String submissionStatus) {
+        this.contest = contest;
+        this.contestProblem = contestProblem;
+        this.user = user;
+        this.solveSubmission = null;
+        this.submissionStatus = submissionStatus;
         this.isCorrect = null;
         this.submittedAt = LocalDateTime.now();
     }
@@ -68,10 +82,20 @@ public class ContestSubmission {
     public ContestProblem getContestProblem() { return contestProblem; }
     public User getUser() { return user; }
     public SolveSubmission getSolveSubmission() { return solveSubmission; }
+    public String getSubmissionStatus() { return submissionStatus; }
     public Boolean getIsCorrect() { return isCorrect; }
     public LocalDateTime getSubmittedAt() { return submittedAt; }
 
     public void updateResult(Boolean isCorrect) {
         this.isCorrect = isCorrect;
+    }
+
+    public void updateStatus(String submissionStatus) {
+        this.submissionStatus = submissionStatus;
+    }
+
+    public void updateResultAndStatus(Boolean isCorrect, String submissionStatus) {
+        this.isCorrect = isCorrect;
+        this.submissionStatus = submissionStatus;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitService.java
@@ -1,0 +1,9 @@
+package net.diveon.backend.domain.contest.service;
+
+import org.springframework.http.ResponseEntity;
+import net.diveon.backend.domain.contest.dto.request.ContestSubmitRequest;
+import net.diveon.backend.global.response.ApiResponse;
+
+public interface ContestSubmitService {
+    ResponseEntity<ApiResponse<?>> submitContestProblem(Long contestId, Long contestProblemId, Long userId, ContestSubmitRequest request);
+}

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitServiceImpl.java
@@ -1,0 +1,249 @@
+package net.diveon.backend.domain.contest.service;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.diveon.backend.domain.contest.dto.request.ContestSubmitRequest;
+import net.diveon.backend.domain.contest.dto.response.ContestSubmitAsyncResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestSubmitImmediateResponse;
+import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.entity.ContestProblem;
+import net.diveon.backend.domain.contest.entity.ContestSubmission;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestProblemRepository;
+import net.diveon.backend.domain.contest.repository.ContestRepository;
+import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ContestNotOngoingException;
+import net.diveon.backend.global.exception.ContestNotFoundException;
+import net.diveon.backend.global.exception.ContestParticipantNotFoundException;
+import net.diveon.backend.global.exception.ContestProblemNotFoundException;
+import net.diveon.backend.global.exception.UserNotFoundException;
+import net.diveon.backend.global.response.ApiResponse;
+
+@Service
+public class ContestSubmitServiceImpl implements ContestSubmitService {
+
+    private final ContestRepository contestRepository;
+    private final ContestProblemRepository contestProblemRepository;
+    private final ContestParticipantRepository contestParticipantRepository;
+    private final ContestSubmissionRepository contestSubmissionRepository;
+    private final UserRepository userRepository;
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    public ContestSubmitServiceImpl(
+            ContestRepository contestRepository,
+            ContestProblemRepository contestProblemRepository,
+            ContestParticipantRepository contestParticipantRepository,
+            ContestSubmissionRepository contestSubmissionRepository,
+            UserRepository userRepository,
+            JdbcTemplate jdbcTemplate,
+            ObjectMapper objectMapper) {
+        this.contestRepository = contestRepository;
+        this.contestProblemRepository = contestProblemRepository;
+        this.contestParticipantRepository = contestParticipantRepository;
+        this.contestSubmissionRepository = contestSubmissionRepository;
+        this.userRepository = userRepository;
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional
+    public ResponseEntity<ApiResponse<?>> submitContestProblem(
+            Long contestId, Long contestProblemId, Long userId, ContestSubmitRequest request) {
+
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(ContestNotFoundException::new);
+
+        if (contest.getStatus() != Contest.ContestStatus.ONGOING) {
+            throw new ContestNotOngoingException();
+        }
+
+        ContestParticipant participant = contestParticipantRepository
+                .findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestParticipantNotFoundException::new);
+
+        if (participant.getIsBanned()) {
+            throw new IllegalArgumentException("밴된 사용자는 제출할 수 없습니다.");
+        }
+
+        ContestProblem contestProblem = contestProblemRepository.findById(contestProblemId)
+                .orElseThrow(ContestProblemNotFoundException::new);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Problem problem = contestProblem.getProblem();
+
+        // TODO: 쿨다운 체크 (Redis)
+
+        switch (request.getSubmissionType()) {
+            case OBJECTIVE:
+                return handleObjectiveSubmission(contest, contestProblem, problem, user, request);
+            case PRACTICE:
+                return handlePracticeSubmission(contest, contestProblem, problem, user, request);
+            case CODING:
+                return handleCodingSubmission(contest, contestProblem, problem, user, request);
+            default:
+                throw new IllegalArgumentException("잘못된 제출 유형입니다.");
+        }
+    }
+
+    @Transactional
+    private ResponseEntity<ApiResponse<?>> handleObjectiveSubmission(
+            Contest contest, ContestProblem contestProblem, Problem problem, User user, ContestSubmitRequest request) {
+
+        String answerJson = jdbcTemplate.queryForObject(
+                "SELECT answer::text FROM problem_objective WHERE prob_id = ?",
+                String.class, problem.getId());
+
+        if (answerJson == null) {
+            throw new RuntimeException("객관식 문제 정보를 찾을 수 없습니다.");
+        }
+
+        List<Integer> correctAnswers;
+        try {
+            correctAnswers = objectMapper.readValue(answerJson, new TypeReference<List<Integer>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("정답 데이터 파싱 실패: " + e.getMessage(), e);
+        }
+
+        String userAnswer = request.getAnswer();
+        if (userAnswer == null || userAnswer.isEmpty()) {
+            throw new IllegalArgumentException("답을 입력해주세요.");
+        }
+
+        boolean isCorrect = false;
+        try {
+            int userAnswerNum = Integer.parseInt(userAnswer);
+            isCorrect = correctAnswers.contains(userAnswerNum);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("유효한 숫자를 입력해주세요.");
+        }
+
+        int scoreToAdd = 0;
+
+        if (isCorrect) {
+            List<Long> solvedProblems = contestSubmissionRepository
+                    .findSolvedContestProblemIds(contest.getId(), user.getId());
+
+            if (!solvedProblems.contains(contestProblem.getId())) {
+                scoreToAdd = contestProblem.getPoints();
+                LocalDateTime now = LocalDateTime.now();
+                ContestParticipant participant = contestParticipantRepository
+                        .findByContestIdAndUserId(contest.getId(), user.getId())
+                        .get();
+                participant.addScore(scoreToAdd, now);
+                contestParticipantRepository.save(participant);
+
+                jdbcTemplate.update("UPDATE problem_summary SET solved_count = solved_count + 1 WHERE id = ?", problem.getId());
+                // TODO: Redis 스코어보드 업데이트
+            }
+        }
+
+        ContestSubmission submission = new ContestSubmission(contest, contestProblem, user);
+        submission.updateResult(isCorrect);
+        contestSubmissionRepository.save(submission);
+
+        jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
+        // TODO: Redis 쿨다운 설정 (TTL 30s)
+
+        ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(isCorrect, scoreToAdd);
+        return ResponseEntity.ok(ApiResponse.success("제출이 완료되었습니다.", response));
+    }
+
+    @Transactional
+    private ResponseEntity<ApiResponse<?>> handlePracticeSubmission(
+            Contest contest, ContestProblem contestProblem, Problem problem, User user, ContestSubmitRequest request) {
+
+        String flagHash = jdbcTemplate.queryForObject(
+                "SELECT flag_hash FROM problem_practice WHERE prob_id = ?",
+                String.class, problem.getId());
+
+        if (flagHash == null) {
+            throw new RuntimeException("실습 문제 정보를 찾을 수 없습니다.");
+        }
+
+        String userAnswer = request.getAnswer();
+        if (userAnswer == null || userAnswer.isEmpty()) {
+            throw new IllegalArgumentException("플래그를 입력해주세요.");
+        }
+
+        String userAnswerHash = hashFlag(userAnswer);
+        boolean isCorrect = userAnswerHash.equals(flagHash);
+
+        int scoreToAdd = 0;
+
+        if (isCorrect) {
+            List<Long> solvedProblems = contestSubmissionRepository
+                    .findSolvedContestProblemIds(contest.getId(), user.getId());
+
+            if (!solvedProblems.contains(contestProblem.getId())) {
+                scoreToAdd = contestProblem.getPoints();
+                LocalDateTime now = LocalDateTime.now();
+                ContestParticipant participant = contestParticipantRepository
+                        .findByContestIdAndUserId(contest.getId(), user.getId())
+                        .get();
+                participant.addScore(scoreToAdd, now);
+                contestParticipantRepository.save(participant);
+
+                jdbcTemplate.update("UPDATE problem_summary SET solved_count = solved_count + 1 WHERE id = ?", problem.getId());
+                // TODO: Redis 스코어보드 업데이트
+            }
+        }
+
+        ContestSubmission submission = new ContestSubmission(contest, contestProblem, user);
+        submission.updateResult(isCorrect);
+        contestSubmissionRepository.save(submission);
+
+        jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
+        // TODO: Redis 쿨다운 설정 (TTL 30s)
+
+        ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(isCorrect, scoreToAdd);
+        return ResponseEntity.ok(ApiResponse.success("제출이 완료되었습니다.", response));
+    }
+
+    @Transactional
+    private ResponseEntity<ApiResponse<?>> handleCodingSubmission(
+            Contest contest, ContestProblem contestProblem, Problem problem, User user, ContestSubmitRequest request) {
+
+        ContestSubmission submission = new ContestSubmission(contest, contestProblem, user, "PENDING");
+        ContestSubmission savedSubmission = contestSubmissionRepository.save(submission);
+
+        jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
+        // TODO: S3 코드 업로드
+        // TODO: SQS 전송 (contestContext 포함)
+        // TODO: Redis 쿨다운 설정 (TTL 30s)
+
+        ContestSubmitAsyncResponse response = new ContestSubmitAsyncResponse(
+                savedSubmission.getId(), "PENDING");
+        return ResponseEntity.status(202).body(
+                ApiResponse.success("채점 요청이 접수되었습니다.", response));
+    }
+
+    private String hashFlag(String flag) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(flag.getBytes());
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -39,15 +39,14 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/ad/**").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/ad/**", "/error").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/groups/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members/pending").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/problems").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/posts/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/contests").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/contests/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/contests/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
- 객관식: 정답 비교 후 즉시 채점, 점수 반영
- 실습형: SHA-256 플래그 해시 비교 후 즉시 채점
- 코딩형: PENDING 상태로 저장 후 202 반환 (비동기 채점)
- 제출 시 problem_summary submitted_count/solved_count 업데이트
- JSONB 매핑 우회를 위해 JdbcTemplate 직접 쿼리 사용

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 대회 제출 문제 api 구현

## 관련 이슈
Closes # 238


<!-- 주석은 제외되고 올라가니 무시하세요 -->
