### PR TITLE
[fix] 대회 시작/종료 시간 유효성 검증 추가 (#291)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestUpdateRequest.java
@@ -13,10 +13,8 @@ public class ContestUpdateRequest {
     @NotBlank
     private String description;
 
-    @NotNull
     private LocalDateTime startTime;
 
-    @NotNull
     private LocalDateTime endTime;
 
     public String getTitle() { return title; }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -167,10 +167,10 @@ public class ContestService {
     // 대회 생성
     @Transactional
     private void validateContestTime(LocalDateTime startTime, LocalDateTime endTime) {
-        if (startTime != null && !startTime.isAfter(LocalDateTime.now())) {
+        if (!startTime.isAfter(LocalDateTime.now())) {
             throw new InvalidContestTimeException("시작 시간은 현재 시간보다 나중이어야 합니다.");
         }
-        if (startTime != null && endTime != null && !endTime.isAfter(startTime)) {
+        if (!endTime.isAfter(startTime)) {
             throw new InvalidContestTimeException("종료 시간은 시작 시간보다 나중이어야 합니다.");
         }
     }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestService.java
@@ -38,6 +38,7 @@ import net.diveon.backend.global.exception.ContestAlreadyParticipatedException;
 import net.diveon.backend.global.exception.ContestAlreadyStartedException;
 import net.diveon.backend.global.exception.ContestNotFoundException;
 import net.diveon.backend.global.exception.ContestParticipantNotFoundException;
+import net.diveon.backend.global.exception.InvalidContestTimeException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 
 @Service
@@ -165,7 +166,17 @@ public class ContestService {
 
     // 대회 생성
     @Transactional
+    private void validateContestTime(LocalDateTime startTime, LocalDateTime endTime) {
+        if (startTime != null && !startTime.isAfter(LocalDateTime.now())) {
+            throw new InvalidContestTimeException("시작 시간은 현재 시간보다 나중이어야 합니다.");
+        }
+        if (startTime != null && endTime != null && !endTime.isAfter(startTime)) {
+            throw new InvalidContestTimeException("종료 시간은 시작 시간보다 나중이어야 합니다.");
+        }
+    }
+
     public ContestCreateResponse createContest(Long userId, ContestCreateRequest request) {
+        validateContestTime(request.getStartTime(), request.getEndTime());
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         Group group = null;
@@ -244,7 +255,10 @@ public class ContestService {
         contest.updateTitleAndDescription(request.getTitle(), request.getDescription());
 
         if (contest.getStatus() == Contest.ContestStatus.UPCOMING) {
-            contest.updateTime(request.getStartTime(), request.getEndTime());
+            LocalDateTime newStartTime = request.getStartTime() != null ? request.getStartTime() : contest.getStartTime();
+            LocalDateTime newEndTime = request.getEndTime() != null ? request.getEndTime() : contest.getEndTime();
+            validateContestTime(newStartTime, newEndTime);
+            contest.updateTime(newStartTime, newEndTime);
         }
     }
 

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -7,9 +7,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-
-// 수정사항 2024.04.18 - 안상완, 코드가 들여쓰기가 왜인지는 모르겠는데 다른곳보다 조금씩 큰데,
-// 그래서 반칸씩 떨어져 있던것을, 한칸씩 들여쓰기에 맞게 수정함.
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -501,6 +498,20 @@ public class GlobalExceptionHandler {
                         request.getRequestURI()
                 );
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
+
+        // 대회 시간 유효하지 않음 → 400
+        @ExceptionHandler(InvalidContestTimeException.class)
+        public ResponseEntity<ErrorResponse> handleInvalidContestTime(
+                InvalidContestTimeException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/invalid-contest-time",
+                        "Bad Request",
+                        400,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
         }
 
         // 쿨다운 중 → 409

--- a/src/main/java/net/diveon/backend/global/exception/InvalidContestTimeException.java
+++ b/src/main/java/net/diveon/backend/global/exception/InvalidContestTimeException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class InvalidContestTimeException extends RuntimeException {
+    public InvalidContestTimeException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
잘못된 시간으로 대회 생성/수정 불가하도록 검증 추가

- 시작 시간이 현재 시간 이하면 400 반환
- 종료 시간이 시작 시간 이하면 400 반환
- 생성 및 시작 전(UPCOMING) 수정 시 모두 적용
- 수정 시 시간 미입력이면 기존 값 유지 (startTime, endTime 선택 필드로 변경)
- InvalidContestTimeException 추가

## 관련 이슈
Closes #291


## 관련 이슈
Closes #


<!-- 주석은 제외되고 올라가니 무시하세요 -->
