### PR TITLE
feat: 실습형 문제 이미지 미준비 시 목록/상세 조회에서 제외 (#331)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -25,6 +25,8 @@ import net.diveon.backend.domain.group.repository.GroupTagRepository;
 import net.diveon.backend.domain.group.repository.GroupUserRepository;
 import net.diveon.backend.domain.contest.repository.ContestRepository;
 import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.entity.ProblemPractice;
+import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.problem.service.ProblemDeleteService;
 import net.diveon.backend.domain.user.entity.User;
@@ -41,6 +43,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class GroupService {
@@ -52,6 +56,7 @@ public class GroupService {
     private final GroupProblemRepository groupProblemRepository;
     private final UserRepository userRepository;
     private final ProblemRepository problemRepository;
+    private final ProblemPracticeRepository problemPracticeRepository;
     private final ContestRepository contestRepository;
     private final ProblemDeleteService problemDeleteService;
 
@@ -61,6 +66,7 @@ public class GroupService {
                         GroupProblemRepository groupProblemRepository,
                         UserRepository userRepository,
                         ProblemRepository problemRepository,
+                        ProblemPracticeRepository problemPracticeRepository,
                         ContestRepository contestRepository,
                         ProblemDeleteService problemDeleteService) {
         this.groupRepository = groupRepository;
@@ -70,6 +76,7 @@ public class GroupService {
         this.groupProblemRepository = groupProblemRepository;
         this.userRepository = userRepository;
         this.problemRepository = problemRepository;
+        this.problemPracticeRepository = problemPracticeRepository;
         this.contestRepository = contestRepository;
         this.problemDeleteService = problemDeleteService;
     }
@@ -224,8 +231,24 @@ public class GroupService {
         Pageable pageable = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "assignedAt"));
         Page<GroupProblem> groupProblemPage = groupProblemRepository.findAllByGroupId(groupId, pageable);
 
+        Set<Long> practiceProblemIds = groupProblemPage.getContent().stream()
+                .map(GroupProblem::getProblem)
+                .filter(p -> "practice".equals(p.getType()))
+                .map(Problem::getId)
+                .collect(Collectors.toSet());
+
+        Set<Long> readyPracticeIds = practiceProblemIds.isEmpty() ? Set.of() :
+                problemPracticeRepository.findAllById(practiceProblemIds).stream()
+                        .filter(pp -> "READY".equals(pp.getImageStatus()))
+                        .map(ProblemPractice::getProbId)
+                        .collect(Collectors.toSet());
+
         List<GroupProblemListResponse.ProblemItem> problems = groupProblemPage.getContent()
                 .stream()
+                .filter(gp -> {
+                    if (!"practice".equals(gp.getProblem().getType())) return true;
+                    return readyPracticeIds.contains(gp.getProblem().getId());
+                })
                 .map(GroupProblemListResponse.ProblemItem::of)
                 .toList();
 

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemDetailService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemDetailService.java
@@ -67,6 +67,9 @@ public class ProblemDetailService {
 
     private ProblemDetailPracticeResponse detailProblemPractice(Problem problem, long probId) {
         ProblemPractice problemPractice = problemPracticeRepository.findById(probId).orElseThrow();
+        if (!"READY".equals(problemPractice.getImageStatus())) {
+            throw new ProblemNotFoundException(probId + "번 문제는 아직 준비 중입니다.");
+        }
         return ProblemDetailPracticeResponse.of(problem, problemPractice);
     }
 

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemListService.java
@@ -5,6 +5,7 @@ import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
 import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemListResponse;
 import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.entity.ProblemPractice;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import org.springframework.data.domain.Page;
@@ -96,6 +97,16 @@ public class ProblemListService {
             if (onlyUnsolved && !solvedIds.isEmpty()) {
                 predicates.add(root.get("id").in(solvedIds).not());
             }
+
+            // practice 문제는 image_status = READY 인 것만 노출
+            var readySubquery = query.subquery(Long.class);
+            var ppRoot = readySubquery.from(ProblemPractice.class);
+            readySubquery.select(ppRoot.get("probId"))
+                    .where(cb.equal(ppRoot.get("imageStatus"), "READY"));
+            predicates.add(cb.or(
+                    cb.notEqual(root.get("type"), "practice"),
+                    root.get("id").in(readySubquery)
+            ));
 
             return cb.and(predicates.toArray(new Predicate[0]));
         };


### PR DESCRIPTION
문제 목록(전체/그룹)과 상세 조회 API에서
image_status = READY가 아닌 실습형 문제를 숨김 처리합니다.
이미지가 준비되지 않은 실습형 문제는 VM을 생성할 수 없으므로
사용자에게 노출되지 않아야 합니다.

변경 내용:
- [ProblemListService] buildSpecification에 JPA 서브쿼리 추가 · (type != 'practice') OR (type = 'practice' AND image_status = 'READY') 조건으로 비준비 실습형 문제를 DB 레벨에서 필터링
- [ProblemDetailService] detailProblemPractice에 imageStatus 검증 추가 · READY가 아니면 ProblemNotFoundException(404) 반환
- [GroupService] 그룹 문제 목록에 실습형 READY 필터 추가 · ProblemPracticeRepository 주입 · 페이지에서 practice 문제 ID만 추출 후 배치 조회하여 N+1 방지 · READY인 것만 응답에 포함

미적용 범위:
- GET /api/contests/{contestId}/problems (대회 문제 목록) → 어드민이 이미지 빌드 전 사전 세팅 가능하도록 의도적으로 제외

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->




<!-- 주석은 제외되고 올라가니 무시하세요 -->
