### PR TITLE
[feat] 챌린지 탭 visibility 필터링 및 대회 문제 생성 방식 변경 (#316)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestProblemNormalController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestProblemNormalController.java
@@ -14,7 +14,6 @@ import net.diveon.backend.domain.contest.dto.request.ContestProblemPointsUpdateR
 import net.diveon.backend.domain.contest.dto.response.ContestProblemListResponse;
 import net.diveon.backend.domain.contest.service.ContestProblemNormalService;
 import net.diveon.backend.global.response.ApiResponse;
-import org.springframework.web.bind.annotation.PostMapping;
 
 
 @RestController
@@ -56,19 +55,5 @@ public class ContestProblemNormalController {
         return ResponseEntity.ok(ApiResponse.success("문제 배점이 수정되었습니다.", null));
     }
 
-    @PostMapping("/{contestId}/problems/{problemId}/add/{point}")
-    public ResponseEntity<ApiResponse<Void>> addProblemToContest(
-        @PathVariable Long contestId,
-        @PathVariable Long problemId,
-        @PathVariable Integer point,
-        @AuthenticationPrincipal String userId
-    ){
-        contestProblemNormalService.addProblemToContestServiceLogic(
-            contestId, 
-            problemId, 
-            Long.parseLong(userId), 
-            point);
-        return ResponseEntity.ok(ApiResponse.success("해당 문제가 대회에 추가되었습니다.", null));
-    }
     
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestProblemNormalService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestProblemNormalService.java
@@ -101,8 +101,12 @@ public class ContestProblemNormalService {
             throw new ContestAccessDeniedException();
         }
 
-        // 현재는 대회 문제만 제거하고, 문제 자체는 삭제하지 않는것으로 구현함
+        Problem problem = contestProblem.getProblem();
         contestProblemRepository.delete(contestProblem);
+
+        if (contest.getStatus() == Contest.ContestStatus.UPCOMING && "contest".equals(problem.getVisibility())) {
+            problemRepository.delete(problem);
+        }
     }
 
     @Transactional

