### PR TITLE
feat: 전체 유저 랭킹 5분마다 갱신 (#363)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/user/controller/UserRankingController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/UserRankingController.java
@@ -1,0 +1,32 @@
+package net.diveon.backend.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.diveon.backend.domain.user.dto.UserRankingResponse;
+import net.diveon.backend.domain.user.service.UserRankingService;
+import net.diveon.backend.global.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserRankingController {
+
+    private final UserRankingService userRankingService;
+
+    public UserRankingController(UserRankingService userRankingService) {
+        this.userRankingService = userRankingService;
+    }
+
+    @GetMapping("/ranking")
+    public ResponseEntity<ApiResponse<UserRankingResponse>> getUserRanking(
+        @AuthenticationPrincipal String userId,
+        @RequestParam(defaultValue = "1") int page
+    ) {
+        UserRankingResponse response = userRankingService.getRanking(Long.parseLong(userId), page);
+        return ResponseEntity.ok(ApiResponse.success("유저 랭킹 조회에 성공하였습니다.", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/UserRankingProjection.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/UserRankingProjection.java
@@ -1,0 +1,10 @@
+package net.diveon.backend.domain.user.dto;
+
+public interface UserRankingProjection {
+    Integer getRank();
+    Long getUserId();
+    String getNickname();
+    String getProfileImgUrl();
+    Integer getTier();
+    Integer getScore();
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/UserRankingResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/UserRankingResponse.java
@@ -1,0 +1,57 @@
+package net.diveon.backend.domain.user.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class UserRankingResponse {
+
+    private final long totalElements;
+    private final int totalPages;
+    private final int currentPage;
+    private final LocalDateTime calculatedAt;
+    private final RankingEntry myRanking;
+    private final List<RankingEntry> rankings;
+
+    public UserRankingResponse(long totalElements, int totalPages, int currentPage,
+                               LocalDateTime calculatedAt, RankingEntry myRanking,
+                               List<RankingEntry> rankings) {
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.currentPage = currentPage;
+        this.calculatedAt = calculatedAt;
+        this.myRanking = myRanking;
+        this.rankings = rankings;
+    }
+
+    public long getTotalElements() { return totalElements; }
+    public int getTotalPages() { return totalPages; }
+    public int getCurrentPage() { return currentPage; }
+    public LocalDateTime getCalculatedAt() { return calculatedAt; }
+    public RankingEntry getMyRanking() { return myRanking; }
+    public List<RankingEntry> getRankings() { return rankings; }
+
+    public static class RankingEntry {
+        private final Integer rank;
+        private final Long userId;
+        private final String nickname;
+        private final String profileImgUrl;
+        private final Integer tier;
+        private final Integer score;
+
+        public RankingEntry(Integer rank, Long userId, String nickname, String profileImgUrl, Integer tier, Integer score) {
+            this.rank = rank;
+            this.userId = userId;
+            this.nickname = nickname;
+            this.profileImgUrl = profileImgUrl;
+            this.tier = tier;
+            this.score = score;
+        }
+
+        public Integer getRank() { return rank; }
+        public Long getUserId() { return userId; }
+        public String getNickname() { return nickname; }
+        public String getProfileImgUrl() { return profileImgUrl; }
+        public Integer getTier() { return tier; }
+        public Integer getScore() { return score; }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/entity/UserRankingSnapshot.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/UserRankingSnapshot.java
@@ -1,0 +1,50 @@
+package net.diveon.backend.domain.user.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(
+    name = "user_ranking_snapshot",
+    indexes = {
+        @Index(name = "idx_user_ranking_snapshot_status_calculated", columnList = "status, calculated_at")
+    }
+)
+public class UserRankingSnapshot {
+
+    public static final String STATUS_BUILDING = "BUILDING";
+    public static final String STATUS_COMPLETED = "COMPLETED";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "calculated_at", nullable = false)
+    private LocalDateTime calculatedAt;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    public UserRankingSnapshot() {}
+
+    public UserRankingSnapshot(LocalDateTime calculatedAt) {
+        this.calculatedAt = calculatedAt;
+        this.status = STATUS_BUILDING;
+    }
+
+    public void complete() {
+        this.status = STATUS_COMPLETED;
+    }
+
+    public Long getId() { return id; }
+    public LocalDateTime getCalculatedAt() { return calculatedAt; }
+    public String getStatus() { return status; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/entity/UserRankingSnapshotEntry.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/UserRankingSnapshotEntry.java
@@ -1,0 +1,53 @@
+package net.diveon.backend.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "user_ranking_snapshot_entry",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_ranking_snapshot_entry_user", columnNames = {"snapshot_id", "user_id"})
+    },
+    indexes = {
+        @Index(name = "idx_user_ranking_snapshot_entry_rank", columnList = "snapshot_id, rank, user_id"),
+        @Index(name = "idx_user_ranking_snapshot_entry_user", columnList = "snapshot_id, user_id")
+    }
+)
+public class UserRankingSnapshotEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "snapshot_id", nullable = false)
+    private Long snapshotId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "rank", nullable = false)
+    private Integer rank;
+
+    @Column(name = "tier", nullable = false)
+    private Integer tier;
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    public UserRankingSnapshotEntry() {}
+
+    public Long getId() { return id; }
+    public Long getSnapshotId() { return snapshotId; }
+    public Long getUserId() { return userId; }
+    public Integer getRank() { return rank; }
+    public Integer getTier() { return tier; }
+    public Integer getScore() { return score; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/repository/UserRankingSnapshotEntryRepository.java
+++ b/src/main/java/net/diveon/backend/domain/user/repository/UserRankingSnapshotEntryRepository.java
@@ -1,0 +1,54 @@
+package net.diveon.backend.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import net.diveon.backend.domain.user.dto.UserRankingProjection;
+import net.diveon.backend.domain.user.entity.UserRankingSnapshotEntry;
+
+public interface UserRankingSnapshotEntryRepository extends JpaRepository<UserRankingSnapshotEntry, Long> {
+
+    @Query(value = """
+            SELECT
+                e.rank AS rank,
+                u.id AS userId,
+                u.nickname AS nickname,
+                u.profile_img_url AS profileImgUrl,
+                e.tier AS tier,
+                e.score AS score
+            FROM user_ranking_snapshot_entry e
+            JOIN domain_user u ON u.id = e.user_id
+            WHERE e.snapshot_id = :snapshotId
+            ORDER BY e.rank ASC, e.user_id ASC
+            """,
+            countQuery = "SELECT COUNT(*) FROM user_ranking_snapshot_entry WHERE snapshot_id = :snapshotId",
+            nativeQuery = true)
+    Page<UserRankingProjection> findRankingBySnapshotId(@Param("snapshotId") Long snapshotId, Pageable pageable);
+
+    @Query(value = """
+            SELECT
+                e.rank AS rank,
+                u.id AS userId,
+                u.nickname AS nickname,
+                u.profile_img_url AS profileImgUrl,
+                e.tier AS tier,
+                e.score AS score
+            FROM user_ranking_snapshot_entry e
+            JOIN domain_user u ON u.id = e.user_id
+            WHERE e.snapshot_id = :snapshotId
+              AND e.user_id = :userId
+            """, nativeQuery = true)
+    Optional<UserRankingProjection> findRankingBySnapshotIdAndUserId(
+        @Param("snapshotId") Long snapshotId,
+        @Param("userId") Long userId
+    );
+
+    @Modifying
+    void deleteBySnapshotId(Long snapshotId);
+}

--- a/src/main/java/net/diveon/backend/domain/user/repository/UserRankingSnapshotRepository.java
+++ b/src/main/java/net/diveon/backend/domain/user/repository/UserRankingSnapshotRepository.java
@@ -1,0 +1,15 @@
+package net.diveon.backend.domain.user.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import net.diveon.backend.domain.user.entity.UserRankingSnapshot;
+
+public interface UserRankingSnapshotRepository extends JpaRepository<UserRankingSnapshot, Long> {
+
+    Optional<UserRankingSnapshot> findTopByStatusOrderByCalculatedAtDescIdDesc(String status);
+
+    List<UserRankingSnapshot> findByStatusOrderByCalculatedAtDescIdDesc(String status);
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/UserRankingService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserRankingService.java
@@ -1,0 +1,70 @@
+package net.diveon.backend.domain.user.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.user.dto.UserRankingProjection;
+import net.diveon.backend.domain.user.dto.UserRankingResponse;
+import net.diveon.backend.domain.user.entity.UserRankingSnapshot;
+import net.diveon.backend.domain.user.repository.UserRankingSnapshotEntryRepository;
+import net.diveon.backend.domain.user.repository.UserRankingSnapshotRepository;
+import net.diveon.backend.global.exception.UserNotFoundException;
+
+@Service
+@Transactional(readOnly = true)
+public class UserRankingService {
+
+    private final UserRankingSnapshotRepository userRankingSnapshotRepository;
+    private final UserRankingSnapshotEntryRepository userRankingSnapshotEntryRepository;
+
+    public UserRankingService(
+        UserRankingSnapshotRepository userRankingSnapshotRepository,
+        UserRankingSnapshotEntryRepository userRankingSnapshotEntryRepository
+    ) {
+        this.userRankingSnapshotRepository = userRankingSnapshotRepository;
+        this.userRankingSnapshotEntryRepository = userRankingSnapshotEntryRepository;
+    }
+
+    public UserRankingResponse getRanking(Long userId, int page) {
+        UserRankingSnapshot snapshot = userRankingSnapshotRepository
+            .findTopByStatusOrderByCalculatedAtDescIdDesc(UserRankingSnapshot.STATUS_COMPLETED)
+            .orElseThrow(() -> new IllegalStateException("완료된 유저 랭킹 스냅샷이 없습니다."));
+
+        Page<UserRankingProjection> resultPage = userRankingSnapshotEntryRepository
+            .findRankingBySnapshotId(snapshot.getId(), PageRequest.of(page - 1, 20));
+        UserRankingResponse.RankingEntry myRanking = userRankingSnapshotEntryRepository
+            .findRankingBySnapshotIdAndUserId(snapshot.getId(), userId)
+            .map(this::toRankingEntry)
+            .orElseThrow(UserNotFoundException::new);
+
+        List<UserRankingResponse.RankingEntry> entries = new ArrayList<>();
+        for (UserRankingProjection user : resultPage.getContent()) {
+            entries.add(toRankingEntry(user));
+        }
+
+        return new UserRankingResponse(
+            resultPage.getTotalElements(),
+            resultPage.getTotalPages(),
+            page,
+            snapshot.getCalculatedAt(),
+            myRanking,
+            entries
+        );
+    }
+
+    private UserRankingResponse.RankingEntry toRankingEntry(UserRankingProjection user) {
+        return new UserRankingResponse.RankingEntry(
+            user.getRank(),
+            user.getUserId(),
+            user.getNickname(),
+            user.getProfileImgUrl(),
+            user.getTier(),
+            user.getScore()
+        );
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/UserRankingSnapshotRefreshService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserRankingSnapshotRefreshService.java
@@ -1,0 +1,70 @@
+package net.diveon.backend.domain.user.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.diveon.backend.domain.user.entity.UserRankingSnapshot;
+import net.diveon.backend.domain.user.repository.UserRankingSnapshotEntryRepository;
+import net.diveon.backend.domain.user.repository.UserRankingSnapshotRepository;
+
+@Service
+public class UserRankingSnapshotRefreshService {
+
+    private static final int SNAPSHOT_RETAIN_COUNT = 2;
+
+    private final UserRankingSnapshotRepository userRankingSnapshotRepository;
+    private final UserRankingSnapshotEntryRepository userRankingSnapshotEntryRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    public UserRankingSnapshotRefreshService(
+        UserRankingSnapshotRepository userRankingSnapshotRepository,
+        UserRankingSnapshotEntryRepository userRankingSnapshotEntryRepository,
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.userRankingSnapshotRepository = userRankingSnapshotRepository;
+        this.userRankingSnapshotEntryRepository = userRankingSnapshotEntryRepository;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Scheduled(
+        fixedDelayString = "${ranking.user.snapshot-refresh-ms:300000}",
+        initialDelayString = "${ranking.user.snapshot-initial-delay-ms:0}"
+    )
+    @Transactional
+    public void refreshSnapshot() {
+        UserRankingSnapshot snapshot = userRankingSnapshotRepository.saveAndFlush(
+            new UserRankingSnapshot(LocalDateTime.now())
+        );
+
+        jdbcTemplate.update("""
+            INSERT INTO user_ranking_snapshot_entry (snapshot_id, user_id, rank, tier, score)
+            SELECT
+                ?,
+                u.id,
+                CAST(DENSE_RANK() OVER (ORDER BY COALESCE(u.score, 0) DESC) AS INTEGER),
+                COALESCE(u.tier, 0),
+                COALESCE(u.score, 0)
+            FROM domain_user u
+            ORDER BY COALESCE(u.score, 0) DESC, u.id ASC
+            """, snapshot.getId());
+
+        snapshot.complete();
+        deleteOldCompletedSnapshots();
+    }
+
+    private void deleteOldCompletedSnapshots() {
+        List<UserRankingSnapshot> completedSnapshots =
+            userRankingSnapshotRepository.findByStatusOrderByCalculatedAtDescIdDesc(UserRankingSnapshot.STATUS_COMPLETED);
+
+        for (int i = SNAPSHOT_RETAIN_COUNT; i < completedSnapshots.size(); i++) {
+            UserRankingSnapshot snapshot = completedSnapshots.get(i);
+            userRankingSnapshotEntryRepository.deleteBySnapshotId(snapshot.getId());
+            userRankingSnapshotRepository.delete(snapshot);
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 아 전체 랭킹 구현 함
- 스냅샷 형태(테이블)로 5분마다 갱신
- 스냅샷은 최대 2개만 들고 있고, 최신버전만 제공함
- 

## 관련 이슈
Closes #363


<!-- 주석은 제외되고 올라가니 무시하세요 -->
