### PR TITLE
[fix] 일반 챌린지 채점 요청시, 모든 유형의 문제 제출횟수 증가 - 객관식, 실습형은 정답시 정답횟수 증가

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeAsyncService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeAsyncService.java
@@ -150,6 +150,7 @@ public class SubmissionGradeAsyncService {
             SolveResult result = new SolveResult(submission, SolveResultState.CORRECT);
             solveResultRepository.save(result);
             submission.setSubmissionState(SubmissionState.COMPLETED);
+            problem.incrementSolvedCount();
         }else{
             //오답
             SolveResult result = new SolveResult(submission, SolveResultState.WRONG);
@@ -197,6 +198,7 @@ public class SubmissionGradeAsyncService {
             SolveResult result = new SolveResult(submission, SolveResultState.CORRECT);
             solveResultRepository.save(result);
             submission.setSubmissionState(SubmissionState.COMPLETED);
+            problem.incrementSolvedCount();
         }else{
             //오답
             SolveResult result = new SolveResult(submission, SolveResultState.WRONG);

--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeStarterService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeStarterService.java
@@ -179,6 +179,9 @@ public class SubmissionGradeStarterService {
 
 
 
+        
+        problem.incrementSolvedCount();
+        problemRepository.save(problem);
         // 그냥 오류 방지용, 바꿔야함
         return new SubmissionGradeResponse(submission.getId(), probId, SubmissionState.PENDING.name(), problemType);
     }


### PR DESCRIPTION
… 증가 (#327)

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 일반 챌린지 채점 요청시, 모든 유형의 문제 제출횟수 증가 - 객관식, 실습형은 정답시 정답횟수 증가

## 관련 이슈
Closes #327


<!-- 주석은 제외되고 올라가니 무시하세요 -->
