### PR TITLE
[feat] 이메일 인증, 아이디/비밀번호 찾기 API 구현 (#295)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,9 @@ dependencies {
 	// S3 업로드
 	implementation 'software.amazon.awssdk:s3:2.26.31'
 
-	// SES 이메일 발송  ← 추가
+	// SES 이메일 발송
 	implementation 'software.amazon.awssdk:ses:2.26.31'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	
 	// 커스텀 설정값 자동완성
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestUpdateRequest.java
@@ -3,7 +3,6 @@ package net.diveon.backend.domain.contest.dto.request;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public class ContestUpdateRequest {
 

--- a/src/main/java/net/diveon/backend/domain/user/controller/EmailVerifyController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/EmailVerifyController.java
@@ -1,0 +1,54 @@
+package net.diveon.backend.domain.user.controller;
+
+import jakarta.validation.Valid;
+import net.diveon.backend.domain.user.dto.EmailSendRequest;
+import net.diveon.backend.domain.user.dto.EmailVerifyRequest;
+import net.diveon.backend.domain.user.dto.PasswordResetRequest;
+import net.diveon.backend.domain.user.service.EmailService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/email")
+public class EmailVerifyController {
+
+    private final EmailService emailService;
+
+    public EmailVerifyController(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @PostMapping("/send")
+    public ResponseEntity<ApiResponse<Void>> send(@Valid @RequestBody EmailSendRequest request) {
+        emailService.sendVerificationCode(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success("인증 코드가 발송되었습니다.", null));
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<ApiResponse<Void>> verify(@Valid @RequestBody EmailVerifyRequest request) {
+        emailService.verifyCode(request.getEmail(), request.getCode());
+        return ResponseEntity.ok(ApiResponse.success("이메일 인증이 완료되었습니다.", null));
+    }
+
+    @PostMapping("/find-id")
+    public ResponseEntity<ApiResponse<Void>> findId(@Valid @RequestBody EmailSendRequest request) {
+        emailService.sendLoginId(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success("이메일로 아이디를 발송했습니다.", null));
+    }
+
+    @PostMapping("/send-reset")
+    public ResponseEntity<ApiResponse<Void>> sendReset(@Valid @RequestBody EmailSendRequest request) {
+        emailService.sendPasswordResetCode(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success("비밀번호 재설정 인증 코드를 발송했습니다.", null));
+    }
+
+    @PostMapping("/password/reset")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody PasswordResetRequest request) {
+        emailService.resetPassword(request.getEmail(), request.getNewPassword());
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다.", null));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
@@ -2,27 +2,14 @@ package net.diveon.backend.domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
-
-
-/**
- * <pre>
- * 회원 가입 요청시 사용할 api 요청의 body의 JSON에 대응하기 위한 dto 클래스.
- * 현재 회원 가입 기능의 request body는 다음과 같음
- * {
-    "email": "{{userEmailAddrInput}}",
-    "loginId": "{{userIdInput}}",
-    "password": "{{userPwInput}}",
-    "nickname": "{{userNicknameInpu}}",
-    "belong": "{{userBelongInput}}", 
-    "interest": "{{userInterestInput}}" 
-    }
- * </pre>
- */
 public class AuthSignUpRequest {
+    @NotBlank
+    @Email
     @JsonProperty("email")
     private String email;
 
@@ -44,56 +31,23 @@ public class AuthSignUpRequest {
     @JsonProperty("interest")
     private List<String> interest;
 
-    // 수정사항, JavaBeans 표준규격에 맞도록, 생성자, getter와 setter 수정
-    // Default constructor for JavaBeans and Jackson
     public AuthSignUpRequest() {}
 
-    // Getters and Setters
-    public String getEmail() {
-        return email;
-    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
 
-    public void setEmail(String email) {
-        this.email = email;
-    }
+    public String getLoginId() { return loginId; }
+    public void setLoginId(String loginId) { this.loginId = loginId; }
 
-    public String getLoginId() {
-        return loginId;
-    }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
 
-    public void setLoginId(String loginId) {
-        this.loginId = loginId;
-    }
+    public String getNickname() { return nickname; }
+    public void setNickname(String nickname) { this.nickname = nickname; }
 
-    public String getPassword() {
-        return password;
-    }
+    public String getBelong() { return belong; }
+    public void setBelong(String belong) { this.belong = belong; }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getNickname() {
-        return nickname;
-    }
-
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public String getBelong() {
-        return belong;
-    }
-
-    public void setBelong(String belong) {
-        this.belong = belong;
-    }
-
-    public List<String> getInterest() {
-        return interest;
-    }
-
-    public void setInterest(List<String> interest) {
-        this.interest = interest;
-    }
+    public List<String> getInterest() { return interest; }
+    public void setInterest(List<String> interest) { this.interest = interest; }
 }

--- a/src/main/java/net/diveon/backend/domain/user/dto/EmailSendRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/EmailSendRequest.java
@@ -1,0 +1,13 @@
+package net.diveon.backend.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class EmailSendRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    public String getEmail() { return email; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/EmailVerifyRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/EmailVerifyRequest.java
@@ -1,0 +1,17 @@
+package net.diveon.backend.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class EmailVerifyRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String code;
+
+    public String getEmail() { return email; }
+    public String getCode() { return code; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/PasswordResetRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/PasswordResetRequest.java
@@ -1,0 +1,17 @@
+package net.diveon.backend.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class PasswordResetRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String newPassword;
+
+    public String getEmail() { return email; }
+    public String getNewPassword() { return newPassword; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/ProfileShowResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/ProfileShowResponse.java
@@ -2,13 +2,10 @@ package net.diveon.backend.domain.user.dto;
 
 import net.diveon.backend.domain.user.entity.User;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-// GET /api/profile/show 응답 DTO
-// User 엔티티에서 필요한 정보만 골라서 클라이언트에 반환함
 public class ProfileShowResponse {
 
     private final UserInfo userInfo;
@@ -23,24 +20,17 @@ public class ProfileShowResponse {
         private final String nickname;
         private final String profileImgUrl;
         private final String selfComment;
-        private final String realName;
-        private final LocalDate birthDate;
         private final LocalDateTime createdAt;
         private final String email;
-        private final String phoneNumber;
         private final String belong;
         private final List<String> interest;
 
-        // User 엔티티를 응답 DTO로 변환
         public UserInfo(User user) {
             this.nickname = user.getNickname();
             this.profileImgUrl = user.getProfileImgUrl();
             this.selfComment = user.getComment();
-            this.realName = user.getRealName();
-            this.birthDate = user.getBirthday();
             this.createdAt = user.getCreatedAt();
             this.email = user.getEmail();
-            this.phoneNumber = user.getPhoneNumber();
             this.belong = user.getBelong();
             this.interest = user.getInterest() == null ? List.of() : Arrays.asList(user.getInterest().split(","));
         }
@@ -48,11 +38,8 @@ public class ProfileShowResponse {
         public String getNickname() { return nickname; }
         public String getProfileImgUrl() { return profileImgUrl; }
         public String getSelfComment() { return selfComment; }
-        public String getRealName() { return realName; }
-        public LocalDate getBirthDate() { return birthDate; }
         public LocalDateTime getCreatedAt() { return createdAt; }
         public String getEmail() { return email; }
-        public String getPhoneNumber() { return phoneNumber; }
         public String getBelong() { return belong; }
         public List<String> getInterest() { return interest; }
     }

--- a/src/main/java/net/diveon/backend/domain/user/dto/ProfileUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/ProfileUpdateRequest.java
@@ -6,13 +6,11 @@ public class ProfileUpdateRequest {
 
     private String nickname;
     private String selfComment;
-    private String email;
     private String belong;
     private List<String> interest;
 
     public String getNickname() { return nickname; }
     public String getSelfComment() { return selfComment; }
-    public String getEmail() { return email; }
     public String getBelong() { return belong; }
     public List<String> getInterest() { return interest; }
 }

--- a/src/main/java/net/diveon/backend/domain/user/dto/ProfileUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/ProfileUpdateRequest.java
@@ -7,14 +7,12 @@ public class ProfileUpdateRequest {
     private String nickname;
     private String selfComment;
     private String email;
-    private String phoneNumber;
     private String belong;
     private List<String> interest;
 
     public String getNickname() { return nickname; }
     public String getSelfComment() { return selfComment; }
     public String getEmail() { return email; }
-    public String getPhoneNumber() { return phoneNumber; }
     public String getBelong() { return belong; }
     public List<String> getInterest() { return interest; }
 }

--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -76,10 +76,9 @@ public class User {
         this.score = 0;
     }
 
-    public void updateProfile(String nickname, String comment, String email, String belong, List<String> interest) {
+    public void updateProfile(String nickname, String comment, String belong, List<String> interest) {
         if (nickname != null) this.nickname = nickname;
         if (comment != null) this.comment = comment;
-        if (email != null) this.email = email;
         if (belong != null) this.belong = belong;
         if (interest != null) this.interest = String.join(",", interest);
     }

--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -76,11 +76,10 @@ public class User {
         this.score = 0;
     }
 
-    public void updateProfile(String nickname, String comment, String email, String phoneNumber, String belong, List<String> interest) {
+    public void updateProfile(String nickname, String comment, String email, String belong, List<String> interest) {
         if (nickname != null) this.nickname = nickname;
         if (comment != null) this.comment = comment;
         if (email != null) this.email = email;
-        if (phoneNumber != null) this.phoneNumber = phoneNumber;
         if (belong != null) this.belong = belong;
         if (interest != null) this.interest = String.join(",", interest);
     }

--- a/src/main/java/net/diveon/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
     boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/net/diveon/backend/domain/user/service/EmailService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/EmailService.java
@@ -1,6 +1,5 @@
 package net.diveon.backend.domain.user.service;
 
-import net.diveon.backend.domain.user.dto.PasswordResetRequest;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.EmailNotVerifiedException;

--- a/src/main/java/net/diveon/backend/domain/user/service/EmailService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/EmailService.java
@@ -1,0 +1,114 @@
+package net.diveon.backend.domain.user.service;
+
+import net.diveon.backend.domain.user.dto.PasswordResetRequest;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.EmailNotVerifiedException;
+import net.diveon.backend.global.exception.EmailVerificationCodeInvalidException;
+import net.diveon.backend.global.exception.UserAlreadyExistException;
+import net.diveon.backend.global.exception.UserNotFoundException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final String VERIFY_KEY_PREFIX = "email_verify:";
+    private static final String VERIFIED_KEY_PREFIX = "email_verified:";
+    private static final long CODE_TTL_MINUTES = 10;
+    private static final long VERIFIED_TTL_MINUTES = 30;
+
+    public EmailService(JavaMailSender mailSender, RedisTemplate<String, String> redisTemplate, UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.mailSender = mailSender;
+        this.redisTemplate = redisTemplate;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public void sendVerificationCode(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new UserAlreadyExistException();
+        }
+        String code = String.format("%06d", new Random().nextInt(999999));
+
+        redisTemplate.opsForValue()
+                .set(VERIFY_KEY_PREFIX + email, code, CODE_TTL_MINUTES, TimeUnit.MINUTES);
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom("noreply@diveon.net");
+        msg.setTo(email);
+        msg.setSubject("[DiveOn] 이메일 인증 코드");
+        msg.setText("인증 코드: " + code + "\n\n10분 내에 입력해주세요.");
+        mailSender.send(msg);
+    }
+
+    public void verifyCode(String email, String code) {
+        String stored = redisTemplate.opsForValue().get(VERIFY_KEY_PREFIX + email);
+        if (stored == null || !stored.equals(code)) {
+            throw new EmailVerificationCodeInvalidException();
+        }
+        redisTemplate.delete(VERIFY_KEY_PREFIX + email);
+        redisTemplate.opsForValue()
+                .set(VERIFIED_KEY_PREFIX + email, "true", VERIFIED_TTL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    public boolean isVerified(String email) {
+        return "true".equals(redisTemplate.opsForValue().get(VERIFIED_KEY_PREFIX + email));
+    }
+
+    public void clearVerified(String email) {
+        redisTemplate.delete(VERIFIED_KEY_PREFIX + email);
+    }
+
+    public void sendPasswordResetCode(String email) {
+        if (!userRepository.existsByEmail(email)) {
+            throw new UserNotFoundException();
+        }
+        String code = String.format("%06d", new Random().nextInt(999999));
+
+        redisTemplate.opsForValue()
+                .set(VERIFY_KEY_PREFIX + email, code, CODE_TTL_MINUTES, TimeUnit.MINUTES);
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom("noreply@diveon.net");
+        msg.setTo(email);
+        msg.setSubject("[DiveOn] 비밀번호 재설정 인증 코드");
+        msg.setText("인증 코드: " + code + "\n\n10분 내에 입력해주세요.");
+        mailSender.send(msg);
+    }
+
+    @Transactional
+    public void resetPassword(String email, String newPassword) {
+        if (!isVerified(email)) {
+            throw new EmailNotVerifiedException();
+        }
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        clearVerified(email);
+    }
+
+    public void sendLoginId(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom("noreply@diveon.net");
+        msg.setTo(email);
+        msg.setSubject("[DiveOn] 아이디 찾기");
+        msg.setText("회원님의 아이디는 [" + user.getLoginId() + "] 입니다.");
+        mailSender.send(msg);
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
@@ -36,7 +36,6 @@ public class ProfileService {
         user.updateProfile(
                 request.getNickname(),
                 request.getSelfComment(),
-                request.getEmail(),
                 request.getBelong(),
                 request.getInterest()
         );

--- a/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
@@ -11,7 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// 프로필 수정 API 구현할 때 이 파일에 메서드 추가할 것임
+
 @Service
 public class ProfileService {
 
@@ -37,7 +37,6 @@ public class ProfileService {
                 request.getNickname(),
                 request.getSelfComment(),
                 request.getEmail(),
-                request.getPhoneNumber(),
                 request.getBelong(),
                 request.getInterest()
         );

--- a/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserSignUpService.java
@@ -1,49 +1,28 @@
 package net.diveon.backend.domain.user.service;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
-import net.diveon.backend.domain.user.entity.User;
-
-
 import net.diveon.backend.domain.user.dto.AuthSignUpRequest;
+import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
-// import net.diveon.backend.global.exception.InvalidCredentialsException;
+import net.diveon.backend.global.exception.EmailNotVerifiedException;
 import net.diveon.backend.global.exception.UserAlreadyExistException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
 
 import java.util.Objects;
 
-
-import org.springframework.stereotype.Service;
-
-
-/**
- * <pre>
- * 유저 가입을 위한 서비스
- * 필요시 UserService와 합칠 것.
- * 현재 서비스는  public boolean signup(AuthSignUpRequest signup_request) 를통해서
- * 계정 생성이 되었다면 true, 모든 생성의 반대 되는상황(오류,불가,기존재 등)에는 false를 반환.
- * 아마 충돌나면 무조건 익셉션이니, 변수 받는 쪽에서는 false를 기본값으로 사용할 것.
- * </pre>
- */
 @Service
 public class UserSignUpService {
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
 
-
-    public UserSignUpService(UserRepository userRepository, PasswordEncoder passwordEncoder){
+    public UserSignUpService(UserRepository userRepository, PasswordEncoder passwordEncoder, EmailService emailService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.emailService = emailService;
     }
 
-    /**<pre>
-     * 사용자 가입 함수 - 계정생성
-     * 계정 생성이 되었다면 true, 모든 생성의 반대 되는상황(오류,불가,기존재 등)에는 false를 반환.
-     * 아마 충돌나면 무조건 익셉션이니, 변수 받는 쪽에서는 false를 기본값으로 사용할 것.
-     * </pre>
-     * 
-     * @param signup_request
-     * @return boolen
-     */
     public boolean isLoginIdAvailable(String loginId) {
         return !userRepository.existsByLoginId(loginId);
     }
@@ -52,29 +31,18 @@ public class UserSignUpService {
         return !userRepository.existsByNickname(nickname);
     }
 
-    public void signup(AuthSignUpRequest signup_request){
+    public void signup(AuthSignUpRequest signup_request) {
+        if (!emailService.isVerified(signup_request.getEmail())) {
+            throw new EmailNotVerifiedException();
+        }
 
-
-
-        // //사용자 엔티티를, ID를 통해서 전부 가져온다.
-        // //existsById()를 사용하여 검색만 진행한다.
-        // 이 아래의 한줄은 우리가 의도한 표준 에러가 아니라서 차후에 수정이 필요할 것임 2026.04.18 - 안상완
-        // 일반 @valid 어노테이션으로 걸러지는거 확인은 했는데, 일단은 살려두겟습니다 - 2026.04.18 - 안상완
         String loginId = Objects.requireNonNull(signup_request.getLoginId(), "아이디는 필수 입력값입니다.");
-
-        //인코드를 통해서 비밀번호 암호화 진행
-        //수정사항 04.08 dto 변경되면서, getter 메서드 변화로 인한 수정
         String encodedPassword = passwordEncoder.encode(signup_request.getPassword());
 
-        // 만약 아이디가 존재한다면, exception 발생
-        if(userRepository.existsByLoginId(loginId)){
-            //이미 존재하는 아이디 임. 따라서 해당 아이디로 신규 가입 불가능
+        if (userRepository.existsByLoginId(loginId)) {
             throw new UserAlreadyExistException();
         }
-        //새로운 유저 객체 생성
-        //DTO 정보에서 Entity 정보로 변경
-        // 필수값이 아닌 값들은 DTO에서 null로 넘어와도, 생성자를 통해 그대로 생성된다.
-        //수정사항 04.08 dto가 변경되면서 수정
+
         User newUser = new User(
             signup_request.getLoginId(),
             encodedPassword,
@@ -84,6 +52,6 @@ public class UserSignUpService {
             signup_request.getInterest()
         );
         userRepository.save(newUser);
-        return;
+        emailService.clearVerified(signup_request.getEmail());
     }
 }

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/ad/**", "/error").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/check-loginId", "/api/auth/check-nickname", "/api/auth/email/send", "/api/auth/email/verify", "/api/auth/email/find-id", "/api/auth/email/send-reset", "/api/auth/email/password/reset", "/api/ad/**", "/error").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/groups/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members/pending").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/problems").authenticated()

--- a/src/main/java/net/diveon/backend/global/exception/EmailNotVerifiedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/EmailNotVerifiedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class EmailNotVerifiedException extends RuntimeException {
+    public EmailNotVerifiedException() {
+        super("이메일 인증이 필요합니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/EmailVerificationCodeInvalidException.java
+++ b/src/main/java/net/diveon/backend/global/exception/EmailVerificationCodeInvalidException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class EmailVerificationCodeInvalidException extends RuntimeException {
+    public EmailVerificationCodeInvalidException() {
+        super("인증 코드가 올바르지 않거나 만료되었습니다.");
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -500,6 +500,34 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
         }
 
+        // 이메일 인증 코드 불일치/만료 → 400
+        @ExceptionHandler(EmailVerificationCodeInvalidException.class)
+        public ResponseEntity<ErrorResponse> handleEmailVerificationCodeInvalid(
+                EmailVerificationCodeInvalidException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/email-verification-code-invalid",
+                        "Bad Request",
+                        400,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+        }
+
+        // 이메일 인증 미완료 → 403
+        @ExceptionHandler(EmailNotVerifiedException.class)
+        public ResponseEntity<ErrorResponse> handleEmailNotVerified(
+                EmailNotVerifiedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/email-not-verified",
+                        "Forbidden",
+                        403,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+        }
+
         // 대회 시간 유효하지 않음 → 400
         @ExceptionHandler(InvalidContestTimeException.class)
         public ResponseEntity<ErrorResponse> handleInvalidContestTime(


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `POST /api/auth/email/send` — 회원가입용 이메일 인증코드 발송 (중복 이메일 차단)
- `POST /api/auth/email/verify` — 인증코드 검증
- `POST /api/auth/email/find-id` — 이메일로 아이디 발송
- `POST /api/auth/email/send-reset` — 비밀번호 찾기 인증코드 발송
- `POST /api/auth/email/password/reset` — 이메일 인증 후 비밀번호 재설정
- 회원가입 시 이메일 인증 완료 여부 체크 추가
- `email` 필수 필드로 변경, `realName`/`birthday` 제거
- 프로필 수정/조회에서 `email`/`phoneNumber` 제거
- `spring-boot-starter-mail` 의존성 추가

## 관련 이슈
Closes #295


<!-- 주석은 제외되고 올라가니 무시하세요 -->
