### PR TITLE
[feat] 문제 삭제 시 S3/ECR 리소스 정리 추가(#335)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	// S3 업로드
 	implementation 'software.amazon.awssdk:s3:2.26.31'
 
+	// ECR 이미지 삭제
+	implementation 'software.amazon.awssdk:ecr:2.26.31'
+
 	// SES 이메일 발송
 	implementation 'software.amazon.awssdk:ses:2.26.31'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/src/main/java/net/diveon/backend/domain/problem/service/EcrService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/EcrService.java
@@ -1,0 +1,5 @@
+package net.diveon.backend.domain.problem.service;
+
+public interface EcrService {
+    void deleteImage(Long probId);
+}

--- a/src/main/java/net/diveon/backend/domain/problem/service/EcrServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/EcrServiceImpl.java
@@ -1,0 +1,32 @@
+package net.diveon.backend.domain.problem.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.BatchDeleteImageRequest;
+import software.amazon.awssdk.services.ecr.model.ImageIdentifier;
+
+@Service
+@Profile("prod")
+public class EcrServiceImpl implements EcrService {
+
+    private final EcrClient ecrClient;
+
+    @Value("${aws.ecr.practice-repository}")
+    private String ecrRepository;
+
+    public EcrServiceImpl(EcrClient ecrClient) {
+        this.ecrClient = ecrClient;
+    }
+
+    @Override
+    public void deleteImage(Long probId) {
+        ecrClient.batchDeleteImage(BatchDeleteImageRequest.builder()
+                .repositoryName(ecrRepository)
+                .imageIds(ImageIdentifier.builder()
+                        .imageTag("prob-" + probId)
+                        .build())
+                .build());
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/service/EcrServiceMock.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/EcrServiceMock.java
@@ -1,0 +1,18 @@
+package net.diveon.backend.domain.problem.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("local")
+public class EcrServiceMock implements EcrService {
+
+    private static final Logger log = LoggerFactory.getLogger(EcrServiceMock.class);
+
+    @Override
+    public void deleteImage(Long probId) {
+        log.info("[Mock] ECR 이미지 삭제 생략 - probId: {}, tag: prob-{}", probId, probId);
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemDeleteService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemDeleteService.java
@@ -1,10 +1,13 @@
 package net.diveon.backend.domain.problem.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import net.diveon.backend.domain.problem.dto.response.ProblemDeleteResponse;
 import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.entity.ProblemPractice;
 import net.diveon.backend.domain.problem.repository.OboStepRepository;
 import net.diveon.backend.domain.problem.repository.ProblemObjectiveRepository;
 import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
@@ -30,28 +33,31 @@ import net.diveon.backend.global.exception.ProblemNotFoundException;
 
 @Service
 public class ProblemDeleteService {
-    /**
-     * 객관식: 구현중
-     * 코드형: 놉
-     * 실습형: 구현중
-     */
+
+    private static final Logger log = LoggerFactory.getLogger(ProblemDeleteService.class);
 
     private final ProblemRepository problemRepository;
     private final ProblemObjectiveRepository problemObjectiveRepository;
     private final ProblemPracticeRepository problemPracticeRepository;
     private final ProblemCodingRepository problemCodingRepository;
     private final OboStepRepository oboStepRepository;
+    private final S3Service s3Service;
+    private final EcrService ecrService;
 
     public ProblemDeleteService(ProblemRepository problemRepository,
         ProblemObjectiveRepository problemObjectiveRepository,
         ProblemPracticeRepository problemPracticeRepository,
         ProblemCodingRepository problemCodingRepository,
-        OboStepRepository oboStepRepository){
+        OboStepRepository oboStepRepository,
+        S3Service s3Service,
+        EcrService ecrService) {
         this.problemRepository = problemRepository;
         this.problemObjectiveRepository = problemObjectiveRepository;
         this.problemPracticeRepository = problemPracticeRepository;
         this.problemCodingRepository = problemCodingRepository;
         this.oboStepRepository = oboStepRepository;
+        this.s3Service = s3Service;
+        this.ecrService = ecrService;
     }
 
     @Transactional
@@ -121,18 +127,41 @@ public class ProblemDeleteService {
 
     // 실습형
     @Transactional
-    public ProblemDeleteResponse deleteProblemPractice(long userId, long probId){
+    public ProblemDeleteResponse deleteProblemPractice(long userId, long probId) {
+        ProblemPractice practice = problemPracticeRepository.findById(probId).orElse(null);
+        boolean isReady = practice != null && "READY".equals(practice.getImageStatus());
+
         problemPracticeRepository.deleteById(probId);
         problemRepository.deleteById(probId);
+
+        try {
+            s3Service.deleteDockerfileZip(probId);
+        } catch (Exception e) {
+            log.warn("S3 Dockerfile zip 삭제 실패 - probId: {}", probId, e);
+        }
+
+        if (isReady) {
+            try {
+                ecrService.deleteImage(probId);
+            } catch (Exception e) {
+                log.warn("ECR 이미지 삭제 실패 - probId: {}", probId, e);
+            }
+        }
 
         return new ProblemDeleteResponse(probId);
     }
 
     // 코딩형
     @Transactional
-    public ProblemDeleteResponse deleteProblemCoding(long userId, long probId){
+    public ProblemDeleteResponse deleteProblemCoding(long userId, long probId) {
         problemCodingRepository.deleteById(probId);
         problemRepository.deleteById(probId);
+
+        try {
+            s3Service.deleteCodingTestcases(probId);
+        } catch (Exception e) {
+            log.warn("S3 테스트케이스 삭제 실패 - probId: {}", probId, e);
+        }
 
         return new ProblemDeleteResponse(probId);
     }

--- a/src/main/java/net/diveon/backend/domain/problem/service/S3Service.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/S3Service.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public interface S3Service {
     void uploadDockerfileZip(Long probId, MultipartFile file);
-
     void uploadCodingTestcases(Long probId, List<ForDtoTestCase> testcases);
+
+    void deleteDockerfileZip(Long probId);
+    void deleteCodingTestcases(Long probId);
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceImpl.java
@@ -7,6 +7,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.util.List;
@@ -64,6 +69,33 @@ public class S3ServiceImpl implements S3Service {
         } catch (Exception e) {
             throw new RuntimeException("코딩형 테스트케이스 S3 업로드 실패: " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public void deleteDockerfileZip(Long probId) {
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key("prob-" + probId + "/source.zip")
+                .build());
+    }
+
+    @Override
+    public void deleteCodingTestcases(Long probId) {
+        String prefix = "testcases/prob-" + probId + "/";
+        List<ObjectIdentifier> keys = s3Client.listObjectsV2(ListObjectsV2Request.builder()
+                        .bucket(codeBucket)
+                        .prefix(prefix)
+                        .build())
+                .contents().stream()
+                .map(o -> ObjectIdentifier.builder().key(o.key()).build())
+                .toList();
+
+        if (keys.isEmpty()) return;
+
+        s3Client.deleteObjects(DeleteObjectsRequest.builder()
+                .bucket(codeBucket)
+                .delete(Delete.builder().objects(keys).build())
+                .build());
     }
 
     private void uploadTextFile(String key, String content) {

--- a/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceMock.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/S3ServiceMock.java
@@ -27,4 +27,14 @@ public class S3ServiceMock implements S3Service {
         log.info("[Mock] 코딩형 테스트케이스 S3 업로드 생략 - probId: {}, testcaseCount: {}, prefix: testcases/prob-{}/",
                 probId, testcaseCount, probId);
     }
+
+    @Override
+    public void deleteDockerfileZip(Long probId) {
+        log.info("[Mock] S3 Dockerfile zip 삭제 생략 - probId: {}, key: prob-{}/source.zip", probId, probId);
+    }
+
+    @Override
+    public void deleteCodingTestcases(Long probId) {
+        log.info("[Mock] S3 코딩형 테스트케이스 삭제 생략 - probId: {}, prefix: testcases/prob-{}/", probId, probId);
+    }
 }

--- a/src/main/java/net/diveon/backend/global/config/AwsConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/AwsConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
@@ -27,6 +28,13 @@ public class AwsConfig {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public EcrClient ecrClient() {
+        return EcrClient.builder()
                 .region(Region.of(region))
                 .build();
     }


### PR DESCRIPTION
문제 삭제 API 호출 시 DB 외 AWS 리소스가 남는 문제를 해결합니다.
S3/ECR 삭제 실패는 warn 로그만 남기고 DB 삭제는 항상 완료합니다.

변경 내용:
- [build.gradle] aws sdk ecr:2.26.31 의존성 추가
- [AwsConfig] EcrClient 빈 등록
- [S3Service] deleteDockerfileZip, deleteCodingTestcases 메서드 추가
- [S3ServiceImpl] Dockerfile zip 단건 삭제, 테스트케이스 배치 삭제 구현
- [S3ServiceMock] 로컬 환경용 Mock 구현 추가
- [EcrService / EcrServiceImpl / EcrServiceMock] ECR 이미지 삭제 서비스 신규 생성
- [ProblemDeleteService] 유형별 리소스 정리 로직 추가 · practice: S3 Dockerfile zip 삭제 + ECR 이미지 삭제 (READY인 경우만) · coding: S3 테스트케이스 삭제 · 제출 기록(solve_submission)은 기존 DB CASCADE로 처리됨

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 관련 이슈
Closes #335


<!-- 주석은 제외되고 올라가니 무시하세요 -->
