### PR TITLE
[feat] User 이메일 컬럼 unique 제약 추가 (#286)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -41,7 +41,7 @@ public class User {
     @Column(name = "birthday")
     private LocalDate birthday;
 
-    @Column(name = "email")
+    @Column(name = "email", unique = true)
     private String email;
 
     @Column(name = "phone_number")


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- User 엔티티 email 컬럼에 unique = true 추가
- 이메일 1계정 1개 제한 (중복 가입 방지)

## 관련 이슈
Closes #286 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
