### PR TITLE
fix: 프로필/그룹 이미지 S3 키에서 확장자 제거

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -188,8 +188,8 @@ public class GroupService {
             throw new GroupAccessDeniedException();
         }
 
-        String extension = ImageFileValidator.validateAndGetExtension(image);
-        String key = "profiles/groups/" + groupId + "." + extension;
+        ImageFileValidator.validateAndGetExtension(image);
+        String key = "profiles/groups/" + groupId;
         String imageUrl = imageUploadService.upload(key, image);
 
         group.updateImage(imageUrl);

--- a/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/ProfileService.java
@@ -62,8 +62,8 @@ public class ProfileService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
-        String extension = ImageFileValidator.validateAndGetExtension(image);
-        String key = "profiles/users/" + userId + "." + extension;
+        ImageFileValidator.validateAndGetExtension(image);
+        String key = "profiles/users/" + userId;
         String imageUrl = imageUploadService.upload(key, image);
 
         user.updateProfileImage(imageUrl);


### PR DESCRIPTION
확장자가 다른 파일을 재업로드할 경우 기존 파일이 S3에
고아 파일로 남는 문제를 수정. 키를 확장자 없이 고정하여
동일 키를 항상 덮어씌우도록 변경.

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->




<!-- 주석은 제외되고 올라가니 무시하세요 -->
