### PR TITLE
[feat] 대회 제출 및 스코어보드 API 구현 (#239)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -21,6 +21,8 @@ import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestRankingResponse;
+import net.diveon.backend.domain.contest.service.ContestRankingService;
 import net.diveon.backend.domain.contest.service.ContestService;
 import net.diveon.backend.domain.contest.service.ContestSubmitService;
 import net.diveon.backend.global.response.ApiResponse;
@@ -31,10 +33,13 @@ public class ContestController {
 
     private final ContestService contestService;
     private final ContestSubmitService contestSubmitService;
+    private final ContestRankingService contestRankingService;
 
-    public ContestController(ContestService contestService, ContestSubmitService contestSubmitService) {
+    public ContestController(ContestService contestService, ContestSubmitService contestSubmitService,
+                             ContestRankingService contestRankingService) {
         this.contestService = contestService;
         this.contestSubmitService = contestSubmitService;
+        this.contestRankingService = contestRankingService;
     }
 
     // 대회 목록 조회
@@ -105,6 +110,15 @@ public class ContestController {
             @Valid @RequestBody ContestCreateRequest request) {
         ContestCreateResponse response = contestService.createContest(Long.parseLong(userId), request);
         return ResponseEntity.status(201).body(ApiResponse.created("대회가 성공적으로 생성되었습니다.", response));
+    }
+
+    // 스코어보드 조회
+    @GetMapping("/{contestId}/rankings")
+    public ResponseEntity<ApiResponse<ContestRankingResponse>> getRankings(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId) {
+        ContestRankingResponse response = contestRankingService.getRankings(contestId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("스코어보드 조회 성공", response));
     }
 
     // 대회 문제 제출

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestRankingResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestRankingResponse.java
@@ -1,0 +1,50 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ContestRankingResponse {
+
+    private final Long contestId;
+    @JsonProperty("isOngoing")
+    private final Boolean isOngoing;
+    private final List<RankingEntry> rankings;
+
+    public ContestRankingResponse(Long contestId, Boolean isOngoing, List<RankingEntry> rankings) {
+        this.contestId = contestId;
+        this.isOngoing = isOngoing;
+        this.rankings = rankings;
+    }
+
+    public Long getContestId() { return contestId; }
+    public Boolean getIsOngoing() { return isOngoing; }
+    public List<RankingEntry> getRankings() { return rankings; }
+
+    public static class RankingEntry {
+        private final Integer rank;
+        private final Long userId;
+        private final String nickname;
+        private final Integer score;
+        private final LocalDateTime lastSolvedAt;
+        private final Integer solvedCount;
+
+        public RankingEntry(Integer rank, Long userId, String nickname,
+                            Integer score, LocalDateTime lastSolvedAt, Integer solvedCount) {
+            this.rank = rank;
+            this.userId = userId;
+            this.nickname = nickname;
+            this.score = score;
+            this.lastSolvedAt = lastSolvedAt;
+            this.solvedCount = solvedCount;
+        }
+
+        public Integer getRank() { return rank; }
+        public Long getUserId() { return userId; }
+        public String getNickname() { return nickname; }
+        public Integer getScore() { return score; }
+        public LocalDateTime getLastSolvedAt() { return lastSolvedAt; }
+        public Integer getSolvedCount() { return solvedCount; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestSubmission.java
@@ -77,6 +77,17 @@ public class ContestSubmission {
         this.submittedAt = LocalDateTime.now();
     }
 
+    public ContestSubmission(Contest contest, ContestProblem contestProblem, User user,
+                             SolveSubmission solveSubmission, String submissionStatus) {
+        this.contest = contest;
+        this.contestProblem = contestProblem;
+        this.user = user;
+        this.solveSubmission = solveSubmission;
+        this.submissionStatus = submissionStatus;
+        this.isCorrect = null;
+        this.submittedAt = LocalDateTime.now();
+    }
+
     public Long getId() { return id; }
     public Contest getContest() { return contest; }
     public ContestProblem getContestProblem() { return contestProblem; }

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
@@ -1,11 +1,33 @@
 package net.diveon.backend.domain.contest.repository;
 
+import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
 
 public interface ContestParticipantRepository extends JpaRepository<ContestParticipant, Long> {
     Optional<ContestParticipant> findByContestIdAndUserId(Long contestId, Long userId);
     long countByContestId(Long contestId);
     long countByContestIdAndScoreGreaterThan(Long contestId, Integer score);
+
+    @Query("""
+            SELECT cp FROM ContestParticipant cp
+            JOIN FETCH cp.user
+            WHERE cp.contest.id = :contestId
+            ORDER BY cp.score DESC, cp.lastSolvedAt ASC NULLS LAST
+            """)
+    List<ContestParticipant> findRankingsByContestId(@Param("contestId") Long contestId);
+
+    @Query("""
+            SELECT cp FROM ContestParticipant cp
+            JOIN FETCH cp.user
+            WHERE cp.contest.id = :contestId AND cp.user.id IN :userIds
+            """)
+    List<ContestParticipant> findByContestIdAndUserIds(
+            @Param("contestId") Long contestId,
+            @Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestSubmissionRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestSubmissionRepository.java
@@ -1,6 +1,7 @@
 package net.diveon.backend.domain.contest.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,14 @@ public interface ContestSubmissionRepository extends JpaRepository<ContestSubmis
               AND cs.isCorrect = true
             """)
     List<Long> findSolvedContestProblemIds(@Param("contestId") Long contestId, @Param("userId") Long userId);
+
+    @Query("""
+            SELECT cs.user.id, COUNT(DISTINCT cs.contestProblem.id)
+            FROM ContestSubmission cs
+            WHERE cs.contest.id = :contestId AND cs.isCorrect = true
+            GROUP BY cs.user.id
+            """)
+    List<Object[]> countSolvedByUserForContest(@Param("contestId") Long contestId);
+
+    Optional<ContestSubmission> findBySolveSubmissionId(Long solveSubmissionId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestRankingService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestRankingService.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.domain.contest.service;
+
+import net.diveon.backend.domain.contest.dto.response.ContestRankingResponse;
+
+public interface ContestRankingService {
+    ContestRankingResponse getRankings(Long contestId, Long userId);
+}

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestRankingServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestRankingServiceImpl.java
@@ -1,0 +1,134 @@
+package net.diveon.backend.domain.contest.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.contest.dto.response.ContestRankingResponse;
+import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestRepository;
+import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
+import net.diveon.backend.global.exception.ContestAccessDeniedException;
+import net.diveon.backend.global.exception.ContestNotFoundException;
+
+@Service
+@Transactional(readOnly = true)
+public class ContestRankingServiceImpl implements ContestRankingService {
+
+    private final ContestRepository contestRepository;
+    private final ContestParticipantRepository participantRepository;
+    private final ContestSubmissionRepository submissionRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    public ContestRankingServiceImpl(
+            ContestRepository contestRepository,
+            ContestParticipantRepository participantRepository,
+            ContestSubmissionRepository submissionRepository,
+            StringRedisTemplate redisTemplate) {
+        this.contestRepository = contestRepository;
+        this.participantRepository = participantRepository;
+        this.submissionRepository = submissionRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public ContestRankingResponse getRankings(Long contestId, Long userId) {
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(ContestNotFoundException::new);
+
+        participantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestAccessDeniedException::new);
+
+        boolean isOngoing = contest.getStatus() == Contest.ContestStatus.ONGOING;
+
+        List<ContestRankingResponse.RankingEntry> rankings;
+        if (isOngoing) {
+            try {
+                rankings = getRankingsFromRedis(contestId);
+            } catch (Exception e) {
+                rankings = getRankingsFromDB(contestId);
+            }
+        } else {
+            rankings = getRankingsFromDB(contestId);
+        }
+
+        return new ContestRankingResponse(contestId, isOngoing, rankings);
+    }
+
+    private List<ContestRankingResponse.RankingEntry> getRankingsFromRedis(Long contestId) {
+        String key = "scoreboard:" + contestId;
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, 99);
+
+        if (tuples == null || tuples.isEmpty()) {
+            return getRankingsFromDB(contestId);
+        }
+
+        List<Long> orderedUserIds = tuples.stream()
+                .map(t -> Long.parseLong(t.getValue()))
+                .collect(Collectors.toList());
+
+        List<ContestParticipant> participants =
+                participantRepository.findByContestIdAndUserIds(contestId, orderedUserIds);
+
+        Map<Long, ContestParticipant> participantMap = participants.stream()
+                .collect(Collectors.toMap(p -> p.getUser().getId(), p -> p));
+
+        Map<Long, Integer> solvedCounts = getSolvedCounts(contestId);
+
+        List<ContestRankingResponse.RankingEntry> rankings = new ArrayList<>();
+        int rank = 1;
+        for (Long uid : orderedUserIds) {
+            ContestParticipant p = participantMap.get(uid);
+            if (p == null) continue;
+            rankings.add(new ContestRankingResponse.RankingEntry(
+                    rank++,
+                    uid,
+                    p.getUser().getNickname(),
+                    p.getScore(),
+                    p.getLastSolvedAt(),
+                    solvedCounts.getOrDefault(uid, 0)
+            ));
+        }
+        return rankings;
+    }
+
+    private List<ContestRankingResponse.RankingEntry> getRankingsFromDB(Long contestId) {
+        List<ContestParticipant> participants =
+                participantRepository.findRankingsByContestId(contestId);
+
+        Map<Long, Integer> solvedCounts = getSolvedCounts(contestId);
+
+        List<ContestRankingResponse.RankingEntry> rankings = new ArrayList<>();
+        int rank = 1;
+        for (ContestParticipant p : participants) {
+            Long uid = p.getUser().getId();
+            rankings.add(new ContestRankingResponse.RankingEntry(
+                    rank++,
+                    uid,
+                    p.getUser().getNickname(),
+                    p.getScore(),
+                    p.getLastSolvedAt(),
+                    solvedCounts.getOrDefault(uid, 0)
+            ));
+        }
+        return rankings;
+    }
+
+    private Map<Long, Integer> getSolvedCounts(Long contestId) {
+        List<Object[]> results = submissionRepository.countSolvedByUserForContest(contestId);
+        return results.stream().collect(Collectors.toMap(
+                row -> (Long) row[0],
+                row -> ((Long) row[1]).intValue()
+        ));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitServiceImpl.java
@@ -2,10 +2,13 @@ package net.diveon.backend.domain.contest.service;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.HexFormat;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -25,9 +28,17 @@ import net.diveon.backend.domain.contest.repository.ContestParticipantRepository
 import net.diveon.backend.domain.contest.repository.ContestProblemRepository;
 import net.diveon.backend.domain.contest.repository.ContestRepository;
 import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
+import net.diveon.backend.domain.grade.dto.message.CodingGradeMessage;
+import net.diveon.backend.domain.grade.entity.SolveSubmission;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionCodingRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.grade.service.CodingGradeQueueService;
 import net.diveon.backend.domain.problem.entity.Problem;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ContestAccessDeniedException;
+import net.diveon.backend.global.exception.ContestCooldownException;
 import net.diveon.backend.global.exception.ContestNotOngoingException;
 import net.diveon.backend.global.exception.ContestNotFoundException;
 import net.diveon.backend.global.exception.ContestParticipantNotFoundException;
@@ -45,6 +56,10 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
     private final UserRepository userRepository;
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redisTemplate;
+    private final SolveSubmissionRepository solveSubmissionRepository;
+    private final SolveSubmissionCodingRepository solveSubmissionCodingRepository;
+    private final CodingGradeQueueService codingGradeQueueService;
 
     public ContestSubmitServiceImpl(
             ContestRepository contestRepository,
@@ -53,7 +68,11 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
             ContestSubmissionRepository contestSubmissionRepository,
             UserRepository userRepository,
             JdbcTemplate jdbcTemplate,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            StringRedisTemplate redisTemplate,
+            SolveSubmissionRepository solveSubmissionRepository,
+            SolveSubmissionCodingRepository solveSubmissionCodingRepository,
+            CodingGradeQueueService codingGradeQueueService) {
         this.contestRepository = contestRepository;
         this.contestProblemRepository = contestProblemRepository;
         this.contestParticipantRepository = contestParticipantRepository;
@@ -61,6 +80,10 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
         this.userRepository = userRepository;
         this.jdbcTemplate = jdbcTemplate;
         this.objectMapper = objectMapper;
+        this.redisTemplate = redisTemplate;
+        this.solveSubmissionRepository = solveSubmissionRepository;
+        this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
+        this.codingGradeQueueService = codingGradeQueueService;
     }
 
     @Override
@@ -77,10 +100,10 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
 
         ContestParticipant participant = contestParticipantRepository
                 .findByContestIdAndUserId(contestId, userId)
-                .orElseThrow(ContestParticipantNotFoundException::new);
+                .orElseThrow(ContestAccessDeniedException::new);
 
         if (participant.getIsBanned()) {
-            throw new IllegalArgumentException("밴된 사용자는 제출할 수 없습니다.");
+            throw new ContestAccessDeniedException();
         }
 
         ContestProblem contestProblem = contestProblemRepository.findById(contestProblemId)
@@ -91,7 +114,7 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
 
         Problem problem = contestProblem.getProblem();
 
-        // TODO: 쿨다운 체크 (Redis)
+        checkCooldown(contestId, userId, contestProblemId);
 
         switch (request.getSubmissionType()) {
             case OBJECTIVE:
@@ -153,7 +176,7 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
                 contestParticipantRepository.save(participant);
 
                 jdbcTemplate.update("UPDATE problem_summary SET solved_count = solved_count + 1 WHERE id = ?", problem.getId());
-                // TODO: Redis 스코어보드 업데이트
+                updateScoreboard(contest.getId(), user.getId(), participant.getScore(), now);
             }
         }
 
@@ -162,7 +185,7 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
         contestSubmissionRepository.save(submission);
 
         jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
-        // TODO: Redis 쿨다운 설정 (TTL 30s)
+        setCooldown(contest.getId(), user.getId(), contestProblem.getId());
 
         ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(isCorrect, scoreToAdd);
         return ResponseEntity.ok(ApiResponse.success("제출이 완료되었습니다.", response));
@@ -204,7 +227,7 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
                 contestParticipantRepository.save(participant);
 
                 jdbcTemplate.update("UPDATE problem_summary SET solved_count = solved_count + 1 WHERE id = ?", problem.getId());
-                // TODO: Redis 스코어보드 업데이트
+                updateScoreboard(contest.getId(), user.getId(), participant.getScore(), now);
             }
         }
 
@@ -213,7 +236,7 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
         contestSubmissionRepository.save(submission);
 
         jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
-        // TODO: Redis 쿨다운 설정 (TTL 30s)
+        setCooldown(contest.getId(), user.getId(), contestProblem.getId());
 
         ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(isCorrect, scoreToAdd);
         return ResponseEntity.ok(ApiResponse.success("제출이 완료되었습니다.", response));
@@ -223,18 +246,50 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
     private ResponseEntity<ApiResponse<?>> handleCodingSubmission(
             Contest contest, ContestProblem contestProblem, Problem problem, User user, ContestSubmitRequest request) {
 
-        ContestSubmission submission = new ContestSubmission(contest, contestProblem, user, "PENDING");
-        ContestSubmission savedSubmission = contestSubmissionRepository.save(submission);
+        // solve_submission + solve_submission_coding 생성 (그레이더가 이 ID로 채점)
+        SolveSubmission solveSubmission = new SolveSubmission(problem, user);
+        SolveSubmission savedSolveSubmission = solveSubmissionRepository.save(solveSubmission);
+
+        SolveSubmissionCoding coding = new SolveSubmissionCoding(savedSolveSubmission, request.getCode(), request.getLanguage());
+        solveSubmissionCodingRepository.save(coding);
+
+        // contest_submission 생성 (solve_submission 연결)
+        ContestSubmission contestSubmission = new ContestSubmission(
+                contest, contestProblem, user, savedSolveSubmission, "PENDING");
+        ContestSubmission savedContestSubmission = contestSubmissionRepository.save(contestSubmission);
 
         jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
-        // TODO: S3 코드 업로드
-        // TODO: SQS 전송 (contestContext 포함)
-        // TODO: Redis 쿨다운 설정 (TTL 30s)
+
+        // S3 업로드 + SQS 전송 (contestContext 포함)
+        CodingGradeMessage.ContestContext contestContext = new CodingGradeMessage.ContestContext(
+                contest.getId(), contestProblem.getId(), contestProblem.getPoints());
+        codingGradeQueueService.sendContestGradeRequest(
+                problem.getId(), user.getId(), savedSolveSubmission.getId(), contestContext);
+
+        setCooldown(contest.getId(), user.getId(), contestProblem.getId());
 
         ContestSubmitAsyncResponse response = new ContestSubmitAsyncResponse(
-                savedSubmission.getId(), "PENDING");
+                savedContestSubmission.getId(), "PENDING");
         return ResponseEntity.status(202).body(
                 ApiResponse.success("채점 요청이 접수되었습니다.", response));
+    }
+
+    private void checkCooldown(Long contestId, Long userId, Long contestProblemId) {
+        String key = "contest:" + contestId + ":cooldown:" + userId + ":" + contestProblemId;
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+            throw new ContestCooldownException();
+        }
+    }
+
+    private void setCooldown(Long contestId, Long userId, Long contestProblemId) {
+        String key = "contest:" + contestId + ":cooldown:" + userId + ":" + contestProblemId;
+        redisTemplate.opsForValue().set(key, "1", 30, TimeUnit.SECONDS);
+    }
+
+    private void updateScoreboard(Long contestId, Long userId, int newTotalScore, LocalDateTime solvedAt) {
+        long epochSecond = solvedAt.toEpochSecond(ZoneOffset.UTC);
+        double compositeScore = (double) newTotalScore * 1_000_000L - epochSecond;
+        redisTemplate.opsForZSet().add("scoreboard:" + contestId, String.valueOf(userId), compositeScore);
     }
 
     private String hashFlag(String flag) {

--- a/src/main/java/net/diveon/backend/domain/grade/dto/message/CodingGradeMessage.java
+++ b/src/main/java/net/diveon/backend/domain/grade/dto/message/CodingGradeMessage.java
@@ -8,6 +8,7 @@ public class CodingGradeMessage {
     private Integer timeLimit;
     private Integer memoryLimit;
     private Integer testcaseCount;
+    private ContestContext contestContext;
 
     public CodingGradeMessage() {}
 
@@ -29,31 +30,31 @@ public class CodingGradeMessage {
         this.testcaseCount = testcaseCount;
     }
 
-    public String getSubmissionId() {
-        return submissionId;
-    }
+    public String getSubmissionId() { return submissionId; }
+    public String getS3Key() { return s3Key; }
+    public String getLanguage() { return language; }
+    public String getProblemId() { return problemId; }
+    public Integer getTimeLimit() { return timeLimit; }
+    public Integer getMemoryLimit() { return memoryLimit; }
+    public Integer getTestcaseCount() { return testcaseCount; }
+    public ContestContext getContestContext() { return contestContext; }
+    public void setContestContext(ContestContext contestContext) { this.contestContext = contestContext; }
 
-    public String getS3Key() {
-        return s3Key;
-    }
+    public static class ContestContext {
+        private Long contestId;
+        private Long contestProblemId;
+        private Integer points;
 
-    public String getLanguage() {
-        return language;
-    }
+        public ContestContext() {}
 
-    public String getProblemId() {
-        return problemId;
-    }
+        public ContestContext(Long contestId, Long contestProblemId, Integer points) {
+            this.contestId = contestId;
+            this.contestProblemId = contestProblemId;
+            this.points = points;
+        }
 
-    public Integer getTimeLimit() {
-        return timeLimit;
-    }
-
-    public Integer getMemoryLimit() {
-        return memoryLimit;
-    }
-
-    public Integer getTestcaseCount() {
-        return testcaseCount;
+        public Long getContestId() { return contestId; }
+        public Long getContestProblemId() { return contestProblemId; }
+        public Integer getPoints() { return points; }
     }
 }

--- a/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueService.java
@@ -1,5 +1,8 @@
 package net.diveon.backend.domain.grade.service;
 
+import net.diveon.backend.domain.grade.dto.message.CodingGradeMessage;
+
 public interface CodingGradeQueueService {
     void sendGradeRequest(long probId, long submitterId, long submissionId);
+    void sendContestGradeRequest(long probId, long submitterId, long submissionId, CodingGradeMessage.ContestContext contestContext);
 }

--- a/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceImpl.java
@@ -56,6 +56,26 @@ public class CodingGradeQueueServiceImpl implements CodingGradeQueueService {
     }
 
     @Override
+    public void sendContestGradeRequest(long probId, long submitterId, long submissionId,
+                                        CodingGradeMessage.ContestContext contestContext) {
+        SolveSubmission submission = solveSubmissionRepository.findById(submissionId)
+            .orElseThrow(() -> new RuntimeException("제출 정보가 없습니다."));
+        SolveSubmissionCoding submissionCoding = solveSubmissionCodingRepository.findById(submissionId)
+            .orElseThrow(() -> new RuntimeException("코딩형 제출 정보가 없습니다."));
+        ProblemCoding problemCoding = problemCodingRepository.findById(probId)
+            .orElseThrow(() -> new RuntimeException("코딩형 문제가 없습니다."));
+
+        String language = submissionCoding.getLanguage();
+        String s3Key = "submissions/" + submissionId + "/" + getFileName(language);
+
+        uploadCode(s3Key, submissionCoding.getAnswer());
+
+        CodingGradeMessage message = createMessage(submissionId, s3Key, language, probId, problemCoding);
+        message.setContestContext(contestContext);
+        sendMessage(message);
+    }
+
+    @Override
     public void sendGradeRequest(long probId, long submitterId, long submissionId) {
         SolveSubmission submission = solveSubmissionRepository.findById(submissionId)
             .orElseThrow(() -> new RuntimeException("제출 정보가 없습니다."));

--- a/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceMock.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/CodingGradeQueueServiceMock.java
@@ -1,21 +1,31 @@
 package net.diveon.backend.domain.grade.service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import net.diveon.backend.domain.grade.entity.SolveSubmission;
-import net.diveon.backend.domain.grade.entity.SolveSubmission.SubmissionState;
-import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.entity.ContestSubmission;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
+import net.diveon.backend.domain.grade.dto.message.CodingGradeMessage;
 import net.diveon.backend.domain.grade.entity.SolveResult;
 import net.diveon.backend.domain.grade.entity.SolveResult.SolveResultState;
 import net.diveon.backend.domain.grade.entity.SolveResultCoding;
+import net.diveon.backend.domain.grade.entity.SolveSubmission;
+import net.diveon.backend.domain.grade.entity.SolveSubmission.SubmissionState;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
+import net.diveon.backend.domain.grade.repository.SolveResultCodingRepository;
 import net.diveon.backend.domain.grade.repository.SolveResultRepository;
 import net.diveon.backend.domain.grade.repository.SolveSubmissionCodingRepository;
 import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
-import net.diveon.backend.domain.grade.repository.SolveResultCodingRepository;
 
 @Service
 @Profile("local")
@@ -28,17 +38,81 @@ public class CodingGradeQueueServiceMock implements CodingGradeQueueService {
     private final SolveSubmissionCodingRepository solveSubmissionCodingRepository;
     private final SolveResultRepository solveResultRepository;
     private final SolveResultCodingRepository solveResultCodingRepository;
+    private final ContestSubmissionRepository contestSubmissionRepository;
+    private final ContestParticipantRepository contestParticipantRepository;
+    private final StringRedisTemplate redisTemplate;
 
     public CodingGradeQueueServiceMock(
         SolveSubmissionRepository solveSubmissionRepository,
         SolveSubmissionCodingRepository solveSubmissionCodingRepository,
         SolveResultRepository solveResultRepository,
-        SolveResultCodingRepository solveResultCodingRepository
+        SolveResultCodingRepository solveResultCodingRepository,
+        ContestSubmissionRepository contestSubmissionRepository,
+        ContestParticipantRepository contestParticipantRepository,
+        StringRedisTemplate redisTemplate
     ) {
         this.solveSubmissionRepository = solveSubmissionRepository;
         this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
         this.solveResultRepository = solveResultRepository;
         this.solveResultCodingRepository = solveResultCodingRepository;
+        this.contestSubmissionRepository = contestSubmissionRepository;
+        this.contestParticipantRepository = contestParticipantRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void sendContestGradeRequest(long probId, long submitterId, long submissionId,
+                                        CodingGradeMessage.ContestContext contestContext) {
+        SolveSubmissionCoding submissionCoding = solveSubmissionCodingRepository.findById(submissionId)
+            .orElseThrow(() -> new RuntimeException("코딩형 제출 정보가 없습니다."));
+
+        log.info(
+            "[Mock] 대회 코딩 채점 요청 생략 - probId: {}, submitterId: {}, submissionId: {}, contestId: {}",
+            probId, submitterId, submissionId, contestContext.getContestId()
+        );
+
+        // ① 일반 채점 처리 (solve_submission + solve_result + solve_result_coding)
+        sendGradeRequest(probId, submitterId, submissionId);
+
+        // ② contest_submission 업데이트
+        ContestSubmission contestSubmission = contestSubmissionRepository
+            .findBySolveSubmissionId(submissionId)
+            .orElse(null);
+        if (contestSubmission == null) {
+            log.warn("[Mock] contest_submission을 찾을 수 없음 - submissionId: {}", submissionId);
+            return;
+        }
+
+        boolean isCorrect = getMockResultState(submissionCoding.getLanguage()) == SolveResultState.CORRECT;
+
+        // ③ 첫 정답 여부 확인 (업데이트 전에 확인)
+        List<Long> solvedProblemIds = contestSubmissionRepository
+            .findSolvedContestProblemIds(contestContext.getContestId(), submitterId);
+        boolean alreadySolved = solvedProblemIds.contains(contestContext.getContestProblemId());
+
+        contestSubmission.updateResultAndStatus(isCorrect, "COMPLETED");
+
+        // ④ 첫 정답이면 점수 반영 + Redis 갱신
+        if (isCorrect && !alreadySolved) {
+            contestParticipantRepository
+                .findByContestIdAndUserId(contestContext.getContestId(), submitterId)
+                .ifPresent(participant -> {
+                    LocalDateTime now = LocalDateTime.now();
+                    participant.addScore(contestContext.getPoints(), now);
+
+                    try {
+                        long epochSecond = now.toEpochSecond(ZoneOffset.UTC);
+                        double compositeScore = (double) participant.getScore() * 1_000_000L - epochSecond;
+                        redisTemplate.opsForZSet().add(
+                            "scoreboard:" + contestContext.getContestId(),
+                            String.valueOf(submitterId),
+                            compositeScore
+                        );
+                    } catch (Exception e) {
+                        log.warn("[Mock] Redis 스코어보드 갱신 실패: {}", e.getMessage());
+                    }
+                });
+        }
     }
 
     @Override
@@ -50,17 +124,11 @@ public class CodingGradeQueueServiceMock implements CodingGradeQueueService {
 
         log.info(
             "[Mock] 코딩 채점 요청 생략 - probId: {}, submitterId: {}, submissionId: {}, language: {}",
-            probId,
-            submitterId,
-            submissionId,
-            submissionCoding.getLanguage()
+            probId, submitterId, submissionId, submissionCoding.getLanguage()
         );
 
         SolveResultState resultState = getMockResultState(submissionCoding.getLanguage());
-        SolveResult result = new SolveResult(
-            submission,
-            resultState
-        );
+        SolveResult result = new SolveResult(submission, resultState);
         solveResultRepository.save(result);
 
         SolveResultCoding resultCoding = new SolveResultCoding(
@@ -83,9 +151,6 @@ public class CodingGradeQueueServiceMock implements CodingGradeQueueService {
     }
 
     private Short getMockScore(SolveResultState resultState) {
-        if (resultState == SolveResultState.CORRECT) {
-            return 100;
-        }
-        return 0;
+        return resultState == SolveResultState.CORRECT ? (short) 100 : (short) 0;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionStatusService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionStatusService.java
@@ -1,51 +1,74 @@
 package net.diveon.backend.domain.grade.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import net.diveon.backend.domain.contest.entity.ContestSubmission;
+import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
 import net.diveon.backend.domain.grade.dto.response.SubmissionStatusResponse;
 import net.diveon.backend.domain.grade.entity.SolveSubmission;
 import net.diveon.backend.domain.grade.entity.SolveSubmission.SubmissionState;
 import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.global.exception.SubmissionAccessDeniedException;
+import net.diveon.backend.global.exception.SubmissionNotFoundException;
 
 @Service
 public class SubmissionStatusService {
 
     private final SolveSubmissionRepository solveSubmissionRepository;
+    private final ContestSubmissionRepository contestSubmissionRepository;
 
-    public SubmissionStatusService(SolveSubmissionRepository solveSubmissionRepository) {
+    public SubmissionStatusService(SolveSubmissionRepository solveSubmissionRepository,
+                                   ContestSubmissionRepository contestSubmissionRepository) {
         this.solveSubmissionRepository = solveSubmissionRepository;
+        this.contestSubmissionRepository = contestSubmissionRepository;
     }
 
     @Transactional(readOnly = true)
     public SubmissionStatusResponse getStatus(Long userId, Long submissionId) {
-        SolveSubmission submission = solveSubmissionRepository.findById(submissionId)
-            // TODO: 서비스 고도화 시 SubmissionNotFoundException 같은 전용 예외로 분리할 것.
-            .orElseThrow(() -> new RuntimeException("제출 상태 조회 실패: 제출 정보가 존재하지 않습니다."));
-
-        if (!submission.getUser().getId().equals(userId)) {
-            // TODO: 서비스 고도화 시 SubmissionAccessDeniedException 같은 전용 예외로 분리할 것.
-            throw new RuntimeException("제출 상태 조회 실패: 해당 제출 정보에 접근할 권한이 없습니다.");
+        // 일반 제출 먼저 조회
+        Optional<SolveSubmission> solveSubmission = solveSubmissionRepository.findById(submissionId);
+        if (solveSubmission.isPresent()) {
+            SolveSubmission submission = solveSubmission.get();
+            if (!submission.getUser().getId().equals(userId)) {
+                throw new SubmissionAccessDeniedException();
+            }
+            SubmissionState state = submission.getSubmissionState();
+            return new SubmissionStatusResponse(
+                String.valueOf(submission.getId()),
+                submission.getProblem().getId(),
+                submission.getProblem().getType(),
+                state.name(),
+                calculateProgress(state.name())
+            );
         }
 
-        SubmissionState submissionState = submission.getSubmissionState();
-        String status = submissionState.name();
-        int progress = calculateProgress(submissionState);
+        // 대회 제출 fallback (contest_submission.id로 polling하는 경우)
+        ContestSubmission contestSubmission = contestSubmissionRepository.findById(submissionId)
+            .orElseThrow(SubmissionNotFoundException::new);
 
+        if (!contestSubmission.getUser().getId().equals(userId)) {
+            throw new SubmissionAccessDeniedException();
+        }
+
+        String status = contestSubmission.getSubmissionStatus();
         return new SubmissionStatusResponse(
-            String.valueOf(submission.getId()),
-            submission.getProblem().getId(),
-            submission.getProblem().getType(),
+            String.valueOf(contestSubmission.getId()),
+            contestSubmission.getContestProblem().getProblem().getId(),
+            contestSubmission.getContestProblem().getProblem().getType(),
             status,
-            progress
+            calculateProgress(status)
         );
     }
 
-    private int calculateProgress(SubmissionState submissionState) {
-        return switch (submissionState) {
-            case PENDING -> 0;
-            case JUDGING -> 60;
-            case COMPLETED -> 100;
+    private int calculateProgress(String status) {
+        return switch (status) {
+            case "PENDING" -> 0;
+            case "JUDGING" -> 60;
+            case "COMPLETED" -> 100;
+            default -> 0;
         };
     }
 }

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/posts/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/contests/*/rankings").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/contests/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/net/diveon/backend/global/exception/ContestCooldownException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestCooldownException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestCooldownException extends RuntimeException {
+    public ContestCooldownException() {
+        super("제출 쿨다운 중입니다. 30초 후 다시 시도해주세요.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -419,18 +419,18 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
         }
 
-        // 진행 중인 대회 아님 → 409
+        // 진행 중인 대회 아님 → 403
         @ExceptionHandler(ContestNotOngoingException.class)
         public ResponseEntity<ErrorResponse> handleContestNotOngoing(
                 ContestNotOngoingException ex, HttpServletRequest request) {
                 ErrorResponse body = new ErrorResponse(
-                        "https://diveon.net/problems/conflict/contest-not-ongoing",
-                        "Conflict",
-                        409,
+                        "https://diveon.net/problems/contest-not-ongoing",
+                        "Forbidden",
+                        403,
                         ex.getMessage(),
                         request.getRequestURI()
                 );
-                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
         }
 
         // Q&A 없음 → 404
@@ -467,6 +467,20 @@ public class GlobalExceptionHandler {
                 ContestAlreadyStartedException ex, HttpServletRequest request) {
                 ErrorResponse body = new ErrorResponse(
                         "https://diveon.net/problems/conflict/contest-already-started",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
+
+        // 쿨다운 중 → 409
+        @ExceptionHandler(ContestCooldownException.class)
+        public ResponseEntity<ErrorResponse> handleContestCooldown(
+                ContestCooldownException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/conflict/contest-cooldown",
                         "Conflict",
                         409,
                         ex.getMessage(),


### PR DESCRIPTION

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- POST /api/contests/{contestId}/problems/{contestProblemId}/submit 구현
  - OBJECTIVE/PRACTICE: 즉시 채점 후 결과 반환
  - CODING: SolveSubmission 생성 후 SQS 비동기 채점 (202 Accepted)
  - 공통: Redis 쿨다운(30s), 첫 정답 시 점수 반영 및 Redis 스코어보드 갱신
- GET /api/contests/{contestId}/rankings 구현
  - 진행 중: Redis ZSET 조회 (장애 시 DB fallback)
  - 종료 후: DB(contest_participant) 직접 조회
- CodingGradeMessage에 ContestContext 추가, CodingGradeQueueService contest 오버로드 추가
- SubmissionStatusService에 ContestSubmission fallback 추가
- 비참가자/밴/대회 시간 외 403, 쿨다운 409 에러 코드 명세 맞춤


## 관련 이슈
Closes #


<!-- 주석은 제외되고 올라가니 무시하세요 -->
