### PR TITLE
[feat] Refresh Token 재발급 및 로그아웃 API 구현 (#297)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/controller/UserController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/UserController.java
@@ -3,11 +3,13 @@ package net.diveon.backend.domain.user.controller;
 import net.diveon.backend.domain.user.dto.AuthLoginRequest;
 import net.diveon.backend.domain.user.dto.AuthLoginResponse;
 import net.diveon.backend.domain.user.dto.AuthSignUpRequest;
+import net.diveon.backend.domain.user.dto.RefreshTokenRequest;
 import net.diveon.backend.domain.user.service.UserService;
 import net.diveon.backend.domain.user.service.UserSignUpService;
 import net.diveon.backend.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -69,5 +71,16 @@ public class UserController {
         userSignUpService.signup(signupRequest);
         return ResponseEntity.status(201).body(ApiResponse.success(("회원가입에 성공했습니다."), null));
     }
-    
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<String>> refresh(@Valid @RequestBody RefreshTokenRequest request) {
+        String newAccessToken = userService.refreshAccessToken(request.getRefreshToken());
+        return ResponseEntity.ok(ApiResponse.success("토큰이 재발급되었습니다.", newAccessToken));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal String userId) {
+        userService.logout(userId);
+        return ResponseEntity.ok(ApiResponse.success("로그아웃되었습니다.", null));
+    }
 }

--- a/src/main/java/net/diveon/backend/domain/user/dto/RefreshTokenRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package net.diveon.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class RefreshTokenRequest {
+
+    @NotBlank
+    private String refreshToken;
+
+    public String getRefreshToken() { return refreshToken; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/UserService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserService.java
@@ -6,42 +6,69 @@ import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.InvalidCredentialsException;
 import net.diveon.backend.global.security.JwtProvider;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 public class UserService {
 
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+    private static final long REFRESH_TOKEN_TTL_DAYS = 7;
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
-    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtProvider jwtProvider) {
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtProvider jwtProvider, RedisTemplate<String, String> redisTemplate) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtProvider = jwtProvider;
+        this.redisTemplate = redisTemplate;
     }
 
     public AuthLoginResponse login(AuthLoginRequest request) {
-        // 아이디로 유저 조회, 없으면 401
         User user = userRepository.findByLoginId(request.getLoginId())
                 .orElseThrow(InvalidCredentialsException::new);
 
-        // 비밀번호 검증 (BCrypt), 불일치 시 401
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new InvalidCredentialsException();
         }
 
-        // JWT access/refresh 토큰 발급
         String accessToken = jwtProvider.generateAccessToken(String.valueOf(user.getId()));
         String refreshToken = jwtProvider.generateRefreshToken(String.valueOf(user.getId()));
 
-        // 응답 데이터 구성 (토큰 + 유저 기본 정보)
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + user.getId(),
+                refreshToken,
+                REFRESH_TOKEN_TTL_DAYS,
+                TimeUnit.DAYS
+        );
+
         AuthLoginResponse.UserInfo userInfo = new AuthLoginResponse.UserInfo(
                 user.getNickname(),
                 user.getProfileImgUrl()
         );
 
         return new AuthLoginResponse(accessToken, refreshToken, userInfo);
+    }
+
+    public String refreshAccessToken(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new InvalidCredentialsException();
+        }
+        String userId = jwtProvider.getUserId(refreshToken);
+        String stored = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
+        if (!refreshToken.equals(stored)) {
+            throw new InvalidCredentialsException();
+        }
+        return jwtProvider.generateAccessToken(userId);
+    }
+
+    public void logout(String userId) {
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
     }
 }

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/check-loginId", "/api/auth/check-nickname", "/api/auth/email/send", "/api/auth/email/verify", "/api/auth/email/find-id", "/api/auth/email/send-reset", "/api/auth/email/password/reset", "/api/ad/**", "/error").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/refresh", "/api/auth/check-loginId", "/api/auth/check-nickname", "/api/auth/email/send", "/api/auth/email/verify", "/api/auth/email/find-id", "/api/auth/email/send-reset", "/api/auth/email/password/reset", "/api/ad/**", "/error").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/groups/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members/pending").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/problems").authenticated()


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

로그인 시 Refresh Token Redis 저장 및 재발급/로그아웃 API 구현

- 로그인 시 refresh token Redis 저장 (7일 TTL)
- `POST /api/auth/refresh` — refresh token으로 access token 재발급
- `POST /api/auth/logout` — Redis에서 refresh token 삭제

## 관련 이슈
Closes #297


<!-- 주석은 제외되고 올라가니 무시하세요 -->
