### PR TITLE
[Feat] 대회 문제 목록 조회 응답에 submittedCount/solvedCount 추가(#329)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/others/ForDtoContestProblem.java
+++ b/src/main/java/net/diveon/backend/domain/contest/others/ForDtoContestProblem.java
@@ -14,6 +14,7 @@ public class ForDtoContestProblem {
 
     private String title;
     private Integer points;
+    private Integer submittedCount;
     private Integer solvedCount;
     private String category;
 
@@ -24,12 +25,13 @@ public class ForDtoContestProblem {
     }
 
     public ForDtoContestProblem(String id, Long contestProblemId, Long problemId, String title, Integer points,
-                                Integer solvedCount, String category, Boolean isSolved) {
+                                Integer submittedCount, Integer solvedCount, String category, Boolean isSolved) {
         this.id = id;
         this.contestProblemId = contestProblemId;
         this.problemId = problemId;
         this.title = title;
         this.points = points;
+        this.submittedCount = submittedCount;
         this.solvedCount = solvedCount;
         this.category = category;
         this.isSolved = isSolved;
@@ -40,6 +42,7 @@ public class ForDtoContestProblem {
     public Long getProblemId() { return problemId; }
     public String getTitle() { return title; }
     public Integer getPoints() { return points; }
+    public Integer getSubmittedCount() { return submittedCount; }
     public Integer getSolvedCount() { return solvedCount; }
     public String getCategory() { return category; }
     public Boolean getIsSolved() { return isSolved; }
@@ -49,6 +52,7 @@ public class ForDtoContestProblem {
     public void setProblemId(Long problemId) { this.problemId = problemId; }
     public void setTitle(String title) { this.title = title; }
     public void setPoints(Integer points) { this.points = points; }
+    public void setSubmittedCount(Integer submittedCount) { this.submittedCount = submittedCount; }
     public void setSolvedCount(Integer solvedCount) { this.solvedCount = solvedCount; }
     public void setCategory(String category) { this.category = category; }
     public void setIsSolved(Boolean isSolved) { this.isSolved = isSolved; }

--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestSubmissionRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestSubmissionRepository.java
@@ -29,4 +29,20 @@ public interface ContestSubmissionRepository extends JpaRepository<ContestSubmis
     List<Object[]> countSolvedByUserForContest(@Param("contestId") Long contestId);
 
     Optional<ContestSubmission> findBySolveSubmissionId(Long solveSubmissionId);
+
+    @Query("""
+            SELECT cs.contestProblem.id, COUNT(cs)
+            FROM ContestSubmission cs
+            WHERE cs.contest.id = :contestId
+            GROUP BY cs.contestProblem.id
+            """)
+    List<Object[]> countSubmissionsPerProblem(@Param("contestId") Long contestId);
+
+    @Query("""
+            SELECT cs.contestProblem.id, COUNT(cs)
+            FROM ContestSubmission cs
+            WHERE cs.contest.id = :contestId AND cs.isCorrect = true
+            GROUP BY cs.contestProblem.id
+            """)
+    List<Object[]> countSolvedPerProblem(@Param("contestId") Long contestId);
 }

--- a/src/main/java/net/diveon/backend/domain/contest/service/ContestProblemNormalService.java
+++ b/src/main/java/net/diveon/backend/domain/contest/service/ContestProblemNormalService.java
@@ -1,6 +1,8 @@
 package net.diveon.backend.domain.contest.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
@@ -70,9 +72,15 @@ public class ContestProblemNormalService {
         Set<Long> solvedContestProblemIds = Set.copyOf(
                 contestSubmissionRepository.findSolvedContestProblemIds(contestId, userId));
 
+        Map<Long, Integer> submittedCountMap = toCountMap(
+                contestSubmissionRepository.countSubmissionsPerProblem(contestId));
+        Map<Long, Integer> solvedCountMap = toCountMap(
+                contestSubmissionRepository.countSolvedPerProblem(contestId));
+
         List<ForDtoContestProblem> problems = new java.util.ArrayList<>();
         for (int i = 0; i < contestProblems.size(); i++) {
-            problems.add(toResponse(contestProblems.get(i), solvedContestProblemIds, i + 1));
+            problems.add(toResponse(contestProblems.get(i), solvedContestProblemIds,
+                    submittedCountMap, solvedCountMap, i + 1));
         }
 
         return new ContestProblemListResponse(problems);
@@ -185,27 +193,30 @@ public class ContestProblemNormalService {
         contestProblemRepository.save(contestProblem);
     }
 
-    private ForDtoContestProblem toResponse(ContestProblem contestProblem, Set<Long> solvedContestProblemIds, int sequence) {
+    private ForDtoContestProblem toResponse(ContestProblem contestProblem, Set<Long> solvedContestProblemIds,
+                                             Map<Long, Integer> submittedCountMap, Map<Long, Integer> solvedCountMap,
+                                             int sequence) {
         Problem problem = contestProblem.getProblem();
-
-        /*
-         * 현재 대회 문제는 신규 생성되고 Problem.visibility 값이 "contest"인 전용 문제만 사용하므로
-         * solvedCount는 Problem.solvedCount를 그대로 사용한다.
-         *
-         * 추후 기존 문제를 대회에 추가할 수 있게 되면 Problem.solvedCount는 전체 풀이 수가 되므로,
-         * ContestSubmission에서 contest_problem_id별 is_correct = true인 distinct user_id 수를
-         * 집계하는 방식으로 확장해야 한다.
-         */
+        Long cpId = contestProblem.getId();
         return new ForDtoContestProblem(
                 buildDisplayId(problem.getCategory(), sequence),
-                contestProblem.getId(),
+                cpId,
                 problem.getId(),
                 problem.getTitle(),
                 contestProblem.getPoints(),
-                problem.getSolvedCount(),
+                submittedCountMap.getOrDefault(cpId, 0),
+                solvedCountMap.getOrDefault(cpId, 0),
                 problem.getCategory(),
-                solvedContestProblemIds.contains(contestProblem.getId())
+                solvedContestProblemIds.contains(cpId)
         );
+    }
+
+    private Map<Long, Integer> toCountMap(List<Object[]> rows) {
+        Map<Long, Integer> map = new HashMap<>();
+        for (Object[] row : rows) {
+            map.put((Long) row[0], ((Number) row[1]).intValue());
+        }
+        return map;
     }
 
     private String buildDisplayId(String category, int sequence) {


### PR DESCRIPTION
- ForDtoContestProblem에 submittedCount 필드 추가
- solvedCount를 Problem.solvedCount에서 ContestSubmission 기반 집계로 변경
- ContestSubmissionRepository에 배치 집계 쿼리 2개 추가 (countSubmissionsPerProblem, countSolvedPerProblem)
- ContestProblemNormalService에서 N+1 없이 맵으로 일괄 조회 후 toResponse에 전달


## 관련 이슈
Closes #329


<!-- 주석은 제외되고 올라가니 무시하세요 -->
