### PR TITLE
[feat] Contest Participants List - 대회 참여자 조회 (#232)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/api_schema.md
+++ b/src/main/java/net/diveon/backend/domain/contest/api_schema.md
@@ -143,3 +143,38 @@ API 세부 명세서를 보관
   "message": "해당 참가자의 상태가 변경되었습니다."
 }
 ```
+
+
+
+### 4-b. 차단된 참가자 목록 조회
+
+- **Method / Endpoint**: `GET /api/contests/{contestId}/participants/Banned`
+- **Authorization**: Bearer Token (관리자 권한)
+- **Query Params**: `?page=1&size=20` (필요 시 검색어 `keyword` 추가 가능)
+- **Response (200 OK)**:
+
+```json
+{
+  "status": 200,
+  "data": {
+    "totalElements": 128,
+    "totalPages": 7,
+    "participants": [
+      {
+        "userId": 1001,
+        "nickname": "Dankook_Hacker",
+        "joinedAt": "2026.05.10T10:00:00",
+        "score": 2850,
+        "isBanned": true
+      },
+      {
+        "userId": 1002,
+        "nickname": "Bad_User_01",
+        "joinedAt": "2026.05.12T11:20:00",
+        "score": 100,
+        "isBanned": true
+      }
+    ]
+  }
+}
+```

--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestParticipantController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestParticipantController.java
@@ -1,0 +1,48 @@
+package net.diveon.backend.domain.contest.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.diveon.backend.domain.contest.dto.response.ContestParticipantListResponse;
+import net.diveon.backend.domain.contest.service.ContestParticipantService;
+import net.diveon.backend.global.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/contests/{contestId}/participants")
+public class ContestParticipantController {
+
+    private final ContestParticipantService contestParticipantService;
+
+    public ContestParticipantController(ContestParticipantService contestParticipantService) {
+        this.contestParticipantService = contestParticipantService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<ContestParticipantListResponse>> getContestParticipants(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        ContestParticipantListResponse response = contestParticipantService.getContestParticipants(
+                contestId, Long.parseLong(userId), keyword, page, size);
+        return ResponseEntity.ok(ApiResponse.success("참가자 목록 조회 성공", response));
+    }
+
+    @GetMapping("/banned")
+    public ResponseEntity<ApiResponse<ContestParticipantListResponse>> getBannedContestParticipants(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        ContestParticipantListResponse response = contestParticipantService.getBannedContestParticipants(
+                contestId, Long.parseLong(userId), keyword, page, size);
+        return ResponseEntity.ok(ApiResponse.success("차단된 참가자 목록 조회 성공", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestParticipantListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestParticipantListResponse.java
@@ -1,0 +1,45 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ContestParticipantListResponse {
+
+    private final Long totalElements;
+    private final Integer totalPages;
+    private final List<ParticipantItem> participants;
+
+    public ContestParticipantListResponse(Long totalElements, Integer totalPages,
+                                          List<ParticipantItem> participants) {
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.participants = participants;
+    }
+
+    public Long getTotalElements() { return totalElements; }
+    public Integer getTotalPages() { return totalPages; }
+    public List<ParticipantItem> getParticipants() { return participants; }
+
+    public static class ParticipantItem {
+        private final Long userId;
+        private final String nickname;
+        private final LocalDateTime joinedAt;
+        private final Integer score;
+        private final Boolean isBanned;
+
+        public ParticipantItem(Long userId, String nickname, LocalDateTime joinedAt,
+                               Integer score, Boolean isBanned) {
+            this.userId = userId;
+            this.nickname = nickname;
+            this.joinedAt = joinedAt;
+            this.score = score;
+            this.isBanned = isBanned;
+        }
+
+        public Long getUserId() { return userId; }
+        public String getNickname() { return nickname; }
+        public LocalDateTime getJoinedAt() { return joinedAt; }
+        public Integer getScore() { return score; }
+        public Boolean getIsBanned() { return isBanned; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
@@ -3,6 +3,8 @@ package net.diveon.backend.domain.contest.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,44 @@ public interface ContestParticipantRepository extends JpaRepository<ContestParti
     Optional<ContestParticipant> findByContestIdAndUserId(Long contestId, Long userId);
     long countByContestId(Long contestId);
     long countByContestIdAndScoreGreaterThan(Long contestId, Integer score);
+
+    @Query(
+            value = """
+                    SELECT cp FROM ContestParticipant cp
+                    JOIN FETCH cp.user
+                    WHERE cp.contest.id = :contestId
+                    AND (:keyword = '' OR LOWER(cp.user.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+                    ORDER BY cp.joinedAt ASC
+                    """,
+            countQuery = """
+                    SELECT COUNT(cp) FROM ContestParticipant cp
+                    WHERE cp.contest.id = :contestId
+                    AND (:keyword = '' OR LOWER(cp.user.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+                    """
+    )
+    Page<ContestParticipant> findPageByContestIdWithUserOrderByJoinedAtAsc(
+            @Param("contestId") Long contestId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+
+    @Query(
+            value = """
+                    SELECT cp FROM ContestParticipant cp
+                    JOIN FETCH cp.user
+                    WHERE cp.contest.id = :contestId AND cp.isBanned = true
+                    AND (:keyword = '' OR LOWER(cp.user.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+                    ORDER BY cp.joinedAt ASC
+                    """,
+            countQuery = """
+                    SELECT COUNT(cp) FROM ContestParticipant cp
+                    WHERE cp.contest.id = :contestId AND cp.isBanned = true
+                    AND (:keyword = '' OR LOWER(cp.user.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+                    """
+    )
+    Page<ContestParticipant> findPageByContestIdAndIsBannedTrueWithUserOrderByJoinedAtAsc(
+            @Param("contestId") Long contestId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
 
     @Query("""
             SELECT cp FROM ContestParticipant cp

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestParticipantService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestParticipantService.java
@@ -1,0 +1,114 @@
+package net.diveon.backend.domain.contest.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.contest.dto.response.ContestParticipantListResponse;
+import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ContestAccessDeniedException;
+import net.diveon.backend.global.exception.ContestNotFoundException;
+import net.diveon.backend.global.exception.UserNotFoundException;
+
+@Service
+public class ContestParticipantService {
+
+    private final ContestRepository contestRepository;
+    private final UserRepository userRepository;
+    private final ContestParticipantRepository contestParticipantRepository;
+
+    public ContestParticipantService(ContestRepository contestRepository,
+                                     UserRepository userRepository,
+                                     ContestParticipantRepository contestParticipantRepository) {
+        this.contestRepository = contestRepository;
+        this.userRepository = userRepository;
+        this.contestParticipantRepository = contestParticipantRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ContestParticipantListResponse getContestParticipants(Long contestId, Long userId, String keyword,
+                                                                 int page, int size) {
+        userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(ContestNotFoundException::new);
+
+        ContestParticipant requester = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestAccessDeniedException::new);
+
+        boolean isContestCreator = contest.getCreatedBy().getId().equals(userId);
+        boolean isContestAdmin = requester.getRole() == ContestParticipant.ContestRole.ADMIN;
+        if (!isContestCreator || !isContestAdmin) {
+            throw new ContestAccessDeniedException();
+        }
+
+        String keywordFilter = keyword == null ? "" : keyword;
+        Page<ContestParticipant> participantPage =
+                contestParticipantRepository.findPageByContestIdWithUserOrderByJoinedAtAsc(
+                        contestId, keywordFilter, PageRequest.of(page - 1, size));
+
+        List<ContestParticipantListResponse.ParticipantItem> participants = participantPage.getContent()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+
+        return new ContestParticipantListResponse(
+                participantPage.getTotalElements(),
+                participantPage.getTotalPages(),
+                participants
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ContestParticipantListResponse getBannedContestParticipants(Long contestId, Long userId,
+                                                                       String keyword, int page, int size) {
+        userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(ContestNotFoundException::new);
+
+        ContestParticipant requester = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                .orElseThrow(ContestAccessDeniedException::new);
+
+        boolean isContestCreator = contest.getCreatedBy().getId().equals(userId);
+        boolean isContestAdmin = requester.getRole() == ContestParticipant.ContestRole.ADMIN;
+        if (!isContestCreator || !isContestAdmin) {
+            throw new ContestAccessDeniedException();
+        }
+
+        String keywordFilter = keyword == null ? "" : keyword;
+        Page<ContestParticipant> participantPage =
+                contestParticipantRepository.findPageByContestIdAndIsBannedTrueWithUserOrderByJoinedAtAsc(
+                        contestId, keywordFilter, PageRequest.of(page - 1, size));
+
+        List<ContestParticipantListResponse.ParticipantItem> participants = participantPage.getContent()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+
+        return new ContestParticipantListResponse(
+                participantPage.getTotalElements(),
+                participantPage.getTotalPages(),
+                participants
+        );
+    }
+
+    private ContestParticipantListResponse.ParticipantItem toResponse(ContestParticipant participant) {
+        User user = participant.getUser();
+        return new ContestParticipantListResponse.ParticipantItem(
+                user.getId(),
+                user.getNickname(),
+                participant.getJoinedAt(),
+                participant.getScore(),
+                participant.getIsBanned()
+        );
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 대회 참여자 조회
- 페이지 지정 가능
- keyword 지정시 부분 조회로 제공
- 추가로 차단된 사용자만 조회하는 기능도 제공함

## 관련 이슈
Closes #232


<!-- 주석은 제외되고 올라가니 무시하세요 -->
