### PR TITLE
[feat] 프로필/그룹 이미지 S3 업로드 API 구현 (#337)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -5,6 +5,7 @@ import net.diveon.backend.domain.group.dto.GroupAddProblemsRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
+import net.diveon.backend.domain.group.dto.GroupImageUploadResponse;
 import net.diveon.backend.domain.group.dto.GroupListResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
@@ -15,6 +16,7 @@ import net.diveon.backend.domain.contest.dto.response.GroupContestListResponse;
 import net.diveon.backend.domain.contest.service.ContestService;
 import net.diveon.backend.domain.group.service.GroupService;
 import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -150,5 +153,15 @@ public class GroupController {
             @Valid @RequestBody GroupCreateRequest request) {
         GroupCreateResponse response = groupService.createGroup(Long.parseLong(userId), request);
         return ResponseEntity.status(201).body(ApiResponse.created("그룹이 성공적으로 생성되었습니다.", response));
+    }
+
+    // 그룹 이미지 업로드 (그룹장만 가능)
+    @PostMapping(value = "/{groupId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<GroupImageUploadResponse>> uploadGroupImage(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId,
+            @RequestParam("image") MultipartFile image) {
+        String imageUrl = groupService.uploadGroupImage(groupId, Long.parseLong(userId), image);
+        return ResponseEntity.ok(ApiResponse.success("그룹 이미지 업로드 성공", new GroupImageUploadResponse(imageUrl)));
     }
 }

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupImageUploadResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupImageUploadResponse.java
@@ -1,0 +1,14 @@
+package net.diveon.backend.domain.group.dto;
+
+public class GroupImageUploadResponse {
+
+    private final String imageUrl;
+
+    public GroupImageUploadResponse(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/group/entity/Group.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/Group.java
@@ -88,4 +88,8 @@ public class Group {
         this.isPrivate = isPrivate;
         this.isAutoApprove = isAutoApprove;
     }
+
+    public void updateImage(String image) {
+        this.image = image;
+    }
 }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -37,8 +37,11 @@ import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.GroupProblemAlreadyExistsException;
 import net.diveon.backend.global.exception.ProblemNotFoundException;
 import net.diveon.backend.global.exception.UserNotFoundException;
+import net.diveon.backend.global.s3.ImageUploadService;
+import net.diveon.backend.global.util.ImageFileValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Map;
@@ -59,6 +62,7 @@ public class GroupService {
     private final ProblemPracticeRepository problemPracticeRepository;
     private final ContestRepository contestRepository;
     private final ProblemDeleteService problemDeleteService;
+    private final ImageUploadService imageUploadService;
 
     public GroupService(GroupRepository groupRepository, GroupTagRepository groupTagRepository,
                         GroupUserRepository groupUserRepository,
@@ -68,7 +72,8 @@ public class GroupService {
                         ProblemRepository problemRepository,
                         ProblemPracticeRepository problemPracticeRepository,
                         ContestRepository contestRepository,
-                        ProblemDeleteService problemDeleteService) {
+                        ProblemDeleteService problemDeleteService,
+                        ImageUploadService imageUploadService) {
         this.groupRepository = groupRepository;
         this.groupTagRepository = groupTagRepository;
         this.groupUserRepository = groupUserRepository;
@@ -79,6 +84,7 @@ public class GroupService {
         this.problemPracticeRepository = problemPracticeRepository;
         this.contestRepository = contestRepository;
         this.problemDeleteService = problemDeleteService;
+        this.imageUploadService = imageUploadService;
     }
 
     // 그룹 목록 조회
@@ -167,6 +173,27 @@ public class GroupService {
                 groupTagRepository.save(new GroupTag(group, tag));
             }
         }
+    }
+
+    // 그룹 이미지 업로드 (그룹장만 가능)
+    @Transactional
+    public String uploadGroupImage(Long groupId, Long userId, MultipartFile image) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupAccessDeniedException::new);
+
+        if (groupUser.getRole() != GroupUser.GroupRole.LEADER) {
+            throw new GroupAccessDeniedException();
+        }
+
+        String extension = ImageFileValidator.validateAndGetExtension(image);
+        String key = "groups/" + groupId + "." + extension;
+        String imageUrl = imageUploadService.upload(key, image);
+
+        group.updateImage(imageUrl);
+        return imageUrl;
     }
 
     // 그룹 삭제

