### PR TITLE
[feat] QnA 답변 다중 등록 기능 구현 (#249)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestQnaController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestQnaController.java
@@ -59,7 +59,7 @@ public class ContestQnaController {
     }
 
     // 8-4. 답변 생성
-    @PatchMapping("/{qnaId}/answer")
+    @PatchMapping("/{qnaId}/answers")
     public ResponseEntity<ApiResponse<Void>> createAnswer(
             @PathVariable Long contestId,
             @PathVariable Long qnaId,
@@ -70,12 +70,13 @@ public class ContestQnaController {
     }
 
     // 8-5. 답변 삭제
-    @DeleteMapping("/{qnaId}/answer")
+    @DeleteMapping("/{qnaId}/answers/{answerId}")
     public ResponseEntity<ApiResponse<Void>> deleteAnswer(
             @PathVariable Long contestId,
             @PathVariable Long qnaId,
+            @PathVariable Long answerId,
             @AuthenticationPrincipal String userId) {
-        contestQnaService.deleteAnswer(contestId, qnaId, Long.parseLong(userId));
+        contestQnaService.deleteAnswer(contestId, qnaId, answerId, Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("답변이 삭제되었습니다.", null));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/QnaListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/QnaListResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import net.diveon.backend.domain.contest.entity.ContestQna;
+import net.diveon.backend.domain.contest.entity.ContestQnaAnswer;
 
 public class QnaListResponse {
 
@@ -18,32 +19,53 @@ public class QnaListResponse {
     public static class QnaItem {
         private final Long qnaId;
         private final String question;
-        private final String answer;
+        private final List<AnswerItem> answers;
         private final boolean isAnswered;
         private final LocalDateTime createdAt;
 
-        public QnaItem(Long qnaId, String question, String answer, boolean isAnswered, LocalDateTime createdAt) {
+        public QnaItem(Long qnaId, String question, List<AnswerItem> answers, boolean isAnswered, LocalDateTime createdAt) {
             this.qnaId = qnaId;
             this.question = question;
-            this.answer = answer;
+            this.answers = answers;
             this.isAnswered = isAnswered;
             this.createdAt = createdAt;
         }
 
         public static QnaItem of(ContestQna qna) {
+            List<AnswerItem> answers = qna.getAnswers().stream().map(AnswerItem::of).toList();
             return new QnaItem(
                 qna.getId(),
                 qna.getQuestion(),
-                qna.getAnswer(),
-                qna.getAnswer() != null,
+                answers,
+                !answers.isEmpty(),
                 qna.getCreatedAt()
             );
         }
 
         public Long getQnaId() { return qnaId; }
         public String getQuestion() { return question; }
-        public String getAnswer() { return answer; }
+        public List<AnswerItem> getAnswers() { return answers; }
         public boolean getIsAnswered() { return isAnswered; }
         public LocalDateTime getCreatedAt() { return createdAt; }
+    }
+
+    public static class AnswerItem {
+        private final Long answerId;
+        private final String answer;
+        private final LocalDateTime answeredAt;
+
+        public AnswerItem(Long answerId, String answer, LocalDateTime answeredAt) {
+            this.answerId = answerId;
+            this.answer = answer;
+            this.answeredAt = answeredAt;
+        }
+
+        public static AnswerItem of(ContestQnaAnswer qnaAnswer) {
+            return new AnswerItem(qnaAnswer.getId(), qnaAnswer.getAnswer(), qnaAnswer.getAnsweredAt());
+        }
+
+        public Long getAnswerId() { return answerId; }
+        public String getAnswer() { return answer; }
+        public LocalDateTime getAnsweredAt() { return answeredAt; }
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestQna.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestQna.java
@@ -1,10 +1,13 @@
 package net.diveon.backend.domain.contest.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,6 +16,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import net.diveon.backend.domain.user.entity.User;
 
@@ -38,19 +43,12 @@ public class ContestQna {
     @Column(name = "question", nullable = false, columnDefinition = "TEXT")
     private String question;
 
-    @Column(name = "answer", columnDefinition = "TEXT")
-    private String answer;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "answered_by")
-    @OnDelete(action = OnDeleteAction.SET_NULL)
-    private User answeredBy;
-
     @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
-    @Column(name = "answered_at", columnDefinition = "TIMESTAMP")
-    private LocalDateTime answeredAt;
+    @OneToMany(mappedBy = "qna", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("answeredAt ASC")
+    private List<ContestQnaAnswer> answers = new ArrayList<>();
 
     public ContestQna() {}
 
@@ -65,14 +63,6 @@ public class ContestQna {
     public Contest getContest() { return contest; }
     public User getQuestioner() { return questioner; }
     public String getQuestion() { return question; }
-    public String getAnswer() { return answer; }
-    public User getAnsweredBy() { return answeredBy; }
     public LocalDateTime getCreatedAt() { return createdAt; }
-    public LocalDateTime getAnsweredAt() { return answeredAt; }
-
-    public void answer(User answeredBy, String answer) {
-        this.answeredBy = answeredBy;
-        this.answer = answer;
-        this.answeredAt = LocalDateTime.now();
-    }
+    public List<ContestQnaAnswer> getAnswers() { return answers; }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestQnaAnswer.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestQnaAnswer.java
@@ -1,0 +1,58 @@
+package net.diveon.backend.domain.contest.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.diveon.backend.domain.user.entity.User;
+
+@Entity
+@Table(name = "contest_qna_answer")
+public class ContestQnaAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "qna_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private ContestQna qna;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answered_by", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User answeredBy;
+
+    @Column(name = "answer", nullable = false, columnDefinition = "TEXT")
+    private String answer;
+
+    @Column(name = "answered_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime answeredAt;
+
+    public ContestQnaAnswer() {}
+
+    public ContestQnaAnswer(ContestQna qna, User answeredBy, String answer) {
+        this.qna = qna;
+        this.answeredBy = answeredBy;
+        this.answer = answer;
+        this.answeredAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public ContestQna getQna() { return qna; }
+    public User getAnsweredBy() { return answeredBy; }
+    public String getAnswer() { return answer; }
+    public LocalDateTime getAnsweredAt() { return answeredAt; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestQnaAnswerRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestQnaAnswerRepository.java
@@ -1,0 +1,11 @@
+package net.diveon.backend.domain.contest.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import net.diveon.backend.domain.contest.entity.ContestQnaAnswer;
+
+public interface ContestQnaAnswerRepository extends JpaRepository<ContestQnaAnswer, Long> {
+    Optional<ContestQnaAnswer> findByIdAndQnaId(Long id, Long qnaId);
+}

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestQnaService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestQnaService.java
@@ -11,7 +11,9 @@ import net.diveon.backend.domain.contest.dto.response.QnaListResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
 import net.diveon.backend.domain.contest.entity.ContestQna;
+import net.diveon.backend.domain.contest.entity.ContestQnaAnswer;
 import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestQnaAnswerRepository;
 import net.diveon.backend.domain.contest.repository.ContestQnaRepository;
 import net.diveon.backend.domain.contest.repository.ContestRepository;
 import net.diveon.backend.domain.user.entity.User;
@@ -19,23 +21,27 @@ import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.ContestAccessDeniedException;
 import net.diveon.backend.global.exception.ContestNotFoundException;
 import net.diveon.backend.global.exception.ContestParticipantNotFoundException;
-import net.diveon.backend.global.exception.UserNotFoundException;
+import net.diveon.backend.global.exception.ContestQnaAnswerNotFoundException;
 import net.diveon.backend.global.exception.ContestQnaNotFoundException;
+import net.diveon.backend.global.exception.UserNotFoundException;
 
 @Service
 public class ContestQnaService {
 
     private final ContestRepository contestRepository;
     private final ContestQnaRepository contestQnaRepository;
+    private final ContestQnaAnswerRepository contestQnaAnswerRepository;
     private final ContestParticipantRepository contestParticipantRepository;
     private final UserRepository userRepository;
 
     public ContestQnaService(ContestRepository contestRepository,
                              ContestQnaRepository contestQnaRepository,
+                             ContestQnaAnswerRepository contestQnaAnswerRepository,
                              ContestParticipantRepository contestParticipantRepository,
                              UserRepository userRepository) {
         this.contestRepository = contestRepository;
         this.contestQnaRepository = contestQnaRepository;
+        this.contestQnaAnswerRepository = contestQnaAnswerRepository;
         this.contestParticipantRepository = contestParticipantRepository;
         this.userRepository = userRepository;
     }
@@ -96,14 +102,14 @@ public class ContestQnaService {
             throw new ContestAccessDeniedException();
         }
 
-        qna.answer(user, request.getAnswer());
+        contestQnaAnswerRepository.save(new ContestQnaAnswer(qna, user, request.getAnswer()));
     }
 
     // 답변 삭제 (관리자)
     @Transactional
-    public void deleteAnswer(Long contestId, Long qnaId, Long userId) {
+    public void deleteAnswer(Long contestId, Long qnaId, Long answerId, Long userId) {
         contestRepository.findById(contestId).orElseThrow(ContestNotFoundException::new);
-        ContestQna qna = contestQnaRepository.findByIdAndContestId(qnaId, contestId)
+        contestQnaRepository.findByIdAndContestId(qnaId, contestId)
                 .orElseThrow(ContestQnaNotFoundException::new);
         ContestParticipant participant = contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
                 .orElseThrow(ContestParticipantNotFoundException::new);
@@ -112,6 +118,8 @@ public class ContestQnaService {
             throw new ContestAccessDeniedException();
         }
 
-        qna.answer(null, null);
+        ContestQnaAnswer answer = contestQnaAnswerRepository.findByIdAndQnaId(answerId, qnaId)
+                .orElseThrow(ContestQnaAnswerNotFoundException::new);
+        contestQnaAnswerRepository.delete(answer);
     }
 }

--- a/src/main/java/net/diveon/backend/global/exception/ContestQnaAnswerNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestQnaAnswerNotFoundException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ContestQnaAnswerNotFoundException extends RuntimeException {
+    public ContestQnaAnswerNotFoundException() {
+        super("존재하지 않는 답변입니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -461,6 +461,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // Q&A 답변 없음 → 404
+        @ExceptionHandler(ContestQnaAnswerNotFoundException.class)
+        public ResponseEntity<ErrorResponse> handleContestQnaAnswerNotFound(
+                ContestQnaAnswerNotFoundException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/contest-qna-answer-not-found",
+                        "Not Found",
+                        404,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+
         // 공지사항 없음 → 404
         @ExceptionHandler(ContestNoticeNotFoundException.class)
         public ResponseEntity<ErrorResponse> handleContestNoticeNotFound(


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- ContestQnaAnswer 엔티티 추가 (contest_qna_answer 테이블 신규 생성)
- ContestQna 엔티티에서 단일 answer 필드 제거, OneToMany 관계 추가
- QnaListResponse 응답 수정: answer(String) → answers(List<AnswerItem>)
- 답변 삭제 endpoint 변경: DELETE /qnas/{qnaId}/answer → DELETE /qnas/{qnaId}/answers/{answerId}
- 답변 생성 endpoint 변경: PATCH /qnas/{qnaId}/answer → PATCH /qnas/{qnaId}/answers
## 관련 이슈

Closes #249 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
