### PR TITLE
[feat] User sex 컬럼 제거 (#288)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -56,9 +56,6 @@ public class User {
     @Column(name = "score", nullable = false)
     private Integer score;
 
-    @Column(name = "sex", length = 1)
-    private String sex;
-
     @Column(name = "belong")
     private String belong;
 
@@ -105,7 +102,6 @@ public class User {
     public String getComment() { return comment; }
     public Integer getTier() { return tier; }
     public Integer getScore() { return score; }
-    public String getSex() { return sex; }
     public String getBelong() { return belong; }
     public String getInterest() { return interest; }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->
사용되지 않는 sex 필드 제거

- User 엔티티에서 sex 필드 및 getSex() 제거
- DB 컬럼은 직접 실행 필요: ALTER TABLE domain_user DROP COLUMN sex

## 관련 이슈
Closes #288

<!-- 주석은 제외되고 올라가니 무시하세요 -->