--- a/src/main/java/net/diveon/backend/domain/user/controller/UserProfileImageController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/UserProfileImageController.java
@@ -1,0 +1,33 @@
+package net.diveon.backend.domain.user.controller;
+
+import net.diveon.backend.domain.user.dto.ProfileImageUploadResponse;
+import net.diveon.backend.domain.user.service.ProfileService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/users/me")
+public class UserProfileImageController {
+
+    private final ProfileService profileService;
+
+    public UserProfileImageController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    // 프로필 이미지 업로드
+    @PostMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<ProfileImageUploadResponse>> uploadProfileImage(
+            @AuthenticationPrincipal String userId,
+            @RequestParam("image") MultipartFile image) {
+        String imageUrl = profileService.uploadProfileImage(Long.parseLong(userId), image);
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지 업로드 성공", new ProfileImageUploadResponse(imageUrl)));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/ProfileImageUploadResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/ProfileImageUploadResponse.java
@@ -1,0 +1,14 @@
+package net.diveon.backend.domain.user.dto;
+
+public class ProfileImageUploadResponse {
+
+    private final String imageUrl;
+
+    public ProfileImageUploadResponse(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -87,6 +87,10 @@ public class User {
         this.password = encodedPassword;
     }
 
+    public void updateProfileImage(String profileImgUrl) {
+        this.profileImgUrl = profileImgUrl;
+    }
+
     public Long getId() { return id; }
     public String getLoginId() { return loginId; }
     public String getPassword() { return password; }

--- a/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
@@ -7,9 +7,12 @@ import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
 import net.diveon.backend.global.exception.InvalidCredentialsException;
 import net.diveon.backend.global.exception.UserNotFoundException;
+import net.diveon.backend.global.s3.ImageUploadService;
+import net.diveon.backend.global.util.ImageFileValidator;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Service
@@ -17,10 +20,13 @@ public class ProfileService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ImageUploadService imageUploadService;
 
-    public ProfileService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public ProfileService(UserRepository userRepository, PasswordEncoder passwordEncoder,
+                           ImageUploadService imageUploadService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.imageUploadService = imageUploadService;
     }
 
     public ProfileShowResponse getProfile(long userId) {
@@ -49,5 +55,18 @@ public class ProfileService {
             throw new InvalidCredentialsException();
         }
         user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+    }
+
+    @Transactional
+    public String uploadProfileImage(Long userId, MultipartFile image) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        String extension = ImageFileValidator.validateAndGetExtension(image);
+        String key = "profiles/" + userId + "." + extension;
+        String imageUrl = imageUploadService.upload(key, image);
+
+        user.updateProfileImage(imageUrl);
+        return imageUrl;
     }
 }

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -570,6 +570,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
         }
 
+        // 이미지 파일 없음 / 허용되지 않는 확장자 / 크기 초과 → 400
+        @ExceptionHandler(InvalidImageFileException.class)
+        public ResponseEntity<ErrorResponse> handleInvalidImageFile(
+                InvalidImageFileException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/invalid-image-file",
+                        "Bad Request",
+                        400,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+        }
+
         // 쿨다운 중 → 409
         @ExceptionHandler(ContestCooldownException.class)
         public ResponseEntity<ErrorResponse> handleContestCooldown(

--- a/src/main/java/net/diveon/backend/global/exception/InvalidImageFileException.java
+++ b/src/main/java/net/diveon/backend/global/exception/InvalidImageFileException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class InvalidImageFileException extends RuntimeException {
+
+    public InvalidImageFileException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/diveon/backend/global/s3/ImageUploadService.java
+++ b/src/main/java/net/diveon/backend/global/s3/ImageUploadService.java
@@ -1,0 +1,9 @@
+package net.diveon.backend.global.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUploadService {
+
+    // S3에 이미지를 업로드하고 CloudFront URL을 반환한다 (같은 key로 업로드 시 덮어쓰기)
+    String upload(String key, MultipartFile file);
+}

--- a/src/main/java/net/diveon/backend/global/s3/ImageUploadServiceImpl.java
+++ b/src/main/java/net/diveon/backend/global/s3/ImageUploadServiceImpl.java
@@ -1,0 +1,45 @@
+package net.diveon.backend.global.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+// 배포 환경용. 프로필/그룹 이미지를 syslab-frontend 버킷(CloudFront 서빙)에 업로드
+@Service
+@Profile("prod")
+public class ImageUploadServiceImpl implements ImageUploadService {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket-frontend}")
+    private String bucket;
+
+    @Value("${aws.s3.cloudfront-domain}")
+    private String cloudfrontDomain;
+
+    public ImageUploadServiceImpl(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    @Override
+    public String upload(String key, MultipartFile file) {
+        try {
+            s3Client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .contentType(file.getContentType())
+                            .build(),
+                    RequestBody.fromBytes(file.getBytes())
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("이미지 업로드 실패: " + e.getMessage(), e);
+        }
+
+        return "https://" + cloudfrontDomain + "/" + key;
+    }
+}

--- a/src/main/java/net/diveon/backend/global/s3/ImageUploadServiceMock.java
+++ b/src/main/java/net/diveon/backend/global/s3/ImageUploadServiceMock.java
@@ -1,0 +1,21 @@
+package net.diveon.backend.global.s3;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+// 로컬 환경용. 실제 S3 업로드 없이 로그만 찍고 mock URL을 반환
+@Service
+@Profile("local")
+public class ImageUploadServiceMock implements ImageUploadService {
+
+    private static final Logger log = LoggerFactory.getLogger(ImageUploadServiceMock.class);
+
+    @Override
+    public String upload(String key, MultipartFile file) {
+        log.info("[Mock] 이미지 업로드 생략 - key: {}, 파일명: {}", key, file.getOriginalFilename());
+        return "https://mock.cloudfront.net/" + key;
+    }
+}

--- a/src/main/java/net/diveon/backend/global/util/ImageFileValidator.java
+++ b/src/main/java/net/diveon/backend/global/util/ImageFileValidator.java
@@ -1,0 +1,36 @@
+package net.diveon.backend.global.util;
+
+import net.diveon.backend.global.exception.InvalidImageFileException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public final class ImageFileValidator {
+
+    private static final long MAX_SIZE_BYTES = 1024 * 1024; // 1MB
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp");
+
+    private ImageFileValidator() {
+    }
+
+    // 검증 후 확장자를 반환한다 (S3 저장 키 생성에 사용)
+    public static String validateAndGetExtension(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new InvalidImageFileException("이미지 파일이 없습니다.");
+        }
+        if (file.getSize() > MAX_SIZE_BYTES) {
+            throw new InvalidImageFileException("이미지 파일은 최대 1MB까지 업로드할 수 있습니다.");
+        }
+
+        String filename = file.getOriginalFilename();
+        String extension = (filename != null && filename.contains("."))
+                ? filename.substring(filename.lastIndexOf('.') + 1).toLowerCase()
+                : "";
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new InvalidImageFileException("허용되지 않는 확장자입니다. (jpg, jpeg, png, webp만 가능)");
+        }
+
+        return extension;
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- POST /api/users/me/profile-image: 프로필 이미지 업로드 API 구현
- POST /api/groups/{groupId}/image: 그룹 이미지 업로드 API 구현 (그룹장 권한 체크)
- syslab-frontend 버킷 업로드 + CloudFront URL 응답 (cloudfront-domain은 application-secret.yml/application-local.yml에서 설정)
- 이미지 파일 검증 (확장자: jpg/jpeg/png/webp, 최대 1MB) 및 InvalidImageFileException 추가
- 기존 S3Service 패턴(인터페이스 + prod/local @Profile 구현체)을 따라 공용 ImageUploadService 작성

## 관련 이슈
Closes #337


<!-- 주석은 제외되고 올라가니 무시하세요 -->
