### PR TITLE
[feat] 문제 목록 조회 API에 미해결 문제 필터 및 isSolved 필드 추가

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/repository/SolveSubmissionRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SolveSubmissionRepository.java
@@ -1,5 +1,7 @@
 package net.diveon.backend.domain.grade.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +17,7 @@ public interface SolveSubmissionRepository extends JpaRepository<SolveSubmission
 
     @Query("SELECT COUNT(s) FROM SolveSubmission s WHERE s.problem.id = :probId AND s.submissionState = 'COMPLETED'")
     Long countCompletedByProbId(@Param("probId") Long probId);
+
+    @Query("SELECT r.submission.problem.id FROM SolveResult r WHERE r.submission.user.id = :userId AND r.resultState = 'CORRECT'")
+    List<Long> findSolvedProblemIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
@@ -32,7 +32,8 @@ public class ProblemController {
         @RequestParam(required = false) String title,
         @RequestParam(required = false) String category,
         @RequestParam(required = false) String difficulty,
-        @RequestParam(required = false) String visibility
+        @RequestParam(required = false) String visibility,
+        @RequestParam(defaultValue = "false") boolean onlyUnsolved
     ) {
         ProblemListResponse responseData = problemListService.listProblems(
             Long.parseLong(userId),
@@ -40,7 +41,8 @@ public class ProblemController {
             title,
             category,
             difficulty,
-            visibility
+            visibility,
+            onlyUnsolved
         );
 
         return ResponseEntity.status(200)

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemListItemResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemListItemResponse.java
@@ -10,27 +10,30 @@ public class ProblemListItemResponse {
     private String category;
     private String difficulty;
     private Integer solvedCount;
+    private Boolean isSolved;
 
     public ProblemListItemResponse() {
     }
 
-    public ProblemListItemResponse(Long probId, String type, String title, String category, String difficulty, Integer solvedCount) {
+    public ProblemListItemResponse(Long probId, String type, String title, String category, String difficulty, Integer solvedCount, Boolean isSolved) {
         this.probId = probId;
         this.type = type;
         this.title = title;
         this.category = category;
         this.difficulty = difficulty;
         this.solvedCount = solvedCount;
+        this.isSolved = isSolved;
     }
 
-    public static ProblemListItemResponse of(Problem problem) {
+    public static ProblemListItemResponse of(Problem problem, boolean isSolved) {
         return new ProblemListItemResponse(
             problem.getId(),
             problem.getType(),
             problem.getTitle(),
             problem.getCategory(),
             problem.getDifficulty(),
-            problem.getSolvedCount()
+            problem.getSolvedCount(),
+            isSolved
         );
     }
 
@@ -56,5 +59,9 @@ public class ProblemListItemResponse {
 
     public Integer getSolvedCount() {
         return solvedCount;
+    }
+
+    public Boolean getIsSolved() {
+        return isSolved;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
@@ -1,6 +1,7 @@
 package net.diveon.backend.domain.problem.service;
 
 import jakarta.persistence.criteria.Predicate;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
 import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemListResponse;
 import net.diveon.backend.domain.problem.entity.Problem;
@@ -15,17 +16,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class ProblemListService {
 
     private final UserRepository userRepository;
     private final ProblemRepository problemRepository;
+    private final SolveSubmissionRepository solveSubmissionRepository;
     private static final int PAGE_SIZE = 10;
 
-    public ProblemListService(UserRepository userRepository, ProblemRepository problemRepository) {
+    public ProblemListService(UserRepository userRepository, ProblemRepository problemRepository,
+                              SolveSubmissionRepository solveSubmissionRepository) {
         this.userRepository = userRepository;
         this.problemRepository = problemRepository;
+        this.solveSubmissionRepository = solveSubmissionRepository;
     }
 
     @Transactional(readOnly = true)
@@ -35,9 +40,12 @@ public class ProblemListService {
         String title,
         String category,
         String difficulty,
-        String visibility
+        String visibility,
+        boolean onlyUnsolved
     ) {
         userRepository.findById(userId).orElseThrow();
+
+        Set<Long> solvedIds = Set.copyOf(solveSubmissionRepository.findSolvedProblemIdsByUserId(userId));
 
         Pageable pageable = PageRequest.of(
             page - 1,
@@ -45,18 +53,19 @@ public class ProblemListService {
             Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        Specification<Problem> spec = buildSpecification(title, category, difficulty, visibility);
+        Specification<Problem> spec = buildSpecification(title, category, difficulty, visibility, onlyUnsolved, solvedIds);
         Page<Problem> problemPage = problemRepository.findAll(spec, pageable);
 
         List<ProblemListItemResponse> problemList = problemPage.getContent()
             .stream()
-            .map(ProblemListItemResponse::of)
+            .map(problem -> ProblemListItemResponse.of(problem, solvedIds.contains(problem.getId())))
             .toList();
 
         return ProblemListResponse.of(problemPage, problemList);
     }
 
-    private Specification<Problem> buildSpecification(String title, String category, String difficulty, String visibility) {
+    private Specification<Problem> buildSpecification(String title, String category, String difficulty,
+                                                      String visibility, boolean onlyUnsolved, Set<Long> solvedIds) {
         return (root, query, cb) -> {
             var predicates = new java.util.ArrayList<>();
 
@@ -74,6 +83,10 @@ public class ProblemListService {
 
             if (visibility != null && !visibility.isEmpty()) {
                 predicates.add(cb.equal(root.get("visibility"), visibility));
+            }
+
+            if (onlyUnsolved && !solvedIds.isEmpty()) {
+                predicates.add(root.get("id").in(solvedIds).not());
             }
 
             return cb.and(predicates.toArray(new Predicate[0]));


### PR DESCRIPTION

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- onlyUnsolved 쿼리 파라미터 추가 (기본값: false)
- 응답 항목에 isSolved 필드 추가 (현재 유저의 정답 여부)
- SolveResult.resultState = CORRECT 기준으로 풀이 여부 판단
 

## 관련 이슈
Closes #304 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
