### PR TITLE
[feat] 내 그룹 목록 조회 시 문제 추가 여부 반환 (#306)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ src/main/resources/application-secret.yml
 src/main/resources/application-local.yml
 *.env
 
+
 # 각자 로컬 환경이 다를 수 있는 Docker 설정
 docker-compose.yml
 

--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -67,8 +67,9 @@ public class GroupController {
     // 내가 속한 그룹 목록 조회
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<GroupMyListResponse>>> getMyGroups(
-            @AuthenticationPrincipal String userId) {
-        List<GroupMyListResponse> response = groupService.getMyGroups(Long.parseLong(userId));
+            @AuthenticationPrincipal String userId,
+            @RequestParam(required = false) Long problemId) {
+        List<GroupMyListResponse> response = groupService.getMyGroups(Long.parseLong(userId), problemId);
         return ResponseEntity.ok(ApiResponse.success("내 그룹 목록 조회 성공", response));
     }
 

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupMyListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupMyListResponse.java
@@ -6,19 +6,23 @@ public class GroupMyListResponse {
 
     private Long groupId;
     private String title;
+    private boolean isAlreadyAdded;
 
-    public GroupMyListResponse(Long groupId, String title) {
+    public GroupMyListResponse(Long groupId, String title, boolean isAlreadyAdded) {
         this.groupId = groupId;
         this.title = title;
+        this.isAlreadyAdded = isAlreadyAdded;
     }
 
-    public static GroupMyListResponse of(GroupUser groupUser) {
+    public static GroupMyListResponse of(GroupUser groupUser, boolean isAlreadyAdded) {
         return new GroupMyListResponse(
                 groupUser.getGroup().getId(),
-                groupUser.getGroup().getTitle()
+                groupUser.getGroup().getTitle(),
+                isAlreadyAdded
         );
     }
 
     public Long getGroupId() { return groupId; }
     public String getTitle() { return title; }
+    public boolean isAlreadyAdded() { return isAlreadyAdded; }
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -258,11 +258,15 @@ public class GroupService {
     /* findAllByUserId(userId) 로 내 userId로 조회하면 내가 속한 그룹들이 List<GroupUser> 형태로 나오고,
       각각에서 group.getId(), group.getTitle() 뽑아서 반환 */
     @Transactional(readOnly = true)
-    public List<GroupMyListResponse> getMyGroups(Long userId) {
+    public List<GroupMyListResponse> getMyGroups(Long userId, Long problemId) {
         List<GroupUser> groupUsers = groupUserRepository.findAllByUserId(userId);
         return groupUsers.stream()
-                .map(GroupMyListResponse::of)
-                .toList(); 
+                .map(groupUser -> {
+                    boolean isAlreadyAdded = problemId != null &&
+                            groupProblemRepository.existsByGroupIdAndProblemId(groupUser.getGroup().getId(), problemId);
+                    return GroupMyListResponse.of(groupUser, isAlreadyAdded);
+                })
+                .toList();
     }
 
     // 그룹 상세 조회


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- `GET /api/groups/me?problemId={problemId}` — problemId 선택 파라미터 추가
- 각 그룹에 해당 문제가 이미 추가됐는지 `isAlreadyAdded` 반환
- problemId 없이 호출하면 isAlreadyAdded는 항상 false

## 관련 이슈
Closes #306


<!-- 주석은 제외되고 올라가니 무시하세요 -->