--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
@@ -30,19 +30,21 @@ public class ProblemController {
         @AuthenticationPrincipal String userId,
         @RequestParam(defaultValue = "1") int page,
         @RequestParam(required = false) String title,
+        @RequestParam(required = false) String type,
         @RequestParam(required = false) String category,
         @RequestParam(required = false) String difficulty,
-        @RequestParam(required = false) String visibility,
-        @RequestParam(defaultValue = "false") boolean onlyUnsolved
+        @RequestParam(defaultValue = "false") boolean onlyUnsolved,
+        @RequestParam(defaultValue = "false") boolean onlyMine
     ) {
         ProblemListResponse responseData = problemListService.listProblems(
             Long.parseLong(userId),
             page,
             title,
+            type,
             category,
             difficulty,
-            visibility,
-            onlyUnsolved
+            onlyUnsolved,
+            onlyMine
         );
 
         return ResponseEntity.status(200)

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreateCodingRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreateCodingRequest.java
@@ -14,6 +14,7 @@ public class ProblemCreateCodingRequest {
     private String difficulty;
     private String visibility;
     private Long groupId;
+    private Long contestId;
     private Constraints constraints;
 
     @JsonProperty("inputDescription")
@@ -52,6 +53,8 @@ public class ProblemCreateCodingRequest {
 
     public Long getGroupId() { return groupId; }
     public void setGroupId(Long groupId) { this.groupId = groupId; }
+    public Long getContestId() { return contestId; }
+    public void setContestId(Long contestId) { this.contestId = contestId; }
 
     public Constraints getConstraints() { return constraints; }
     public void setConstraints(Constraints constraints) { this.constraints = constraints; }

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreateObjectiveRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreateObjectiveRequest.java
@@ -49,6 +49,7 @@ public class ProblemCreateObjectiveRequest {
     private String difficulty;
     private String visibility;
     private Long groupId;
+    private Long contestId;
     private String summary;
     private List<ForDtoChoice> choices;
     private List<Integer> answer;
@@ -100,6 +101,10 @@ public class ProblemCreateObjectiveRequest {
 
     public Long getGroupId() {
         return groupId;
+    }
+
+    public Long getContestId() {
+        return contestId;
     }
 
     public void setGroupId(Long groupId) {

--- a/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/request/ProblemCreatePracticeRequest.java
@@ -38,6 +38,7 @@ public class ProblemCreatePracticeRequest {
     private String visibility;
 
     private Long groupId;
+    private Long contestId;
 
     @NotBlank
     private String osImage;
@@ -81,6 +82,8 @@ public class ProblemCreatePracticeRequest {
 
     public Long getGroupId() { return groupId; }
     public void setGroupId(Long groupId) { this.groupId = groupId; }
+    public Long getContestId() { return contestId; }
+    public void setContestId(Long contestId) { this.contestId = contestId; }
 
     public String getOsImage() { return osImage; }
     public void setOsImage(String osImage) { this.osImage = osImage; }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemCreateService.java
@@ -1,9 +1,17 @@
 package net.diveon.backend.domain.problem.service;
 
+import net.diveon.backend.domain.contest.entity.Contest;
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.entity.ContestProblem;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.contest.repository.ContestProblemRepository;
+import net.diveon.backend.domain.contest.repository.ContestRepository;
+import net.diveon.backend.global.exception.ContestAccessDeniedException;
 import net.diveon.backend.domain.group.entity.Group;
 import net.diveon.backend.domain.group.entity.GroupProblem;
 import net.diveon.backend.domain.group.repository.GroupProblemRepository;
 import net.diveon.backend.domain.group.repository.GroupRepository;
+import net.diveon.backend.global.exception.ContestNotFoundException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.domain.problem.dto.request.ProblemCreateObjectiveRequest;
 import net.diveon.backend.domain.problem.dto.request.ProblemCreatePracticeRequest;
@@ -43,6 +51,9 @@ public class ProblemCreateService {
     private final S3Service s3Service;
     private final GroupRepository groupRepository;
     private final GroupProblemRepository groupProblemRepository;
+    private final ContestRepository contestRepository;
+    private final ContestProblemRepository contestProblemRepository;
+    private final ContestParticipantRepository contestParticipantRepository;
 
     public ProblemCreateService(ProblemObjectiveRepository problemObjectiveRepository,
         ProblemPracticeRepository problemPracticeRepository,
@@ -52,7 +63,10 @@ public class ProblemCreateService {
         OboStepRepository oboStepRepository,
         S3Service s3Service,
         GroupRepository groupRepository,
-        GroupProblemRepository groupProblemRepository){
+        GroupProblemRepository groupProblemRepository,
+        ContestRepository contestRepository,
+        ContestProblemRepository contestProblemRepository,
+        ContestParticipantRepository contestParticipantRepository){
         this.problemObjectiveRepository = problemObjectiveRepository;
         this.problemPracticeRepository = problemPracticeRepository;
         this.problemCodingRepository = problemCodingRepository;
@@ -62,6 +76,9 @@ public class ProblemCreateService {
         this.s3Service = s3Service;
         this.groupRepository = groupRepository;
         this.groupProblemRepository = groupProblemRepository;
+        this.contestRepository = contestRepository;
+        this.contestProblemRepository = contestProblemRepository;
+        this.contestParticipantRepository = contestParticipantRepository;
     }
 
 
@@ -116,6 +133,7 @@ public class ProblemCreateService {
          */
 
         saveGroupProblemIfNeeded(savedProblem, request.getGroupId(), request.getVisibility());
+        saveContestProblemIfNeeded(savedProblem, request.getContestId(), request.getVisibility(), userId);
 
         return new ProblemCreateObjectiveResponse(
                 savedProblem.getId(),
@@ -158,6 +176,7 @@ public class ProblemCreateService {
         s3Service.uploadDockerfileZip(savedProblem.getId(), request.getDockerfile());
 
         saveGroupProblemIfNeeded(savedProblem, request.getGroupId(), request.getVisibility());
+        saveContestProblemIfNeeded(savedProblem, request.getContestId(), request.getVisibility(), userId);
 
         return new ProblemCreatePracticeResponse(
                 savedProblem.getId(),
@@ -204,6 +223,7 @@ public class ProblemCreateService {
         s3Service.uploadCodingTestcases(savedProblem.getId(), request.getTestcases());
 
         saveGroupProblemIfNeeded(savedProblem, request.getGroupId(), request.getVisibility());
+        saveContestProblemIfNeeded(savedProblem, request.getContestId(), request.getVisibility(), userId);
 
         return new ProblemCreateCodingResponse(
                 savedProblem.getId(),
@@ -229,6 +249,17 @@ public class ProblemCreateService {
             Group group = groupRepository.findById(groupId)
                     .orElseThrow(GroupNotFoundException::new);
             groupProblemRepository.save(new GroupProblem(problem, group));
+        }
+    }
+
+    private void saveContestProblemIfNeeded(Problem problem, Long contestId, String visibility, long userId) {
+        if ("contest".equals(visibility) && contestId != null) {
+            Contest contest = contestRepository.findById(contestId)
+                    .orElseThrow(ContestNotFoundException::new);
+            contestParticipantRepository.findByContestIdAndUserId(contestId, userId)
+                    .filter(p -> p.getRole() == ContestParticipant.ContestRole.ADMIN)
+                    .orElseThrow(ContestAccessDeniedException::new);
+            contestProblemRepository.save(new ContestProblem(contest, problem, 100));
         }
     }
 

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
@@ -38,10 +38,11 @@ public class ProblemListService {
         long userId,
         int page,
         String title,
+        String type,
         String category,
         String difficulty,
-        String visibility,
-        boolean onlyUnsolved
+        boolean onlyUnsolved,
+        boolean onlyMine
     ) {
         userRepository.findById(userId).orElseThrow();
 
@@ -53,7 +54,7 @@ public class ProblemListService {
             Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        Specification<Problem> spec = buildSpecification(title, category, difficulty, visibility, onlyUnsolved, solvedIds);
+        Specification<Problem> spec = buildSpecification(userId, title, type, category, difficulty, onlyUnsolved, onlyMine, solvedIds);
         Page<Problem> problemPage = problemRepository.findAll(spec, pageable);
 
         List<ProblemListItemResponse> problemList = problemPage.getContent()
@@ -64,13 +65,24 @@ public class ProblemListService {
         return ProblemListResponse.of(problemPage, problemList);
     }
 
-    private Specification<Problem> buildSpecification(String title, String category, String difficulty,
-                                                      String visibility, boolean onlyUnsolved, Set<Long> solvedIds) {
+    private Specification<Problem> buildSpecification(long userId, String title, String type, String category, String difficulty,
+                                                      boolean onlyUnsolved, boolean onlyMine, Set<Long> solvedIds) {
         return (root, query, cb) -> {
             var predicates = new java.util.ArrayList<>();
 
+            if (onlyMine) {
+                predicates.add(cb.equal(root.get("author").get("id"), userId));
+                predicates.add(cb.equal(root.get("visibility"), "private"));
+            } else {
+                predicates.add(cb.equal(root.get("visibility"), "public"));
+            }
+
             if (title != null && !title.isEmpty()) {
                 predicates.add(cb.like(root.get("title"), "%" + title + "%"));
+            }
+
+            if (type != null && !type.isEmpty()) {
+                predicates.add(cb.equal(root.get("type"), type));
             }
 
             if (category != null && !category.isEmpty()) {
@@ -79,10 +91,6 @@ public class ProblemListService {
 
             if (difficulty != null && !difficulty.isEmpty()) {
                 predicates.add(cb.equal(root.get("difficulty"), difficulty));
-            }
-
-            if (visibility != null && !visibility.isEmpty()) {
-                predicates.add(cb.equal(root.get("visibility"), visibility));
             }
 
             if (onlyUnsolved && !solvedIds.isEmpty()) {


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용

문제 목록 visibility 필터링 및 대회 문제 생성 방식 그룹과 통일

- GET /api/problems 기본값 public 문제만 반환
- onlyMine=true 파라미터 추가 (내 비공개 문제 보기)
- type 파라미터 추가 (objective/coding/practice 유형 필터)
- visibility 파라미터 제거 (챌린지 탭은 공개 문제만 표시)
- 문제 생성 시 contestId 넘기면 ContestProblem 자동 생성 (배점 기본 100)
- 기존 addProblemToContest API 제거
- 대회 문제 삭제 시 UPCOMING이면 Problem도 같이 삭제

## 관련 이슈
Closes #316

## 관련 이슈
Closes #


<!-- 주석은 제외되고 올라가니 무시하세요 -->
