### PR TITLE
[fix] Contest Normal - 대회 참여자 차단시, 스스로를 차단하는 상황 제거 (#251)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestParticipantService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestParticipantService.java
@@ -107,6 +107,11 @@ public class ContestParticipantService {
     @Transactional
     public ContestParticipantBanResponse updateContestParticipantBanStatus(
             Long contestId, Long participantUserId, Long requestUserId, ContestParticipantBanRequest request) {
+        
+        if(participantUserId == requestUserId){
+                throw new ContestAccessDeniedException("그룹장은 스스로를 차단할 수 없습니다.");
+        }
+        
         userRepository.findById(requestUserId).orElseThrow(UserNotFoundException::new);
 
         Contest contest = contestRepository.findById(contestId)

--- a/src/main/java/net/diveon/backend/global/exception/ContestAccessDeniedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestAccessDeniedException.java
@@ -4,4 +4,8 @@ public class ContestAccessDeniedException extends RuntimeException {
     public ContestAccessDeniedException() {
         super("대회에 대한 권한이 없습니다.");
     }
+
+    public ContestAccessDeniedException(String message){
+        super(message);
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 회 참여자 차단시, 그룹장이 스스로를 차단하는 상황 제거

## 관련 이슈
Closes #251


<!-- 주석은 제외되고 올라가니 무시하세요 -->
