### PR TITLE
[feat] 프로필 수정 API 구현 (#269)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/controller/ProfileController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/ProfileController.java
@@ -1,11 +1,16 @@
 package net.diveon.backend.domain.user.controller;
 
+import jakarta.validation.Valid;
+import net.diveon.backend.domain.user.dto.PasswordUpdateRequest;
 import net.diveon.backend.domain.user.dto.ProfileShowResponse;
+import net.diveon.backend.domain.user.dto.ProfileUpdateRequest;
 import net.diveon.backend.domain.user.service.ProfileService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,10 +23,29 @@ public class ProfileController {
     public ProfileController(ProfileService profileService) {
         this.profileService = profileService;
     }
-
+    // 프로필 조회
     @GetMapping("/show")
     public ResponseEntity<ApiResponse<ProfileShowResponse>> show(@AuthenticationPrincipal String userId) {
         ProfileShowResponse response = profileService.getProfile(Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("성공", response));
+    }
+
+    // 프로필 수정
+    @PatchMapping
+    public ResponseEntity<ApiResponse<Void>> updateProfile(
+            @AuthenticationPrincipal String userId,
+            @RequestBody ProfileUpdateRequest request) {
+        profileService.updateProfile(Long.parseLong(userId), request);
+        return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다.", null));
+    }
+
+    // 비밀번호 변경
+
+    @PatchMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody PasswordUpdateRequest request) {
+        profileService.updatePassword(Long.parseLong(userId), request);
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다.", null));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.List;
+
 
 
 /**
@@ -40,7 +42,7 @@ public class AuthSignUpRequest {
     private String belong;
 
     @JsonProperty("interest")
-    private String interest;
+    private List<String> interest;
 
     // 수정사항, JavaBeans 표준규격에 맞도록, 생성자, getter와 setter 수정
     // Default constructor for JavaBeans and Jackson
@@ -87,11 +89,11 @@ public class AuthSignUpRequest {
         this.belong = belong;
     }
 
-    public String getInterest() {
+    public List<String> getInterest() {
         return interest;
     }
 
-    public void setInterest(String interest) {
+    public void setInterest(List<String> interest) {
         this.interest = interest;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/user/dto/PasswordUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/PasswordUpdateRequest.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class PasswordUpdateRequest {
+
+    @NotBlank
+    private String currentPassword;
+
+    @NotBlank
+    private String newPassword;
+
+    public String getCurrentPassword() { return currentPassword; }
+    public String getNewPassword() { return newPassword; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/ProfileShowResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/ProfileShowResponse.java
@@ -4,6 +4,8 @@ import net.diveon.backend.domain.user.entity.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 // GET /api/profile/show 응답 DTO
 // User 엔티티에서 필요한 정보만 골라서 클라이언트에 반환함
@@ -27,7 +29,7 @@ public class ProfileShowResponse {
         private final String email;
         private final String phoneNumber;
         private final String belong;
-        private final String interest;
+        private final List<String> interest;
 
         // User 엔티티를 응답 DTO로 변환
         public UserInfo(User user) {
@@ -40,7 +42,7 @@ public class ProfileShowResponse {
             this.email = user.getEmail();
             this.phoneNumber = user.getPhoneNumber();
             this.belong = user.getBelong();
-            this.interest = user.getInterest();
+            this.interest = user.getInterest() == null ? List.of() : Arrays.asList(user.getInterest().split(","));
         }
 
         public String getNickname() { return nickname; }
@@ -52,6 +54,6 @@ public class ProfileShowResponse {
         public String getEmail() { return email; }
         public String getPhoneNumber() { return phoneNumber; }
         public String getBelong() { return belong; }
-        public String getInterest() { return interest; }
+        public List<String> getInterest() { return interest; }
     }
 }

--- a/src/main/java/net/diveon/backend/domain/user/dto/ProfileUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/ProfileUpdateRequest.java
@@ -1,0 +1,20 @@
+package net.diveon.backend.domain.user.dto;
+
+import java.util.List;
+
+public class ProfileUpdateRequest {
+
+    private String nickname;
+    private String selfComment;
+    private String email;
+    private String phoneNumber;
+    private String belong;
+    private List<String> interest;
+
+    public String getNickname() { return nickname; }
+    public String getSelfComment() { return selfComment; }
+    public String getEmail() { return email; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public String getBelong() { return belong; }
+    public List<String> getInterest() { return interest; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Table;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "domain_user")
@@ -66,16 +67,29 @@ public class User {
 
     public User() {}
 
-    public User(String loginId, String password, String nickname, String email, String belong, String interest) {
+    public User(String loginId, String password, String nickname, String email, String belong, List<String> interest) {
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
         this.email = email;
         this.belong = belong;
-        this.interest = interest;
+        this.interest = interest == null ? null : String.join(",", interest);
         this.createdAt = LocalDateTime.now();
         this.tier = 0;
         this.score = 0;
+    }
+
+    public void updateProfile(String nickname, String comment, String email, String phoneNumber, String belong, List<String> interest) {
+        if (nickname != null) this.nickname = nickname;
+        if (comment != null) this.comment = comment;
+        if (email != null) this.email = email;
+        if (phoneNumber != null) this.phoneNumber = phoneNumber;
+        if (belong != null) this.belong = belong;
+        if (interest != null) this.interest = String.join(",", interest);
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
     }
 
     public Long getId() { return id; }

--- a/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
@@ -1,27 +1,55 @@
 package net.diveon.backend.domain.user.service;
 
+import net.diveon.backend.domain.user.dto.PasswordUpdateRequest;
 import net.diveon.backend.domain.user.dto.ProfileShowResponse;
+import net.diveon.backend.domain.user.dto.ProfileUpdateRequest;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.InvalidCredentialsException;
 import net.diveon.backend.global.exception.UserNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 // 프로필 수정 API 구현할 때 이 파일에 메서드 추가할 것임
 @Service
 public class ProfileService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public ProfileService(UserRepository userRepository) {
+    public ProfileService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
-    // userId로 유저 조회 후 ProfileShowResponse로 변환하여 반환
-    // 유저가 없으면 UserNotFoundException → 404
     public ProfileShowResponse getProfile(long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-
         return new ProfileShowResponse(new ProfileShowResponse.UserInfo(user));
+    }
+
+    @Transactional
+    public void updateProfile(Long userId, ProfileUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        user.updateProfile(
+                request.getNickname(),
+                request.getSelfComment(),
+                request.getEmail(),
+                request.getPhoneNumber(),
+                request.getBelong(),
+                request.getInterest()
+        );
+    }
+
+    @Transactional
+    public void updatePassword(Long userId, PasswordUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new InvalidCredentialsException();
+        }
+        user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
@@ -70,7 +70,7 @@ public class UserSignUpService {
         //수정사항 04.08 dto가 변경되면서 수정
         User newUser = new User(
             signup_request.getLoginId(),
-            encodedPassword, 
+            encodedPassword,
             signup_request.getNickname(),
             signup_request.getEmail(),
             signup_request.getBelong(),


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- PATCH /api/profile — 프로필 수정 (nickname, selfComment, email, phoneNumber, belong, interest)
- PATCH /api/profile/password — 비밀번호 변경 (현재 비밀번호 확인 후 변경)
- 회원가입/프로필 조회 interest 타입 변경: String → List<String>

## 관련 이슈
Closes #269



<!-- 주석은 제외되고 올라가니 무시하세요 -->
