### PR TITLE
[Develop] 대회 문제 추가를 위한, 소유 대회 리스트 제공

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -1,5 +1,7 @@
 package net.diveon.backend.domain.contest.controller;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestOwnedListResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestRankingResponse;
 import net.diveon.backend.domain.contest.service.ContestRankingService;
 import net.diveon.backend.domain.contest.service.ContestService;
@@ -54,6 +57,14 @@ public class ContestController {
         Long parsedUserId = userId != null ? Long.parseLong(userId) : null;
         ContestListResponse response = contestService.getContestList(keyword, status, onlyJoined, page, size, parsedUserId);
         return ResponseEntity.ok(ApiResponse.success("대회 목록 조회 성공", response));
+    }
+
+    // 내가 소유한 대회 목록 조회
+    @GetMapping("/me/owned")
+    public ResponseEntity<ApiResponse<List<ContestOwnedListResponse>>> getOwnedContests(
+            @AuthenticationPrincipal String userId) {
+        List<ContestOwnedListResponse> response = contestService.getOwnedContests(Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("내가 소유한 대회 목록 조회 성공", response));
     }
 
     // 대회 상세 조회

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestOwnedListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestOwnedListResponse.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+public class ContestOwnedListResponse {
+
+    private Long contestId;
+    private String title;
+
+    public ContestOwnedListResponse(Long contestId, String title) {
+        this.contestId = contestId;
+        this.title = title;
+    }
+
+    public Long getContestId() { return contestId; }
+    public String getTitle() { return title; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import net.diveon.backend.domain.contest.dto.response.ContestOwnedListResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
-import net.diveon.backend.domain.contest.entity.ContestParticipant;
 
 public interface ContestRepository extends JpaRepository<Contest, Long> {
 
@@ -34,4 +34,8 @@ public interface ContestRepository extends JpaRepository<Contest, Long> {
 
     @Query("SELECT c FROM Contest c WHERE c.group.id = :groupId AND c.visibility = net.diveon.backend.domain.contest.entity.Contest$Visibility.GROUP")
     Page<Contest> findGroupContestsByGroupId(@Param("groupId") Long groupId, Pageable pageable);
+
+    @Query("SELECT new net.diveon.backend.domain.contest.dto.response.ContestOwnedListResponse(c.id, c.title) " +
+           "FROM Contest c WHERE c.createdBy.id = :userId")
+    List<ContestOwnedListResponse> findOwnedContestsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -17,6 +17,7 @@ import net.diveon.backend.domain.contest.dto.response.ContestCreateResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestDetailResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestOwnedListResponse;
 import net.diveon.backend.domain.contest.dto.response.GroupContestListResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
 import net.diveon.backend.domain.contest.entity.ContestParticipant;
@@ -100,6 +101,13 @@ public class ContestService {
         }).toList();
 
         return new ContestListResponse(contestPage.getTotalElements(), page, contestPage.getTotalPages(), items);
+    }
+
+    // 내가 소유한 대회 목록 조회
+    @Transactional(readOnly = true)
+    public List<ContestOwnedListResponse> getOwnedContests(Long userId) {
+        userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        return contestRepository.findOwnedContestsByUserId(userId);
     }
 
     // 대회 상세 조회

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupCommentResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupCommentResponse.java
@@ -13,7 +13,7 @@ public class GroupCommentResponse {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
     public static class CommentList {
-        @JsonProperty("total_elements")
+        @JsonProperty("totalElements")
         private final long totalElements;
         private final List<CommentListItem> comments;
 
@@ -34,7 +34,7 @@ public class GroupCommentResponse {
     }
 
     public static class CommentListItem {
-        @JsonProperty("comment_id")
+        @JsonProperty("commentId")
         private final Long commentId;
         private final String author;
         private final String content;
@@ -65,7 +65,7 @@ public class GroupCommentResponse {
     }
 
     public static class CommentCreate {
-        @JsonProperty("comment_id")
+        @JsonProperty("commentId")
         private final Long commentId;
 
         public CommentCreate(Long commentId) {

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupPostResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupPostResponse.java
@@ -139,7 +139,7 @@ public class GroupPostResponse {
     }
 
     public static class PostCreate {
-        @JsonProperty("post_id")
+        @JsonProperty("postId")
         private final Long postId;
 
         public PostCreate(Long postId) {


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 대회 문제 추가를 위한, 소유 대회 리스트 제공

## 관련 이슈
Closes #255


<!-- 주석은 제외되고 올라가니 무시하세요 -->
