### PR TITLE
[feat] 그룹 문제 삭제 API 구현 (#314)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -93,6 +93,16 @@ public class GroupController {
         return ResponseEntity.ok(ApiResponse.success("그룹 문제 목록 조회 성공", response));
     }
 
+    // 그룹 문제 삭제
+    @DeleteMapping("/{groupId}/problems/{problemId}")
+    public ResponseEntity<ApiResponse<Void>> deleteGroupProblem(
+            @PathVariable Long groupId,
+            @PathVariable Long problemId,
+            @AuthenticationPrincipal String userId) {
+        groupService.deleteGroupProblem(groupId, problemId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("그룹에서 문제가 삭제되었습니다.", null));
+    }
+
     // 공개 문제 그룹에 추가
     @PostMapping("/{groupId}/problems")
     public ResponseEntity<ApiResponse<Void>> addProblems(

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupProblemRepository.java
@@ -11,6 +11,7 @@ import net.diveon.backend.domain.group.entity.GroupProblem;
 public interface GroupProblemRepository extends JpaRepository<GroupProblem, Long> {
     long countByGroupId(Long groupId);
     boolean existsByGroupIdAndProblemId(Long groupId, Long problemId);
+    java.util.Optional<net.diveon.backend.domain.group.entity.GroupProblem> findByGroupIdAndProblemId(Long groupId, Long problemId);
     Page<GroupProblem> findAllByGroupId(Long groupId, Pageable pageable);
     List<GroupProblem> findAllByGroupId(Long groupId);
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -29,8 +29,10 @@ import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.GroupAccessDeniedException;
+import net.diveon.backend.global.exception.GroupLeaderPermissionDeniedException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.GroupProblemAlreadyExistsException;
+import net.diveon.backend.global.exception.ProblemNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -252,6 +254,29 @@ public class GroupService {
         }
 
         groupProblemRepository.save(new GroupProblem(problem, group));
+    }
+
+    // 그룹 문제 삭제
+    @Transactional
+    public void deleteGroupProblem(Long groupId, Long problemId, Long userId) {
+        groupRepository.findById(groupId).orElseThrow(GroupNotFoundException::new);
+
+        GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupAccessDeniedException::new);
+
+        if (groupUser.getRole() != GroupUser.GroupRole.LEADER) {
+            throw new GroupLeaderPermissionDeniedException();
+        }
+
+        GroupProblem groupProblem = groupProblemRepository.findByGroupIdAndProblemId(groupId, problemId)
+                .orElseThrow(ProblemNotFoundException::new);
+
+        Problem problem = groupProblem.getProblem();
+        groupProblemRepository.delete(groupProblem);
+
+        if ("group".equals(problem.getVisibility())) {
+            problemRepository.delete(problem);
+        }
     }
 
     // 내가 속한 그룹 목록 조회


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

그룹 문제 삭제 시 visibility 분기 처리 구현

- DELETE /api/groups/{groupId}/problems/{problemId} 신규 구현
- visibility=group → GroupProblem + Problem 모두 삭제
- visibility=public → GroupProblem만 삭제, Problem 유지
- 그룹장만 삭제 가능 (403)

## 관련 이슈
Closes #314


<!-- 주석은 제외되고 올라가니 무시하세요 -->
