### PR TITLE
[feat] 아이디 마스킹 및 비밀번호 유효성 검증 추가 (#308)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/AuthSignUpRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.List;
 
@@ -18,6 +19,8 @@ public class AuthSignUpRequest {
     private String loginId;
 
     @NotBlank
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?])[^\\s]{8,16}$",
+             message = "비밀번호는 8~16자이며, 영문, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다.")
     @JsonProperty("password")
     private String password;
 

--- a/src/main/java/net/diveon/backend/domain/user/dto/PasswordResetRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/PasswordResetRequest.java
@@ -2,6 +2,7 @@ package net.diveon.backend.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public class PasswordResetRequest {
 
@@ -10,6 +11,8 @@ public class PasswordResetRequest {
     private String email;
 
     @NotBlank
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?])[^\\s]{8,16}$",
+             message = "비밀번호는 8~16자이며, 영문, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다.")
     private String newPassword;
 
     public String getEmail() { return email; }

--- a/src/main/java/net/diveon/backend/domain/user/dto/PasswordUpdateRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/PasswordUpdateRequest.java
@@ -1,6 +1,7 @@
 package net.diveon.backend.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public class PasswordUpdateRequest {
 
@@ -8,6 +9,8 @@ public class PasswordUpdateRequest {
     private String currentPassword;
 
     @NotBlank
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?])[^\\s]{8,16}$",
+             message = "비밀번호는 8~16자이며, 영문, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다.")
     private String newPassword;
 
     public String getCurrentPassword() { return currentPassword; }

--- a/src/main/java/net/diveon/backend/domain/user/service/EmailService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/EmailService.java
@@ -103,11 +103,24 @@ public class EmailService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
 
+        String loginId = user.getLoginId();
+        String maskedId = maskLoginId(loginId);
+
         SimpleMailMessage msg = new SimpleMailMessage();
         msg.setFrom("noreply@diveon.net");
         msg.setTo(email);
         msg.setSubject("[DiveOn] 아이디 찾기");
-        msg.setText("회원님의 아이디는 [" + user.getLoginId() + "] 입니다.");
+        msg.setText("회원님의 아이디는 [" + maskedId + "] 입니다.");
         mailSender.send(msg);
+    }
+
+    private String maskLoginId(String loginId) {
+        if (loginId.length() <= 4) {
+            return loginId.charAt(0) + "****";
+        }
+        String prefix = loginId.substring(0, 3);
+        String suffix = String.valueOf(loginId.charAt(loginId.length() - 1));
+        String masked = "*".repeat(loginId.length() - 4);
+        return prefix + masked + suffix;
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 아이디 찾기 이메일에서 로그인 ID 일부 마스킹 처리 (앞 3자리 + * + 마지막 1자리)
- 회원가입, 비밀번호 변경, 비밀번호 재설정에 비밀번호 유효성 검증 추가
- 조건: 8~16자, 영문·숫자·특수문자 각 1개 이상, 공백 불가
- 조건 불일치 시 400 반환

## 관련 이슈
Closes #308


<!-- 주석은 제외되고 올라가니 무시하세요 -->
