### PR TITLE
[FIX] add contest submission/polling/result/scoreboard API(#271)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestController.java
@@ -25,8 +25,12 @@ import net.diveon.backend.domain.contest.dto.response.ContestJoinResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestListResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestOwnedListResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestRankingResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestSubmissionResultResponse;
+import net.diveon.backend.domain.contest.dto.response.ContestSubmissionStatusResponse;
 import net.diveon.backend.domain.contest.service.ContestRankingService;
 import net.diveon.backend.domain.contest.service.ContestService;
+import net.diveon.backend.domain.contest.service.ContestSubmissionResultService;
+import net.diveon.backend.domain.contest.service.ContestSubmissionStatusService;
 import net.diveon.backend.domain.contest.service.ContestSubmitService;
 import net.diveon.backend.global.response.ApiResponse;
 
@@ -37,12 +41,18 @@ public class ContestController {
     private final ContestService contestService;
     private final ContestSubmitService contestSubmitService;
     private final ContestRankingService contestRankingService;
+    private final ContestSubmissionStatusService contestSubmissionStatusService;
+    private final ContestSubmissionResultService contestSubmissionResultService;
 
     public ContestController(ContestService contestService, ContestSubmitService contestSubmitService,
-                             ContestRankingService contestRankingService) {
+                             ContestRankingService contestRankingService,
+                             ContestSubmissionStatusService contestSubmissionStatusService,
+                             ContestSubmissionResultService contestSubmissionResultService) {
         this.contestService = contestService;
         this.contestSubmitService = contestSubmitService;
         this.contestRankingService = contestRankingService;
+        this.contestSubmissionStatusService = contestSubmissionStatusService;
+        this.contestSubmissionResultService = contestSubmissionResultService;
     }
 
     // 대회 목록 조회
@@ -140,5 +150,27 @@ public class ContestController {
             @AuthenticationPrincipal String userId,
             @Valid @RequestBody ContestSubmitRequest request) {
         return contestSubmitService.submitContestProblem(contestId, contestProblemId, Long.parseLong(userId), request);
+    }
+
+    // 채점 상태 조회 (CODING 전용 polling)
+    @GetMapping("/{contestId}/submissions/{submissionId}/status")
+    public ResponseEntity<ApiResponse<ContestSubmissionStatusResponse>> getSubmissionStatus(
+            @PathVariable Long contestId,
+            @PathVariable Long submissionId,
+            @AuthenticationPrincipal String userId) {
+        ContestSubmissionStatusResponse response = contestSubmissionStatusService
+                .getStatus(contestId, submissionId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("채점 상태 조회에 성공하였습니다.", response));
+    }
+
+    // 제출 코드 조회 (CODING 전용)
+    @GetMapping("/{contestId}/submissions/{submissionId}/result")
+    public ResponseEntity<ApiResponse<ContestSubmissionResultResponse>> getSubmissionResult(
+            @PathVariable Long contestId,
+            @PathVariable Long submissionId,
+            @AuthenticationPrincipal String userId) {
+        ContestSubmissionResultResponse response = contestSubmissionResultService
+                .getResult(contestId, submissionId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("제출 코드 조회에 성공하였습니다.", response));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmissionResultResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmissionResultResponse.java
@@ -1,0 +1,27 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ContestSubmissionResultResponse {
+
+    @JsonProperty("submissionId")
+    private Long submissionId;
+
+    @JsonProperty("language")
+    private String language;
+
+    @JsonProperty("code")
+    private String code;
+
+    public ContestSubmissionResultResponse() {}
+
+    public ContestSubmissionResultResponse(Long submissionId, String language, String code) {
+        this.submissionId = submissionId;
+        this.language = language;
+        this.code = code;
+    }
+
+    public Long getSubmissionId() { return submissionId; }
+    public String getLanguage() { return language; }
+    public String getCode() { return code; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmissionStatusResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmissionStatusResponse.java
@@ -1,0 +1,54 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ContestSubmissionStatusResponse {
+
+    @JsonProperty("submissionId")
+    private Long submissionId;
+
+    @JsonProperty("submissionStatus")
+    private String submissionStatus;
+
+    @JsonProperty("progress")
+    private Integer progress;
+
+    @JsonProperty("isCorrect")
+    private Boolean isCorrect;
+
+    @JsonProperty("score")
+    private Integer score;
+
+    @JsonProperty("rank")
+    private Integer rank;
+
+    public ContestSubmissionStatusResponse() {}
+
+    public static ContestSubmissionStatusResponse pending(Long submissionId, String status, int progress) {
+        ContestSubmissionStatusResponse r = new ContestSubmissionStatusResponse();
+        r.submissionId = submissionId;
+        r.submissionStatus = status;
+        r.progress = progress;
+        return r;
+    }
+
+    public static ContestSubmissionStatusResponse completed(Long submissionId, boolean isCorrect, int score, int rank) {
+        ContestSubmissionStatusResponse r = new ContestSubmissionStatusResponse();
+        r.submissionId = submissionId;
+        r.submissionStatus = "COMPLETED";
+        r.progress = 100;
+        r.isCorrect = isCorrect;
+        r.score = score;
+        r.rank = rank;
+        return r;
+    }
+
+    public Long getSubmissionId() { return submissionId; }
+    public String getSubmissionStatus() { return submissionStatus; }
+    public Integer getProgress() { return progress; }
+    public Boolean getIsCorrect() { return isCorrect; }
+    public Integer getScore() { return score; }
+    public Integer getRank() { return rank; }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitAsyncResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitAsyncResponse.java
@@ -7,16 +7,16 @@ public class ContestSubmitAsyncResponse {
     @JsonProperty("submissionId")
     private Long submissionId;
 
-    @JsonProperty("status")
-    private String status;
+    @JsonProperty("submissionStatus")
+    private String submissionStatus;
 
     public ContestSubmitAsyncResponse() {}
 
-    public ContestSubmitAsyncResponse(Long submissionId, String status) {
+    public ContestSubmitAsyncResponse(Long submissionId, String submissionStatus) {
         this.submissionId = submissionId;
-        this.status = status;
+        this.submissionStatus = submissionStatus;
     }
 
     public Long getSubmissionId() { return submissionId; }
-    public String getStatus() { return status; }
+    public String getSubmissionStatus() { return submissionStatus; }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitImmediateResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestSubmitImmediateResponse.java
@@ -4,19 +4,34 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ContestSubmitImmediateResponse {
 
+    @JsonProperty("submissionId")
+    private Long submissionId;
+
+    @JsonProperty("submissionStatus")
+    private String submissionStatus;
+
     @JsonProperty("isCorrect")
     private Boolean isCorrect;
 
     @JsonProperty("score")
     private Integer score;
 
+    @JsonProperty("rank")
+    private Integer rank;
+
     public ContestSubmitImmediateResponse() {}
 
-    public ContestSubmitImmediateResponse(Boolean isCorrect, Integer score) {
+    public ContestSubmitImmediateResponse(Long submissionId, Boolean isCorrect, Integer score, Integer rank) {
+        this.submissionId = submissionId;
+        this.submissionStatus = "COMPLETED";
         this.isCorrect = isCorrect;
         this.score = score;
+        this.rank = rank;
     }
 
+    public Long getSubmissionId() { return submissionId; }
+    public String getSubmissionStatus() { return submissionStatus; }
     public Boolean getIsCorrect() { return isCorrect; }
     public Integer getScore() { return score; }
+    public Integer getRank() { return rank; }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmissionResultService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmissionResultService.java
@@ -1,0 +1,51 @@
+package net.diveon.backend.domain.contest.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.contest.dto.response.ContestSubmissionResultResponse;
+import net.diveon.backend.domain.contest.entity.ContestSubmission;
+import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
+import net.diveon.backend.domain.grade.entity.SolveSubmissionCoding;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionCodingRepository;
+import net.diveon.backend.global.exception.ContestNotFoundException;
+import net.diveon.backend.global.exception.SubmissionAccessDeniedException;
+import net.diveon.backend.global.exception.SubmissionNotFoundException;
+
+@Service
+public class ContestSubmissionResultService {
+
+    private final ContestSubmissionRepository contestSubmissionRepository;
+    private final SolveSubmissionCodingRepository solveSubmissionCodingRepository;
+
+    public ContestSubmissionResultService(
+            ContestSubmissionRepository contestSubmissionRepository,
+            SolveSubmissionCodingRepository solveSubmissionCodingRepository) {
+        this.contestSubmissionRepository = contestSubmissionRepository;
+        this.solveSubmissionCodingRepository = solveSubmissionCodingRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ContestSubmissionResultResponse getResult(Long contestId, Long submissionId, Long userId) {
+        ContestSubmission submission = contestSubmissionRepository.findById(submissionId)
+                .orElseThrow(SubmissionNotFoundException::new);
+
+        if (!submission.getUser().getId().equals(userId)) {
+            throw new SubmissionAccessDeniedException();
+        }
+
+        if (!submission.getContest().getId().equals(contestId)) {
+            throw new ContestNotFoundException();
+        }
+
+        if (submission.getSolveSubmission() == null) {
+            throw new SubmissionNotFoundException();
+        }
+
+        SolveSubmissionCoding coding = solveSubmissionCodingRepository
+                .findById(submission.getSolveSubmission().getId())
+                .orElseThrow(SubmissionNotFoundException::new);
+
+        return new ContestSubmissionResultResponse(submissionId, coding.getLanguage(), coding.getAnswer());
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmissionStatusService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmissionStatusService.java
@@ -1,0 +1,87 @@
+package net.diveon.backend.domain.contest.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.contest.dto.response.ContestSubmissionStatusResponse;
+import net.diveon.backend.domain.contest.entity.ContestSubmission;
+import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
+import net.diveon.backend.global.exception.ContestNotFoundException;
+import net.diveon.backend.global.exception.SubmissionAccessDeniedException;
+import net.diveon.backend.global.exception.SubmissionNotFoundException;
+
+@Service
+public class ContestSubmissionStatusService {
+
+    private final ContestSubmissionRepository contestSubmissionRepository;
+    private final StringRedisTemplate redisTemplate;
+    private final JdbcTemplate jdbcTemplate;
+
+    public ContestSubmissionStatusService(
+            ContestSubmissionRepository contestSubmissionRepository,
+            StringRedisTemplate redisTemplate,
+            JdbcTemplate jdbcTemplate) {
+        this.contestSubmissionRepository = contestSubmissionRepository;
+        this.redisTemplate = redisTemplate;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Transactional(readOnly = true)
+    public ContestSubmissionStatusResponse getStatus(Long contestId, Long submissionId, Long userId) {
+        ContestSubmission submission = contestSubmissionRepository.findById(submissionId)
+                .orElseThrow(SubmissionNotFoundException::new);
+
+        if (!submission.getUser().getId().equals(userId)) {
+            throw new SubmissionAccessDeniedException();
+        }
+
+        if (!submission.getContest().getId().equals(contestId)) {
+            throw new ContestNotFoundException();
+        }
+
+        String status = submission.getSubmissionStatus();
+
+        if ("COMPLETED".equals(status)) {
+            boolean isCorrect = Boolean.TRUE.equals(submission.getIsCorrect());
+            int score = submission.getContest() != null
+                    ? getParticipantScore(contestId, userId)
+                    : 0;
+            int rank = getRank(contestId, userId, score);
+            return ContestSubmissionStatusResponse.completed(submissionId, isCorrect, score, rank);
+        }
+
+        return ContestSubmissionStatusResponse.pending(submissionId, status, calculateProgress(status));
+    }
+
+    private int getParticipantScore(Long contestId, Long userId) {
+        Integer score = jdbcTemplate.queryForObject(
+                "SELECT score FROM contest_participant WHERE contest_id = ? AND user_id = ?",
+                Integer.class, contestId, userId);
+        return score != null ? score : 0;
+    }
+
+    private int getRank(Long contestId, Long userId, int score) {
+        try {
+            Long zeroBasedRank = redisTemplate.opsForZSet()
+                    .reverseRank("scoreboard:" + contestId, String.valueOf(userId));
+            if (zeroBasedRank != null) {
+                return zeroBasedRank.intValue() + 1;
+            }
+        } catch (Exception ignored) {}
+        Integer higherCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM contest_participant WHERE contest_id = ? AND score > ?",
+                Integer.class, contestId, score);
+        return (higherCount != null ? higherCount : 0) + 1;
+    }
+
+    private int calculateProgress(String status) {
+        return switch (status) {
+            case "PENDING" -> 0;
+            case "JUDGING" -> 50;
+            case "COMPLETED" -> 100;
+            default -> 0;
+        };
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestSubmitServiceImpl.java
@@ -160,19 +160,16 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
             throw new IllegalArgumentException("유효한 숫자를 입력해주세요.");
         }
 
-        int scoreToAdd = 0;
+        ContestParticipant participant = contestParticipantRepository
+                .findByContestIdAndUserId(contest.getId(), user.getId()).get();
 
         if (isCorrect) {
             List<Long> solvedProblems = contestSubmissionRepository
                     .findSolvedContestProblemIds(contest.getId(), user.getId());
 
             if (!solvedProblems.contains(contestProblem.getId())) {
-                scoreToAdd = contestProblem.getPoints();
                 LocalDateTime now = LocalDateTime.now();
-                ContestParticipant participant = contestParticipantRepository
-                        .findByContestIdAndUserId(contest.getId(), user.getId())
-                        .get();
-                participant.addScore(scoreToAdd, now);
+                participant.addScore(contestProblem.getPoints(), now);
                 contestParticipantRepository.save(participant);
 
                 jdbcTemplate.update("UPDATE problem_summary SET solved_count = solved_count + 1 WHERE id = ?", problem.getId());
@@ -180,15 +177,18 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
             }
         }
 
+        int currentRank = getRank(contest.getId(), user.getId(), participant.getScore());
+
         ContestSubmission submission = new ContestSubmission(contest, contestProblem, user);
         submission.updateResult(isCorrect);
-        contestSubmissionRepository.save(submission);
+        ContestSubmission savedSubmission = contestSubmissionRepository.save(submission);
 
         jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
         setCooldown(contest.getId(), user.getId(), contestProblem.getId());
 
-        ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(isCorrect, scoreToAdd);
-        return ResponseEntity.ok(ApiResponse.success("제출이 완료되었습니다.", response));
+        ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(
+                savedSubmission.getId(), isCorrect, participant.getScore(), currentRank);
+        return ResponseEntity.ok(ApiResponse.success("채점 요청이 접수되었습니다.", response));
     }
 
     @Transactional
@@ -211,19 +211,16 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
         String userAnswerHash = hashFlag(userAnswer);
         boolean isCorrect = userAnswerHash.equals(flagHash);
 
-        int scoreToAdd = 0;
+        ContestParticipant participant = contestParticipantRepository
+                .findByContestIdAndUserId(contest.getId(), user.getId()).get();
 
         if (isCorrect) {
             List<Long> solvedProblems = contestSubmissionRepository
                     .findSolvedContestProblemIds(contest.getId(), user.getId());
 
             if (!solvedProblems.contains(contestProblem.getId())) {
-                scoreToAdd = contestProblem.getPoints();
                 LocalDateTime now = LocalDateTime.now();
-                ContestParticipant participant = contestParticipantRepository
-                        .findByContestIdAndUserId(contest.getId(), user.getId())
-                        .get();
-                participant.addScore(scoreToAdd, now);
+                participant.addScore(contestProblem.getPoints(), now);
                 contestParticipantRepository.save(participant);
 
                 jdbcTemplate.update("UPDATE problem_summary SET solved_count = solved_count + 1 WHERE id = ?", problem.getId());
@@ -231,15 +228,18 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
             }
         }
 
+        int currentRank = getRank(contest.getId(), user.getId(), participant.getScore());
+
         ContestSubmission submission = new ContestSubmission(contest, contestProblem, user);
         submission.updateResult(isCorrect);
-        contestSubmissionRepository.save(submission);
+        ContestSubmission savedSubmission = contestSubmissionRepository.save(submission);
 
         jdbcTemplate.update("UPDATE problem_summary SET submitted_count = submitted_count + 1 WHERE id = ?", problem.getId());
         setCooldown(contest.getId(), user.getId(), contestProblem.getId());
 
-        ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(isCorrect, scoreToAdd);
-        return ResponseEntity.ok(ApiResponse.success("제출이 완료되었습니다.", response));
+        ContestSubmitImmediateResponse response = new ContestSubmitImmediateResponse(
+                savedSubmission.getId(), isCorrect, participant.getScore(), currentRank);
+        return ResponseEntity.ok(ApiResponse.success("채점 요청이 접수되었습니다.", response));
     }
 
     @Transactional
@@ -284,6 +284,20 @@ public class ContestSubmitServiceImpl implements ContestSubmitService {
     private void setCooldown(Long contestId, Long userId, Long contestProblemId) {
         String key = "contest:" + contestId + ":cooldown:" + userId + ":" + contestProblemId;
         redisTemplate.opsForValue().set(key, "1", 30, TimeUnit.SECONDS);
+    }
+
+    private int getRank(Long contestId, Long userId, int score) {
+        try {
+            Long zeroBasedRank = redisTemplate.opsForZSet()
+                    .reverseRank("scoreboard:" + contestId, String.valueOf(userId));
+            if (zeroBasedRank != null) {
+                return zeroBasedRank.intValue() + 1;
+            }
+        } catch (Exception ignored) {}
+        Integer higherCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM contest_participant WHERE contest_id = ? AND score > ?",
+                Integer.class, contestId, score);
+        return (higherCount != null ? higherCount : 0) + 1;
     }
 
     private void updateScoreboard(Long contestId, Long userId, int newTotalScore, LocalDateTime solvedAt) {

--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionStatusService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionStatusService.java
@@ -1,12 +1,8 @@
 package net.diveon.backend.domain.grade.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import net.diveon.backend.domain.contest.entity.ContestSubmission;
-import net.diveon.backend.domain.contest.repository.ContestSubmissionRepository;
 import net.diveon.backend.domain.grade.dto.response.SubmissionStatusResponse;
 import net.diveon.backend.domain.grade.entity.SolveSubmission;
 import net.diveon.backend.domain.grade.entity.SolveSubmission.SubmissionState;
@@ -18,48 +14,27 @@ import net.diveon.backend.global.exception.SubmissionNotFoundException;
 public class SubmissionStatusService {
 
     private final SolveSubmissionRepository solveSubmissionRepository;
-    private final ContestSubmissionRepository contestSubmissionRepository;
 
-    public SubmissionStatusService(SolveSubmissionRepository solveSubmissionRepository,
-                                   ContestSubmissionRepository contestSubmissionRepository) {
+    public SubmissionStatusService(SolveSubmissionRepository solveSubmissionRepository) {
         this.solveSubmissionRepository = solveSubmissionRepository;
-        this.contestSubmissionRepository = contestSubmissionRepository;
     }
 
     @Transactional(readOnly = true)
     public SubmissionStatusResponse getStatus(Long userId, Long submissionId) {
-        // 일반 제출 먼저 조회
-        Optional<SolveSubmission> solveSubmission = solveSubmissionRepository.findById(submissionId);
-        if (solveSubmission.isPresent()) {
-            SolveSubmission submission = solveSubmission.get();
-            if (!submission.getUser().getId().equals(userId)) {
-                throw new SubmissionAccessDeniedException();
-            }
-            SubmissionState state = submission.getSubmissionState();
-            return new SubmissionStatusResponse(
-                String.valueOf(submission.getId()),
-                submission.getProblem().getId(),
-                submission.getProblem().getType(),
-                state.name(),
-                calculateProgress(state.name())
-            );
-        }
-
-        // 대회 제출 fallback (contest_submission.id로 polling하는 경우)
-        ContestSubmission contestSubmission = contestSubmissionRepository.findById(submissionId)
+        SolveSubmission submission = solveSubmissionRepository.findById(submissionId)
             .orElseThrow(SubmissionNotFoundException::new);
 
-        if (!contestSubmission.getUser().getId().equals(userId)) {
+        if (!submission.getUser().getId().equals(userId)) {
             throw new SubmissionAccessDeniedException();
         }
 
-        String status = contestSubmission.getSubmissionStatus();
+        SubmissionState state = submission.getSubmissionState();
         return new SubmissionStatusResponse(
-            String.valueOf(contestSubmission.getId()),
-            contestSubmission.getContestProblem().getProblem().getId(),
-            contestSubmission.getContestProblem().getProblem().getType(),
-            status,
-            calculateProgress(status)
+            String.valueOf(submission.getId()),
+            submission.getProblem().getId(),
+            submission.getProblem().getType(),
+            state.name(),
+            calculateProgress(state.name())
         );
     }
 


### PR DESCRIPTION
- add POST /api/contests/{contestId}/problems/{contestProblemId}/submit
  - support OBJECTIVE, PRACTICE (sync, 200), CODING (async, 202)
  - common validation: ongoing check, participant check, ban check, cooldown check
  - score/rank update before COMPLETED status for transaction safety
  - Redis ZADD for scoreboard, ZREVRANK for rank response

- add GET /api/contests/{contestId}/submissions/{submissionId}/status
  - polling API for CODING submission (separated from existing /api/submissions/{submissionId}/status)
  - include isCorrect, score, rank on COMPLETED

- add GET /api/contests/{contestId}/submissions/{submissionId}/result
  - return submitted code and language for CODING type only

- add GET /api/contests/{contestId}/rankings
  - ongoing: Redis ZREVRANGEWITHSCORES, fallback to DB on Redis failure
  - ended: DB direct query (contest_participant ORDER BY score DESC, last_solved_at ASC)

- modify CodingGradeMessage: add contestContext field (null = normal, non-null = contest)
- modify CodingGradeQueueServiceImpl: add sendContestGradingMessage method
- modify grader worker: add contest result branch in process()
  - fix update order: score/last_solved_at → Redis → submission COMPLETED

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 

## 관련 이슈
Closes #


<!-- 주석은 제외되고 올라가니 무시하세요 -->
