### PR TITLE
[feat] 아이디/닉네임 중복 확인 API 구현 (#284)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/controller/UserController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/UserController.java
@@ -8,9 +8,11 @@ import net.diveon.backend.domain.user.service.UserSignUpService;
 import net.diveon.backend.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,9 +21,24 @@ public class UserController {
 
     private final UserService userService;
     private final UserSignUpService userSignUpService;
+
     public UserController(UserService userService, UserSignUpService userSignUpService) {
         this.userService = userService;
         this.userSignUpService = userSignUpService;
+    }
+
+    @GetMapping("/check-loginId")
+    public ResponseEntity<ApiResponse<Boolean>> checkLoginId(@RequestParam String loginId) {
+        boolean available = userSignUpService.isLoginIdAvailable(loginId);
+        String message = available ? "사용 가능한 아이디입니다." : "이미 사용 중인 아이디입니다.";
+        return ResponseEntity.ok(ApiResponse.success(message, available));
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<ApiResponse<Boolean>> checkNickname(@RequestParam String nickname) {
+        boolean available = userSignUpService.isNicknameAvailable(nickname);
+        String message = available ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다.";
+        return ResponseEntity.ok(ApiResponse.success(message, available));
     }
 
     @PostMapping("/login")

--- a/src/main/java/net/diveon/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
@@ -44,7 +44,14 @@ public class UserSignUpService {
      * @param signup_request
      * @return boolen
      */
-    // 수정사항 - 04.18 - 안상완 - 표준 에러 출력을 위해, 기존의 boolean 반환에서 exception throw로 변경
+    public boolean isLoginIdAvailable(String loginId) {
+        return !userRepository.existsByLoginId(loginId);
+    }
+
+    public boolean isNicknameAvailable(String nickname) {
+        return !userRepository.existsByNickname(nickname);
+    }
+
     public void signup(AuthSignUpRequest signup_request){
 
 


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- GET /api/auth/check-loginId?loginId={loginId} 구현
- GET /api/auth/check-nickname?nickname={nickname} 구현
- UserRepository에 existsByNickname 추가
- data: true면 사용 가능, false면 중복

## 관련 이슈
Closes #284


<!-- 주석은 제외되고 올라가니 무시하세요 -->
