### PR TITLE
[feat] 대회 관리자 이전 구현 (#319)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/controller/ContestParticipantController.java
+++ b/src/main/java/net/diveon/backend/domain/contest/controller/ContestParticipantController.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import net.diveon.backend.domain.contest.dto.request.ContestLeadershipTransferRequest;
 import net.diveon.backend.domain.contest.dto.request.ContestParticipantBanRequest;
+import net.diveon.backend.domain.contest.dto.response.ContestLeadershipTransferResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestParticipantBanResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestParticipantListResponse;
 import net.diveon.backend.domain.contest.service.ContestParticipantService;
@@ -59,5 +61,18 @@ public class ContestParticipantController {
         ContestParticipantBanResponse response = contestParticipantService.updateContestParticipantBanStatus(
                 contestId, participantUserId, Long.parseLong(userId), request);
         return ResponseEntity.ok(ApiResponse.success("해당 참가자의 상태가 변경되었습니다.", response));
+    }
+
+    @PatchMapping("/leadership/transfer")
+    public ResponseEntity<ApiResponse<ContestLeadershipTransferResponse>> transferContestLeadership(
+            @PathVariable Long contestId,
+            @AuthenticationPrincipal String userId,
+            @RequestBody ContestLeadershipTransferRequest request) {
+        ContestLeadershipTransferResponse response = contestParticipantService.transferContestLeadership(
+                contestId,
+                Long.parseLong(userId),
+                request
+        );
+        return ResponseEntity.ok(ApiResponse.success("대회 관리자 권한이 이관되었습니다.", response));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestLeadershipTransferRequest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/request/ContestLeadershipTransferRequest.java
@@ -1,0 +1,10 @@
+package net.diveon.backend.domain.contest.dto.request;
+
+public class ContestLeadershipTransferRequest {
+
+    private Long victimUserId;
+
+    public Long getVictimUserId() {
+        return victimUserId;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestLeadershipTransferResponse.java
+++ b/src/main/java/net/diveon/backend/domain/contest/dto/response/ContestLeadershipTransferResponse.java
@@ -1,0 +1,20 @@
+package net.diveon.backend.domain.contest.dto.response;
+
+public class ContestLeadershipTransferResponse {
+
+    private final String previousLeaderNickname;
+    private final String newLeaderNickname;
+
+    public ContestLeadershipTransferResponse(String previousLeaderNickname, String newLeaderNickname) {
+        this.previousLeaderNickname = previousLeaderNickname;
+        this.newLeaderNickname = newLeaderNickname;
+    }
+
+    public String getPreviousLeaderNickname() {
+        return previousLeaderNickname;
+    }
+
+    public String getNewLeaderNickname() {
+        return newLeaderNickname;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/Contest.java
@@ -158,4 +158,9 @@ public class Contest {
         this.endTime = endTime;
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void transferLeadership(User newLeader) {
+        this.createdBy = newLeader;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/net/diveon/backend/domain/contest/entity/ContestParticipant.java
+++ b/src/main/java/net/diveon/backend/domain/contest/entity/ContestParticipant.java
@@ -86,6 +86,10 @@ public class ContestParticipant {
     public void ban() { this.isBanned = true; }
     public void unban() { this.isBanned = false; }
 
+    public void updateRole(ContestRole role) {
+        this.role = role;
+    }
+
     public void addScore(Integer points, LocalDateTime solvedAt) {
         this.score += points;
         this.lastSolvedAt = solvedAt;

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestParticipantService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestParticipantService.java
@@ -1,13 +1,16 @@
 package net.diveon.backend.domain.contest.service;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import net.diveon.backend.domain.contest.dto.request.ContestLeadershipTransferRequest;
 import net.diveon.backend.domain.contest.dto.request.ContestParticipantBanRequest;
+import net.diveon.backend.domain.contest.dto.response.ContestLeadershipTransferResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestParticipantBanResponse;
 import net.diveon.backend.domain.contest.dto.response.ContestParticipantListResponse;
 import net.diveon.backend.domain.contest.entity.Contest;
@@ -137,6 +140,51 @@ public class ContestParticipantService {
         }
 
         return new ContestParticipantBanResponse(participant.getIsBanned());
+    }
+
+    @Transactional
+    public ContestLeadershipTransferResponse transferContestLeadership(
+            Long contestId, Long requestUserId, ContestLeadershipTransferRequest request) {
+        userRepository.findById(requestUserId)
+                .orElseThrow(() -> new UserNotFoundException("대회 관리자 권한 이관 요청자를 찾을 수 없습니다."));
+        User targetUser = userRepository.findById(request.getVictimUserId())
+                .orElseThrow(() -> new UserNotFoundException("대회 관리자 권한 이관 대상 사용자를 찾을 수 없습니다."));
+
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(() -> new ContestNotFoundException("관리자 권한을 이관할 대상 대회를 찾을 수 없습니다."));
+
+        ContestParticipant previousLeader = contestParticipantRepository.findByContestIdAndUserId(
+                contestId,
+                requestUserId
+        ).orElseThrow(() -> new ContestAccessDeniedException("대회 관리자 권한 이관 요청자가 해당 대회의 참가자가 아닙니다."));
+
+        boolean isContestCreator = contest.getCreatedBy().getId().equals(requestUserId);
+        boolean isContestAdmin = previousLeader.getRole() == ContestParticipant.ContestRole.ADMIN;
+        if (!isContestCreator || !isContestAdmin) {
+            throw new ContestAccessDeniedException("대회 관리자 권한 이관은 현재 대회 관리자만 요청할 수 있습니다.");
+        }
+
+        if (Objects.equals(requestUserId, request.getVictimUserId())) {
+            throw new ContestAccessDeniedException("관리자 권한은 자기 자신에게 이관할 수 없습니다.");
+        }
+
+        ContestParticipant newLeader = contestParticipantRepository.findByContestIdAndUserId(
+                contestId,
+                targetUser.getId()
+        ).orElseThrow(() -> new ContestParticipantNotFoundException("대회 관리자 권한 이관 대상 사용자가 해당 대회의 참가자가 아닙니다."));
+
+        if (Boolean.TRUE.equals(newLeader.getIsBanned())) {
+            throw new ContestAccessDeniedException("차단된 참가자에게 관리자 권한을 이관할 수 없습니다.");
+        }
+
+        previousLeader.updateRole(ContestParticipant.ContestRole.PARTICIPANT);
+        newLeader.updateRole(ContestParticipant.ContestRole.ADMIN);
+        contest.transferLeadership(targetUser);
+
+        return new ContestLeadershipTransferResponse(
+                previousLeader.getUser().getNickname(),
+                targetUser.getNickname()
+        );
     }
 
     private ContestParticipantListResponse.ParticipantItem toResponse(ContestParticipant participant) {

--- a/src/main/java/net/diveon/backend/global/exception/ContestNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestNotFoundException.java
@@ -4,4 +4,8 @@ public class ContestNotFoundException extends RuntimeException {
     public ContestNotFoundException() {
         super("존재하지 않는 대회입니다.");
     }
+
+    public ContestNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/net/diveon/backend/global/exception/ContestParticipantNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/ContestParticipantNotFoundException.java
@@ -4,4 +4,8 @@ public class ContestParticipantNotFoundException extends RuntimeException {
     public ContestParticipantNotFoundException() {
         super("대회 참가자를 찾을 수 없습니다.");
     }
+
+    public ContestParticipantNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/net/diveon/backend/global/exception/UserNotFoundException.java
+++ b/src/main/java/net/diveon/backend/global/exception/UserNotFoundException.java
@@ -5,4 +5,8 @@ public class UserNotFoundException extends RuntimeException {
     public UserNotFoundException() {
         super("존재하지 않는 사용자입니다.");
     }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- [feat] 대회 관리자 이전 구현 (#319)

브랜치명이 refactor인건 비밀

## 관련 이슈
Closes [feat] 대회 관리자 이전 구현 (#319)


<!-- 주석은 제외되고 올라가니 무시하세요 -->
