### PR TITLE
[feat] 문제 수정 필드 4개로 통일 (#312)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdateCodingRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdateCodingRequest.java
@@ -1,68 +1,13 @@
 package net.diveon.backend.domain.problem.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import net.diveon.backend.domain.problem.others.ForDtoTestCase;
-
-import java.util.List;
-
-/**
- * 다음과 같은 형태의 PATCH request 양식을 만족하기 위한 DTO
- * <pre>
- * {
- *   "title": "프로세스 우선순위 정렬 심화",
- *   "description": "N개의 프로세스가 주어질 때...",
- *   "category": "scheduling",
- *   "difficulty": "hard",
- *   "visibility": "public",
- *   "summary": "프로세스 우선순위 정렬 심화 문제",
- *   "inputDescription": "첫째 줄에 N...",
- *   "outputDescription": "우선순위가 높은 순으로...",
- *   "constraints": {
- *     "timeLimitMs": 2000,
- *     "memoryLimitMb": 512,
- *     "allowedLanguages": ["python", "java", "c", "cpp", "go"]
- *   },
- *   "testcases": [
- *     {
- *       "index": 1,
- *       "input": "3\n1 5\n2 3\n3 8",
- *       "output": "3\n1\n2",
- *       "isSample": true
- *     }
- *   ],
- *   "fileUrl": null,
- *   "obo": {
- *     "enabled": true,
- *     "initialImageUrl": "https://cdn.dk-world.com/problems/p99_init.png"
- *   }
- * }
- * </pre>
- */
 public class ProblemUpdateCodingRequest {
 
     private String title;
     private String summary;
     private String description;
-    private String category;
     private String difficulty;
-    private String visibility;
-    private Constraints constraints;
 
-    @JsonProperty("inputDescription")
-    private String inputDescription;
-
-    @JsonProperty("outputDescription")
-    private String outputDescription;
-
-    private List<ForDtoTestCase> testcases;
-
-    @JsonProperty("fileUrl")
-    private String fileUrl;
-
-    private Obo obo;
-
-    public ProblemUpdateCodingRequest() {
-    }
+    public ProblemUpdateCodingRequest() {}
 
     public String getTitle() { return title; }
     public void setTitle(String title) { this.title = title; }
@@ -73,69 +18,6 @@ public class ProblemUpdateCodingRequest {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
 
-    public String getCategory() { return category; }
-    public void setCategory(String category) { this.category = category; }
-
     public String getDifficulty() { return difficulty; }
     public void setDifficulty(String difficulty) { this.difficulty = difficulty; }
-
-    public String getVisibility() { return visibility; }
-    public void setVisibility(String visibility) { this.visibility = visibility; }
-
-    public Constraints getConstraints() { return constraints; }
-    public void setConstraints(Constraints constraints) { this.constraints = constraints; }
-
-    public String getInputDescription() { return inputDescription; }
-    public void setInputDescription(String inputDescription) { this.inputDescription = inputDescription; }
-
-    public String getOutputDescription() { return outputDescription; }
-    public void setOutputDescription(String outputDescription) { this.outputDescription = outputDescription; }
-
-    public List<ForDtoTestCase> getTestcases() { return testcases; }
-    public void setTestcases(List<ForDtoTestCase> testcases) { this.testcases = testcases; }
-
-    public String getFileUrl() { return fileUrl; }
-    public void setFileUrl(String fileUrl) { this.fileUrl = fileUrl; }
-
-    public Obo getObo() { return obo; }
-    public void setObo(Obo obo) { this.obo = obo; }
-
-    public static class Constraints {
-        @JsonProperty("timeLimitMs")
-        private Integer timeLimitMs;
-
-        @JsonProperty("memoryLimitMb")
-        private Integer memoryLimitMb;
-
-        @JsonProperty("allowedLanguages")
-        private List<String> allowedLanguages;
-
-        public Constraints() {
-        }
-
-        public Integer getTimeLimitMs() { return timeLimitMs; }
-        public void setTimeLimitMs(Integer timeLimitMs) { this.timeLimitMs = timeLimitMs; }
-
-        public Integer getMemoryLimitMb() { return memoryLimitMb; }
-        public void setMemoryLimitMb(Integer memoryLimitMb) { this.memoryLimitMb = memoryLimitMb; }
-
-        public List<String> getAllowedLanguages() { return allowedLanguages; }
-        public void setAllowedLanguages(List<String> allowedLanguages) { this.allowedLanguages = allowedLanguages; }
-    }
-
-    public static class Obo {
-        private Boolean enabled;
-
-        @JsonProperty("initialImageUrl")
-        private String initialImageUrl;
-
-        public Obo() {
-        }
-
-        public Boolean getEnabled() { return enabled; }
-        public void setEnabled(Boolean enabled) { this.enabled = enabled; }
-
-        public String getInitialImageUrl() { return initialImageUrl; }
-        public void setInitialImageUrl(String initialImageUrl) { this.initialImageUrl = initialImageUrl; }
-    }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdateObjectiveRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdateObjectiveRequest.java
@@ -1,155 +1,23 @@
-
 package net.diveon.backend.domain.problem.dto.request;
-
-import net.diveon.backend.domain.problem.others.ForDtoChoice;
-import net.diveon.backend.domain.problem.others.ForDtoOboStep;
-
-import java.util.List;
-
-/**
- * 다음과 같은 형태의 Patch request 양식을 만족하기 위한 dto
- * <pre>
- * {
-  "title": {{title}},
-  "description": {{description}},
-  "category": {{category}},
-  "difficulty": {{medium}},
-  "visibility": "{{visibility}}", // 여기까지 String
-  "summary": "{{summary}}",
-  "choices": [
-    { "index": 1, "content": "선점형이다", "imageUrl": null },
-    { "index": 2, "content": "비선점형이다", "imageUrl": null },
-    { "index": 3, "content": "우선순위 기반이다", "imageUrl": null },
-    { "index": 4, "content": "FIFO 방식이다", "imageUrl": null }
-  ],  // JSONB로 데이터베이스 저장될 것임.
-  "answer": [1, 2],
-  "oboEnabled": {{enabled}},
-  "obo": {  // object 타입
-    "steps": [
-      {
-        "step": 1,
-        "description": "프로세스 A가 CPU를 점유합니다.",
-        "imageUrl": "https://cdn.dk-world.com/problems/p42_obo_step1.png"
-      },
-      {
-        "step": 2,
-        "description": "타임 퀀텀이 만료되어 프로세스 B로 전환됩니다.",
-        "imageUrl": "https://cdn.dk-world.com/problems/p42_obo_step2.png"
-      }
-    ]
-  }
-}
- * </pre>
- */
 
 public class ProblemUpdateObjectiveRequest {
 
     private String title;
-    private String description;
-    private String category;
-    private String difficulty;
-    private String visibility;
     private String summary;
-    private List<ForDtoChoice> choices;
-    private List<Integer> answer;
-    private Boolean oboEnabled;
-    private Obo obo;
+    private String description;
+    private String difficulty;
 
-    public ProblemUpdateObjectiveRequest() {
-    }
+    public ProblemUpdateObjectiveRequest() {}
 
-    public String getTitle() {
-        return title;
-    }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
+    public String getSummary() { return summary; }
+    public void setSummary(String summary) { this.summary = summary; }
 
-    public String getDescription() {
-        return description;
-    }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public String getDifficulty() {
-        return difficulty;
-    }
-
-    public void setDifficulty(String difficulty) {
-        this.difficulty = difficulty;
-    }
-
-    public String getVisibility() {
-        return visibility;
-    }
-
-    public void setVisibility(String visibility) {
-        this.visibility = visibility;
-    }
-
-    public String getSummary() {
-        return summary;
-    }
-
-    public void setSummary(String summary) {
-        this.summary = summary;
-    }
-
-    public List<ForDtoChoice> getChoices() {
-        return choices;
-    }
-
-    public void setChoices(List<ForDtoChoice> choices) {
-        this.choices = choices;
-    }
-
-    public List<Integer> getAnswer() {
-        return answer;
-    }
-
-    public void setAnswer(List<Integer> answer) {
-        this.answer = answer;
-    }
-
-    public Boolean getOboEnabled() {
-        return oboEnabled;
-    }
-
-    public void setOboEnabled(Boolean oboEnabled) {
-        this.oboEnabled = oboEnabled;
-    }
-
-    public Obo getObo() {
-        return obo;
-    }
-
-    public void setObo(Obo obo) {
-        this.obo = obo;
-    }
-
-    public static class Obo {
-        private List<ForDtoOboStep> steps;
-
-        public Obo() {
-        }
-
-        public List<ForDtoOboStep> getSteps() {
-            return steps;
-        }
-
-        public void setSteps(List<ForDtoOboStep> steps) {
-            this.steps = steps;
-        }
-    }
+    public String getDifficulty() { return difficulty; }
+    public void setDifficulty(String difficulty) { this.difficulty = difficulty; }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdatePracticeRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemUpdatePracticeRequest.java
@@ -1,34 +1,13 @@
 package net.diveon.backend.domain.problem.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.List;
-
 public class ProblemUpdatePracticeRequest {
 
     private String title;
     private String summary;
     private String description;
-    private String category;
     private String difficulty;
-    private String visibility;
 
-    @JsonProperty("osImage")
-    private String osImage;
-
-    @JsonProperty("allowedCommands")
-    private List<String> allowedCommands;
-
-    @JsonProperty("cpuLimit")
-    private String cpuLimit;
-
-    @JsonProperty("memoryLimit")
-    private String memoryLimit;
-
-    private String flag;
-
-    public ProblemUpdatePracticeRequest() {
-    }
+    public ProblemUpdatePracticeRequest() {}
 
     public String getTitle() { return title; }
     public void setTitle(String title) { this.title = title; }
@@ -39,27 +18,6 @@ public class ProblemUpdatePracticeRequest {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
 
-    public String getCategory() { return category; }
-    public void setCategory(String category) { this.category = category; }
-
     public String getDifficulty() { return difficulty; }
     public void setDifficulty(String difficulty) { this.difficulty = difficulty; }
-
-    public String getVisibility() { return visibility; }
-    public void setVisibility(String visibility) { this.visibility = visibility; }
-
-    public String getOsImage() { return osImage; }
-    public void setOsImage(String osImage) { this.osImage = osImage; }
-
-    public List<String> getAllowedCommands() { return allowedCommands; }
-    public void setAllowedCommands(List<String> allowedCommands) { this.allowedCommands = allowedCommands; }
-
-    public String getCpuLimit() { return cpuLimit; }
-    public void setCpuLimit(String cpuLimit) { this.cpuLimit = cpuLimit; }
-
-    public String getMemoryLimit() { return memoryLimit; }
-    public void setMemoryLimit(String memoryLimit) { this.memoryLimit = memoryLimit; }
-
-    public String getFlag() { return flag; }
-    public void setFlag(String flag) { this.flag = flag; }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/entity/ProblemCoding.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/ProblemCoding.java
@@ -117,21 +117,8 @@ public class ProblemCoding {
     public void setOboInitialImageUrl(String oboInitialImageUrl) { this.oboInitialImageUrl = oboInitialImageUrl; }
 
     // 5. 비즈니스 로직
-    public void updateProblemCoding(String summary, String description,
-                                    String inputDescription, String outputDescription,
-                                    Integer timeLimitMs, Integer memoryLimitMb,
-                                    List<String> allowedLanguages, List<ForDtoTestCase> testcases,
-                                    String fileUrl, Boolean oboEnabled, String oboInitialImageUrl) {
+    public void updateProblemCoding(String summary, String description) {
         if (summary != null) this.summary = summary;
         if (description != null) this.description = description;
-        if (inputDescription != null) this.inputDescription = inputDescription;
-        if (outputDescription != null) this.outputDescription = outputDescription;
-        if (timeLimitMs != null) this.timeLimitMs = timeLimitMs;
-        if (memoryLimitMb != null) this.memoryLimitMb = memoryLimitMb;
-        if (allowedLanguages != null) this.allowedLanguages = allowedLanguages;
-        if (testcases != null) this.testcases = testcases;
-        if (fileUrl != null) this.fileUrl = fileUrl;
-        if (oboEnabled != null) this.oboEnabled = oboEnabled;
-        if (oboInitialImageUrl != null) this.oboInitialImageUrl = oboInitialImageUrl;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/entity/ProblemObjective.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/ProblemObjective.java
@@ -83,12 +83,8 @@ public class ProblemObjective {
      * - oboEnabled; boolean, ???
      * </pre>
      */
-    public void updateProblemObjective(String summary, String description,
-        List<ForDtoChoice> choices, List<Integer> answer, Boolean oboEnabled){
-            if(summary != null) this.summary = summary;
-            if(description != null)this.description = description;
-            if(choices != null)this.choices = choices;
-            if(answer != null)this.answer = answer;
-            if(oboEnabled != null)this.oboEnabled = oboEnabled;
+    public void updateProblemObjective(String summary, String description) {
+        if (summary != null) this.summary = summary;
+        if (description != null) this.description = description;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/entity/ProblemPractice.java
+++ b/src/main/java/net/diveon/backend/domain/problem/entity/ProblemPractice.java
@@ -99,15 +99,8 @@ public class ProblemPractice {
     public Boolean getIsDraft() { return isDraft; }
     public Integer getTimeLimitSec() { return timeLimitSec; }
 
-    public void updatePractice(String summary, String description, String osImage,
-                               List<String> allowedCommands, String cpuLimit,
-                               String memoryLimit, String flagHash) {
+    public void updatePractice(String summary, String description) {
         if (summary != null) this.summary = summary;
         if (description != null) this.description = description;
-        if (osImage != null) this.osImage = osImage;
-        if (allowedCommands != null) this.allowedCommands = allowedCommands;
-        if (cpuLimit != null) this.cpuLimit = cpuLimit;
-        if (memoryLimit != null) this.memoryLimit = memoryLimit;
-        if (flagHash != null) this.flagHash = flagHash;
     }
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemUpdateService.java
@@ -72,46 +72,10 @@ public class ProblemUpdateService {
 
             ProblemObjective problemObjective = problemObjectiveRepository.findById(prodId).orElseThrow();
 
-            problem.updateProblem(request.getTitle(), request.getCategory(), request.getDifficulty(), request.getVisibility());
+            problem.updateProblem(request.getTitle(), null, request.getDifficulty(), null);
+            problemObjective.updateProblemObjective(request.getSummary(), request.getDescription());
 
-            problemObjective.updateProblemObjective(
-                request.getSummary(),
-                request.getDescription(),
-                request.getChoices(),
-                request.getAnswer(),
-                request.getOboEnabled()
-            );
-
-            // List<OboStep> existingSteps = oboStepRepository.findByProblemOrderByStepAsc(problem);
-            // if (!existingSteps.isEmpty()) {
-            //     oboStepRepository.deleteAll(existingSteps);
-            // }
-
-            //이 아래의 로직은, obo step에 대해서, 일단 전부 삭제하고 전부 삽입하는것이라, 
-            // update에서 아무 값도 안주면 바로 다 삭제되는 방식입니다.
-
-
-            /**
-             * TODO : 현재 객관식 업데이트에서 obo step을 업데이트 하는 방법을 고도화 하기
-             * 고도화 하는 방법은 다음과 같음
-             * 1. 현재 삭제 방식을 다듬어서, 값이 주어지지 않는다면, 삭제가 되지 않도록 하기
-             * 2. 개별 삭제 기능을 구현할 것.
-             */
-            boolean oboProvided = request.getObo() != null;
-            boolean oboDisabled = Boolean.FALSE.equals(request.getOboEnabled());
-
-            if (oboProvided || oboDisabled) {
-                oboStepRepository.deleteByProblem_Id(prodId);
-            }
-
-            // 개별 업데이트 개선 필요
-            if (Boolean.TRUE.equals(problemObjective.getOboEnabled()) && oboProvided && request.getObo().getSteps() != null && !request.getObo().getSteps().isEmpty()) {
-                List<OboStep> oboSteps = request.getObo().getSteps().stream()
-                    .map(step -> toOboStep(problem, step))
-                    .toList();
-                oboStepRepository.saveAll(oboSteps);
-            }
-            return new ProblemUpdateObjectiveResponse(prodId, request.getCategory(), request.getTitle(), problem.getUpatedAt().toString());
+            return new ProblemUpdateObjectiveResponse(prodId, problem.getCategory(), problem.getTitle(), problem.getUpatedAt().toString());
     }
 
     // 코딩형
@@ -122,35 +86,10 @@ public class ProblemUpdateService {
         checkOwner(problem, userId);
         ProblemCoding problemCoding = problemCodingRepository.findById(probId).orElseThrow();
 
-        problem.updateProblem(request.getTitle(), request.getCategory(), request.getDifficulty(), request.getVisibility());
+        problem.updateProblem(request.getTitle(), null, request.getDifficulty(), null);
+        problemCoding.updateProblemCoding(request.getSummary(), request.getDescription());
 
-        ProblemUpdateCodingRequest.Constraints constraints = request.getConstraints();
-        ProblemUpdateCodingRequest.Obo obo = request.getObo();
-
-        problemCoding.updateProblemCoding(
-            request.getSummary(),
-            request.getDescription(),
-            request.getInputDescription(),
-            request.getOutputDescription(),
-            constraints != null ? constraints.getTimeLimitMs() : null,
-            constraints != null ? constraints.getMemoryLimitMb() : null,
-            constraints != null ? constraints.getAllowedLanguages() : null,
-            request.getTestcases(),
-            request.getFileUrl(),
-            obo != null ? obo.getEnabled() : null,
-            obo != null ? obo.getInitialImageUrl() : null
-        );
-
-        if (request.getTestcases() != null) {
-            s3Service.uploadCodingTestcases(probId, request.getTestcases());
-        }
-
-        return new ProblemUpdateCodingResponse(
-            probId,
-            problem.getType(),
-            problem.getTitle(),
-            problem.getUpatedAt().toString()
-        );
+        return new ProblemUpdateCodingResponse(probId, problem.getType(), problem.getTitle(), problem.getUpatedAt().toString());
     }
     
     // 실습형
@@ -161,31 +100,10 @@ public class ProblemUpdateService {
             checkOwner(problem, userId);
             ProblemPractice problemPractice = problemPracticeRepository.findById(probId).orElseThrow();
 
-            problem.updateProblem(
-                request.getTitle(),
-                request.getCategory(),
-                request.getDifficulty(),
-                request.getVisibility()
-            );
+            problem.updateProblem(request.getTitle(), null, request.getDifficulty(), null);
+            problemPractice.updatePractice(request.getSummary(), request.getDescription());
 
-            String flagHash = request.getFlag() != null ? hashFlag(request.getFlag()) : null;
-
-            problemPractice.updatePractice(
-                request.getSummary(),
-                request.getDescription(),
-                request.getOsImage(),
-                request.getAllowedCommands(),
-                request.getCpuLimit(),
-                request.getMemoryLimit(),
-                flagHash
-            );
-
-            return new ProblemUpdatePracticeResponse(
-                probId,
-                problem.getType(),
-                problem.getTitle(),
-                problem.getUpatedAt().toString()
-            );
+            return new ProblemUpdatePracticeResponse(probId, problem.getType(), problem.getTitle(), problem.getUpatedAt().toString());
     }
     
     // flag 원문을 암호화해서 저장 - DB에 정답 노출 안 되도록 (실습형)


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

객관식/코딩형/실습형 문제 수정을 title, summary, description, difficulty 4개 필드로 통일

- 3가지 유형 수정 Request DTO를 4개 필드로 통일
- 엔티티 update 메서드 summary, description만 받도록 간소화
- 추후 유형별 고도화 시 개별 확장 예정

## 관련 이슈
Closes #312

<!-- 주석은 제외되고 올라가니 무시하세요 -->
