### PR TITLE
개별 유저 채점시, 각 유저의 개별적인 티어 총점 및 티어 변동 기능

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/entity/SolveSubmission.java
+++ b/src/main/java/net/diveon/backend/domain/grade/entity/SolveSubmission.java
@@ -27,7 +27,7 @@ import org.hibernate.annotations.OnDeleteAction;
 | result       | enum      | NOT NULL                                   | 클래스 enum 참고 |
 | submitted_at | TIMESTAMP | NOT NULL, DEFAULT NOW()                    | 제출 시각       |
 </pre>
- */
+ */ 
 @Entity
 public class SolveSubmission {
 

--- a/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
@@ -23,4 +23,31 @@ public interface SolveResultRepository extends JpaRepository<SolveResult, Long>{
         @Param("userId") Long userId,
         @Param("probId") Long probId
     );
+
+    @Query(value = """
+        SELECT COALESCE(SUM(solved.score), 0)
+        FROM (
+            SELECT
+                CASE ps.difficulty
+                    WHEN '1' THEN 10
+                    WHEN '2' THEN 20
+                    WHEN '3' THEN 30
+                    WHEN '4' THEN 40
+                    WHEN '5' THEN 50
+                    WHEN '6' THEN 60
+                    WHEN '7' THEN 70
+                    ELSE 0
+                END AS score
+            FROM solve_result sr
+            JOIN solve_submission ss ON sr.submission_id = ss.id
+            JOIN problem_summary ps ON ss.prob_id = ps.id
+            WHERE ss.submitter_id = :userId
+              AND sr.result_status = 'CORRECT'
+              AND ps.visibility NOT IN ('group', 'contest')
+            GROUP BY ps.id, ps.difficulty
+            ORDER BY score DESC
+            LIMIT 100
+        ) solved
+        """, nativeQuery = true)
+    Integer calculateTierScoreByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeAsyncService.java
+++ b/src/main/java/net/diveon/backend/domain/grade/service/SubmissionGradeAsyncService.java
@@ -27,6 +27,7 @@ import net.diveon.backend.domain.problem.repository.ProblemPracticeRepository;
 import net.diveon.backend.domain.problem.repository.ProblemRepository;
 import net.diveon.backend.domain.user.entity.User;
 import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.domain.user.service.UserTierService;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -65,6 +66,7 @@ public class SubmissionGradeAsyncService {
 
     private final SolveResultRepository solveResultRepository;
     private final CodingGradeQueueService codingGradeQueueService;
+    private final UserTierService userTierService;
 
     public SubmissionGradeAsyncService(UserRepository userRepository,
         ProblemRepository problemRepository,
@@ -76,7 +78,8 @@ public class SubmissionGradeAsyncService {
         SolveSubmissionCodingRepository solveSubmissionCodingRepository,
         SolveSubmissionPracticeRepository solveSubmissionPracticeRepository,
         SolveResultRepository solveResultRepository,
-        CodingGradeQueueService codingGradeQueueService
+        CodingGradeQueueService codingGradeQueueService,
+        UserTierService userTierService
     ){
         this.userRepository = userRepository;
         this.problemRepository = problemRepository;
@@ -90,6 +93,7 @@ public class SubmissionGradeAsyncService {
         this.solveSubmissionPracticeRepository = solveSubmissionPracticeRepository;
         this.solveSubmissionObjectiveRepository = solveSubmissionObjectiveRepository;
         this.codingGradeQueueService = codingGradeQueueService;
+        this.userTierService = userTierService;
     }
 
 
@@ -153,6 +157,7 @@ public class SubmissionGradeAsyncService {
             submission.setSubmissionState(SubmissionState.COMPLETED);
             if (!alreadySolved) {
                 problem.incrementSolvedCount();
+                userTierService.refreshTierScore(submitterId);
             }
         }else{
             //오답
@@ -204,6 +209,7 @@ public class SubmissionGradeAsyncService {
             submission.setSubmissionState(SubmissionState.COMPLETED);
             if (!alreadySolved) {
                 problem.incrementSolvedCount();
+                userTierService.refreshTierScore(submitterId);
             }
         }else{
             //오답

--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -91,6 +91,11 @@ public class User {
         this.profileImgUrl = profileImgUrl;
     }
 
+    public void updateTierScore(Integer score, Integer tier) {
+        this.score = score;
+        this.tier = tier;
+    }
+
     public Long getId() { return id; }
     public String getLoginId() { return loginId; }
     public String getPassword() { return password; }

--- a/src/main/java/net/diveon/backend/domain/user/service/UserTierService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserTierService.java
@@ -1,0 +1,42 @@
+package net.diveon.backend.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.grade.repository.SolveResultRepository;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.UserNotFoundException;
+
+@Service
+public class UserTierService {
+
+    private final UserRepository userRepository;
+    private final SolveResultRepository solveResultRepository;
+
+    public UserTierService(UserRepository userRepository, SolveResultRepository solveResultRepository) {
+        this.userRepository = userRepository;
+        this.solveResultRepository = solveResultRepository;
+    }
+
+    @Transactional
+    public void refreshTierScore(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        Integer score = solveResultRepository.calculateTierScoreByUserId(userId);
+        int tierScore = score == null ? 0 : score;
+        user.updateTierScore(tierScore, calculateTier(tierScore));
+    }
+
+    private int calculateTier(int score) {
+        if (score >= 6600) return 7;
+        if (score >= 5400) return 6;
+        if (score >= 4000) return 5;
+        if (score >= 2400) return 4;
+        if (score >= 1350) return 3;
+        if (score >= 600) return 2;
+        if (score >= 150) return 1;
+        return 0;
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- SolveSubmission.java는 엔터 하나 넣은거(커밋용)
- 총 3개 파일 수정
- 1개 파일 생성

수정한 파일 목록 및 내용
- SovleResultRepository.java 
    -  필요 SQL 쿼리 추가
    -  내용 상위(난이도 기준 내림차순) 100개 문제중, 중복(같은 문제 여러번 푼거)을 제거하고 총 점수를 업데이트 
- SubmissionGradeAsyncService.java
    -  새로운 서비스(티어 매기는 서비스)를 호출하기 위해 의존성 주입
    - 새 서비스 호출코드
- User.java 엔티티
    - 티어랑 점수 컬럼 업데이트 위한 메서드 추가

추가한 파일
- UserTierService.java
  - 새롭게 생성한 서비스
  - User Domain에 위치
  - 위에서 말한 레포지토리 코드로 총점 업데이트를 하도록 호출하고
  - 이후 특정 한계값이 넘으면 티어를 변경시켜주는 로직

## 관련 이슈
Closes #362, #360


<!-- 주석은 제외되고 올라가니 무시하세요 -->
