### PR TITLE
[fix] 그룹 상세 조회 응답에 이미지 URL 누락 수정 (#342)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupDetailResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupDetailResponse.java
@@ -7,16 +7,18 @@ public class GroupDetailResponse {
     private final Long groupId;
     private final String title;
     private final String description;
+    private final String imageUrl;
     private final List<String> tags;
     private final Stats stats;
     private final Settings settings;
     private final UserContext userContext;
 
-    public GroupDetailResponse(Long groupId, String title, String description, List<String> tags,
+    public GroupDetailResponse(Long groupId, String title, String description, String imageUrl, List<String> tags,
                                Stats stats, Settings settings, UserContext userContext) {
         this.groupId = groupId;
         this.title = title;
         this.description = description;
+        this.imageUrl = imageUrl;
         this.tags = tags;
         this.stats = stats;
         this.settings = settings;
@@ -26,6 +28,7 @@ public class GroupDetailResponse {
     public Long getGroupId() { return groupId; }
     public String getTitle() { return title; }
     public String getDescription() { return description; }
+    public String getImageUrl() { return imageUrl; }
     public List<String> getTags() { return tags; }
     public Stats getStats() { return stats; }
     public Settings getSettings() { return settings; }

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -380,6 +380,7 @@ public class GroupService {
                 group.getId(),
                 group.getTitle(),
                 group.getDescription(),
+                group.getImage(),
                 tags,
                 new GroupDetailResponse.Stats(memberCount, problemCount, contestCount),
                 new GroupDetailResponse.Settings(group.getIsPrivate(), group.getIsAutoApprove()),


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 그룹 이미지를 업로드해도 새로고침 시 보이지 않던 버그 수정
- 원인: GroupDetailResponse(그룹 상세 조회 응답 DTO)에 이미지 URL 필드가 없어서, 업로드는 정상적으로 DB/S3에 반영되지만 조회 응답에는 포함되지 않았음
- GroupDetailResponse에 imageUrl 필드를 추가하고, 그룹 상세 조회 시 group.getImage() 값을 매핑하도록 수정

## 관련 이슈
Closes #342


<!-- 주석은 제외되고 올라가니 무시하세요 -->
