### PR TITLE
feat: 문제 수정/삭제 소유자 권한 체크 추가 (#310)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemDeleteService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemDeleteService.java
@@ -10,7 +10,7 @@ import net.diveon.backend.domain.problem.repository.ProblemObjectiveRepository;
 import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
 import net.diveon.backend.domain.problem.repository.ProblemCodingRepository;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
-import net.diveon.backend.global.exception.ProblemDeletePermisionDeny;
+import net.diveon.backend.global.exception.ProblemAccessDeniedException;
 import net.diveon.backend.global.exception.ProblemNotFoundException;
 
 
@@ -61,7 +61,7 @@ public class ProblemDeleteService {
             .orElseThrow(() -> new ProblemNotFoundException(probId + "번에 해당하는 문제가 존재하지 않습니다."));
 
         if (!problem.getAuthor().getId().equals(userId)) {
-            throw new ProblemDeletePermisionDeny();
+            throw new ProblemAccessDeniedException();
         }
 
         if (problem.getType().equals("practice")) {

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -22,6 +22,8 @@ import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
 import net.diveon.backend.domain.problem.repository.ProblemCodingRepository;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.ProblemAccessDeniedException;
+import net.diveon.backend.global.exception.ProblemNotFoundException;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -56,10 +58,17 @@ public class ProblemUpdateService {
         }
 
     // 객관식형
+    private void checkOwner(Problem problem, long userId) {
+        if (!problem.getAuthor().getId().equals(userId)) {
+            throw new ProblemAccessDeniedException();
+        }
+    }
+
     @Transactional
-    public ProblemUpdateObjectiveResponse updateProblemObjective(long userId, long prodId, 
+    public ProblemUpdateObjectiveResponse updateProblemObjective(long userId, long prodId,
         ProblemUpdateObjectiveRequest request){
-            Problem problem = problemRepository.findById(prodId).orElseThrow();
+            Problem problem = problemRepository.findById(prodId).orElseThrow(ProblemNotFoundException::new);
+            checkOwner(problem, userId);
 
             ProblemObjective problemObjective = problemObjectiveRepository.findById(prodId).orElseThrow();
 
@@ -109,7 +118,8 @@ public class ProblemUpdateService {
     @Transactional
     public ProblemUpdateCodingResponse updateProblemCoding(long userId, long probId,
         ProblemUpdateCodingRequest request) {
-        Problem problem = problemRepository.findById(probId).orElseThrow();
+        Problem problem = problemRepository.findById(probId).orElseThrow(ProblemNotFoundException::new);
+        checkOwner(problem, userId);
         ProblemCoding problemCoding = problemCodingRepository.findById(probId).orElseThrow();
 
         problem.updateProblem(request.getTitle(), request.getCategory(), request.getDifficulty(), request.getVisibility());
@@ -147,7 +157,8 @@ public class ProblemUpdateService {
     @Transactional
     public ProblemUpdatePracticeResponse updateProblemPractice(long userId, long probId,
         ProblemUpdatePracticeRequest request){
-            Problem problem = problemRepository.findById(probId).orElseThrow();
+            Problem problem = problemRepository.findById(probId).orElseThrow(ProblemNotFoundException::new);
+            checkOwner(problem, userId);
             ProblemPractice problemPractice = problemPracticeRepository.findById(probId).orElseThrow();
 
             problem.updateProblem(

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -94,6 +94,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // 문제 수정/삭제 권한 없음 → 403
+        @ExceptionHandler(ProblemAccessDeniedException.class)
+        public ResponseEntity<ErrorResponse> handleProblemAccessDenied(
+                ProblemAccessDeniedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/problem-access-denied",
+                        "Forbidden",
+                        403,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+        }
+
         // 문제 삭제 권한 없음 → 403
         @ExceptionHandler(ProblemDeletePermisionDeny.class)
         public ResponseEntity<ErrorResponse> handleProblemDeletePermisionDeny(

--- a/src/main/java/net/diveon/backend/global/exception/ProblemAccessDeniedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ProblemAccessDeniedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class ProblemAccessDeniedException extends RuntimeException {
+    public ProblemAccessDeniedException() {
+        super("본인이 생성한 문제만 수정/삭제할 수 있습니다.");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
본인이 생성한 문제만 수정/삭제 가능하도록 권한 체크 추가

- 문제 수정 시 작성자 확인 후 타인의 문제 수정 불가 (403)
- 문제 삭제 시 기존 체크 로직 ProblemAccessDeniedException으로 통일
- ProblemAccessDeniedException 추가


## 관련 이슈
Closes #310


<!-- 주석은 제외되고 올라가니 무시하세요 -->
