### PR TITLE
feat: Google Social Login (#374)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	// 보안
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'com.google.api-client:google-api-client:2.7.2'
+	implementation 'com.google.http-client:google-http-client-jackson2:1.45.0'
 
 	// JWT (jjwt)
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/net/diveon/backend/domain/user/controller/GoogleOAuthController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/GoogleOAuthController.java
@@ -1,0 +1,38 @@
+package net.diveon.backend.domain.user.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import net.diveon.backend.domain.user.dto.AuthLoginResponse;
+import net.diveon.backend.domain.user.dto.GoogleLoginRequest;
+import net.diveon.backend.domain.user.service.GoogleOAuthService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("prod")
+@RestController
+@RequestMapping("/api/auth/google")
+public class GoogleOAuthController {
+
+    private final GoogleOAuthService googleOAuthService;
+
+    public GoogleOAuthController(GoogleOAuthService googleOAuthService) {
+        this.googleOAuthService = googleOAuthService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<AuthLoginResponse>> googleLogin(
+            @Valid @RequestBody GoogleLoginRequest request,
+            HttpServletRequest servletRequest) {
+        AuthLoginResponse response = googleOAuthService.login(
+                request,
+                servletRequest.getHeader("X-Requested-With"),
+                servletRequest.getHeader("Origin")
+        );
+        return ResponseEntity.ok(ApiResponse.success("구글 로그인에 성공하였습니다.", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/controller/LocalGoogleLoginTestController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/LocalGoogleLoginTestController.java
@@ -1,0 +1,19 @@
+package net.diveon.backend.domain.user.controller;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+public class LocalGoogleLoginTestController {
+
+    @GetMapping(value = "/local/google-login-test.html", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<Resource> googleLoginTestPage() {
+        return ResponseEntity.ok(new ClassPathResource("local-static/google-login-test.html"));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/controller/LocalGoogleOAuthController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/LocalGoogleOAuthController.java
@@ -1,0 +1,31 @@
+package net.diveon.backend.domain.user.controller;
+
+import jakarta.validation.Valid;
+import net.diveon.backend.domain.user.dto.AuthLoginResponse;
+import net.diveon.backend.domain.user.dto.GoogleLoginRequest;
+import net.diveon.backend.domain.user.service.LocalGoogleOAuthService;
+import net.diveon.backend.global.response.ApiResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+@RequestMapping("/api/local/auth/google")
+public class LocalGoogleOAuthController {
+
+    private final LocalGoogleOAuthService localGoogleOAuthService;
+
+    public LocalGoogleOAuthController(LocalGoogleOAuthService localGoogleOAuthService) {
+        this.localGoogleOAuthService = localGoogleOAuthService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<AuthLoginResponse>> googleLogin(@Valid @RequestBody GoogleLoginRequest request) {
+        AuthLoginResponse response = localGoogleOAuthService.login(request);
+        return ResponseEntity.ok(ApiResponse.success("구글 로그인에 성공하였습니다.", response));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/GoogleLoginRequest.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/GoogleLoginRequest.java
@@ -1,0 +1,17 @@
+package net.diveon.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class GoogleLoginRequest {
+
+    @NotBlank
+    private String code;
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/entity/User.java
+++ b/src/main/java/net/diveon/backend/domain/user/entity/User.java
@@ -76,6 +76,20 @@ public class User {
         this.score = 0;
     }
 
+    public static User createSocialUser(String loginId, String password, String nickname, String email, String realName, String profileImgUrl) {
+        User user = new User();
+        user.loginId = loginId;
+        user.password = password;
+        user.nickname = nickname;
+        user.email = email;
+        user.realName = realName;
+        user.profileImgUrl = profileImgUrl;
+        user.createdAt = LocalDateTime.now();
+        user.tier = 0;
+        user.score = 0;
+        return user;
+    }
+
     public void updateProfile(String nickname, String comment, String belong, List<String> interest) {
         if (nickname != null) this.nickname = nickname;
         if (comment != null) this.comment = comment;

--- a/src/main/java/net/diveon/backend/domain/user/service/GoogleOAuthService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/GoogleOAuthService.java
@@ -1,0 +1,286 @@
+package net.diveon.backend.domain.user.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import net.diveon.backend.domain.user.dto.AuthLoginResponse;
+import net.diveon.backend.domain.user.dto.GoogleLoginRequest;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.GoogleOAuthException;
+import net.diveon.backend.global.exception.SocialAccountConflictException;
+import net.diveon.backend.global.security.JwtProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Service
+@Profile("prod")
+public class GoogleOAuthService {
+
+    private static final String GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+    private static final String GOOGLE_LOGIN_ID_PREFIX = "google:";
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+    private static final String REQUESTED_WITH_HEADER_VALUE = "XmlHttpRequest";
+    private static final long REFRESH_TOKEN_TTL_DAYS = 7;
+    private static final int NICKNAME_MAX_LENGTH = 50;
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RestClient restClient;
+    private final GoogleIdTokenVerifier idTokenVerifier;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+    private final Set<String> allowedOrigins;
+
+    public GoogleOAuthService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            JwtProvider jwtProvider,
+            RedisTemplate<String, String> redisTemplate,
+            RestClient.Builder restClientBuilder,
+            @Value("${auth.google.client-id}") String clientId,
+            @Value("${auth.google.client-secret}") String clientSecret,
+            @Value("${auth.google.redirect-uri}") String redirectUri,
+            @Value("${auth.google.allowed-origins:}") String allowedOrigins) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtProvider = jwtProvider;
+        this.redisTemplate = redisTemplate;
+        this.restClient = restClientBuilder.build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+        this.allowedOrigins = parseAllowedOrigins(allowedOrigins);
+        this.idTokenVerifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
+                .setAudience(Collections.singletonList(clientId))
+                .build();
+    }
+
+    @Transactional
+    public AuthLoginResponse login(GoogleLoginRequest request, String requestedWith, String origin) {
+        validateCodeRequest(requestedWith, origin);
+
+        GoogleTokenResponse tokenResponse = exchangeCode(request.getCode());
+        GoogleIdToken.Payload payload = verifyIdToken(tokenResponse.getIdToken());
+
+        String googleSubject = payload.getSubject();
+        String loginId = GOOGLE_LOGIN_ID_PREFIX + googleSubject;
+
+        User user = userRepository.findByLoginId(loginId)
+                .orElseGet(() -> createUser(loginId, payload));
+
+        return issueTokens(user);
+    }
+
+    private void validateCodeRequest(String requestedWith, String origin) {
+        if (!REQUESTED_WITH_HEADER_VALUE.equals(requestedWith)) {
+            throw new GoogleOAuthException("유효하지 않은 구글 로그인 요청입니다.");
+        }
+
+        if (!allowedOrigins.isEmpty() && (origin == null || !allowedOrigins.contains(origin))) {
+            throw new GoogleOAuthException("허용되지 않은 출처의 구글 로그인 요청입니다.");
+        }
+    }
+
+    private GoogleTokenResponse exchangeCode(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", code);
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("grant_type", "authorization_code");
+
+        try {
+            GoogleTokenResponse tokenResponse = restClient.post()
+                    .uri(GOOGLE_TOKEN_ENDPOINT)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(GoogleTokenResponse.class);
+
+            if (tokenResponse == null || tokenResponse.getIdToken() == null || tokenResponse.getIdToken().isBlank()) {
+                throw new GoogleOAuthException("구글 토큰 응답에 ID 토큰이 없습니다.");
+            }
+            return tokenResponse;
+        } catch (RestClientException ex) {
+            throw new GoogleOAuthException("구글 토큰 교환에 실패했습니다.");
+        }
+    }
+
+    private GoogleIdToken.Payload verifyIdToken(String idToken) {
+        try {
+            GoogleIdToken verifiedIdToken = idTokenVerifier.verify(idToken);
+            if (verifiedIdToken == null) {
+                throw new GoogleOAuthException("유효하지 않은 구글 ID 토큰입니다.");
+            }
+
+            GoogleIdToken.Payload payload = verifiedIdToken.getPayload();
+            if (!Boolean.TRUE.equals(payload.getEmailVerified())) {
+                throw new GoogleOAuthException("구글 이메일 인증이 완료되지 않은 계정입니다.");
+            }
+            return payload;
+        } catch (GeneralSecurityException | IOException ex) {
+            throw new GoogleOAuthException("구글 ID 토큰 검증에 실패했습니다.");
+        }
+    }
+
+    private User createUser(String loginId, GoogleIdToken.Payload payload) {
+        String email = payload.getEmail();
+        if (email == null || email.isBlank()) {
+            throw new GoogleOAuthException("구글 계정 이메일을 확인할 수 없습니다.");
+        }
+
+        Optional<User> existingEmailUser = userRepository.findByEmail(email);
+        if (existingEmailUser.isPresent()) {
+            throw new SocialAccountConflictException();
+        }
+
+        String name = (String) payload.get("name");
+        String picture = (String) payload.get("picture");
+        String encodedPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+        String nickname = createUniqueNickname(name, email);
+
+        User user = User.createSocialUser(loginId, encodedPassword, nickname, email, name, picture);
+        return userRepository.save(user);
+    }
+
+    private String createUniqueNickname(String name, String email) {
+        String base = name;
+        if (base == null || base.isBlank()) {
+            base = email.substring(0, email.indexOf("@"));
+        }
+
+        base = base.replaceAll("[^가-힣a-zA-Z0-9_-]", "");
+        if (base.isBlank()) {
+            base = "google_user";
+        }
+        base = truncate(base, NICKNAME_MAX_LENGTH);
+
+        if (!userRepository.existsByNickname(base)) {
+            return base;
+        }
+
+        for (int i = 0; i < 10; i++) {
+            String suffix = "_" + UUID.randomUUID().toString().substring(0, 8);
+            String candidate = truncate(base, NICKNAME_MAX_LENGTH - suffix.length()) + suffix;
+            if (!userRepository.existsByNickname(candidate)) {
+                return candidate;
+            }
+        }
+
+        throw new GoogleOAuthException("사용 가능한 닉네임 생성에 실패했습니다.");
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    private AuthLoginResponse issueTokens(User user) {
+        String accessToken = jwtProvider.generateAccessToken(String.valueOf(user.getId()));
+        String refreshToken = jwtProvider.generateRefreshToken(String.valueOf(user.getId()));
+
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + user.getId(),
+                refreshToken,
+                REFRESH_TOKEN_TTL_DAYS,
+                TimeUnit.DAYS
+        );
+
+        AuthLoginResponse.UserInfo userInfo = new AuthLoginResponse.UserInfo(
+                user.getNickname(),
+                user.getProfileImgUrl()
+        );
+
+        return new AuthLoginResponse(accessToken, refreshToken, userInfo);
+    }
+
+    private Set<String> parseAllowedOrigins(String allowedOrigins) {
+        if (allowedOrigins == null || allowedOrigins.isBlank()) {
+            return Collections.emptySet();
+        }
+
+        return Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static class GoogleTokenResponse {
+        @JsonProperty("access_token")
+        private String accessToken;
+        @JsonProperty("expires_in")
+        private Long expiresIn;
+        @JsonProperty("id_token")
+        private String idToken;
+        private String scope;
+        @JsonProperty("token_type")
+        private String tokenType;
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public void setAccessToken(String accessToken) {
+            this.accessToken = accessToken;
+        }
+
+        public Long getExpiresIn() {
+            return expiresIn;
+        }
+
+        public void setExpiresIn(Long expiresIn) {
+            this.expiresIn = expiresIn;
+        }
+
+        public String getIdToken() {
+            return idToken;
+        }
+
+        public void setIdToken(String idToken) {
+            this.idToken = idToken;
+        }
+
+        public String getScope() {
+            return scope;
+        }
+
+        public void setScope(String scope) {
+            this.scope = scope;
+        }
+
+        public String getTokenType() {
+            return tokenType;
+        }
+
+        public void setTokenType(String tokenType) {
+            this.tokenType = tokenType;
+        }
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/LocalGoogleOAuthService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/LocalGoogleOAuthService.java
@@ -1,0 +1,256 @@
+package net.diveon.backend.domain.user.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import net.diveon.backend.domain.user.dto.AuthLoginResponse;
+import net.diveon.backend.domain.user.dto.GoogleLoginRequest;
+import net.diveon.backend.domain.user.entity.User;
+import net.diveon.backend.domain.user.repository.UserRepository;
+import net.diveon.backend.global.exception.GoogleOAuthException;
+import net.diveon.backend.global.exception.SocialAccountConflictException;
+import net.diveon.backend.global.security.JwtProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Profile("local")
+public class LocalGoogleOAuthService {
+
+    private static final String GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+    private static final String GOOGLE_LOGIN_ID_PREFIX = "google:";
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+    private static final long REFRESH_TOKEN_TTL_DAYS = 7;
+    private static final int NICKNAME_MAX_LENGTH = 50;
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RestClient restClient;
+    private final GoogleIdTokenVerifier idTokenVerifier;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public LocalGoogleOAuthService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            JwtProvider jwtProvider,
+            RedisTemplate<String, String> redisTemplate,
+            RestClient.Builder restClientBuilder,
+            @Value("${auth.google.client-id}") String clientId,
+            @Value("${auth.google.client-secret}") String clientSecret,
+            @Value("${auth.google.redirect-uri}") String redirectUri) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtProvider = jwtProvider;
+        this.redisTemplate = redisTemplate;
+        this.restClient = restClientBuilder.build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+        this.idTokenVerifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
+                .setAudience(Collections.singletonList(clientId))
+                .build();
+    }
+
+    @Transactional
+    public AuthLoginResponse login(GoogleLoginRequest request) {
+        GoogleTokenResponse tokenResponse = exchangeCode(request.getCode());
+        GoogleIdToken.Payload payload = verifyIdToken(tokenResponse.getIdToken());
+
+        String googleSubject = payload.getSubject();
+        String loginId = GOOGLE_LOGIN_ID_PREFIX + googleSubject;
+
+        User user = userRepository.findByLoginId(loginId)
+                .orElseGet(() -> createUser(loginId, payload));
+
+        return issueTokens(user);
+    }
+
+    private GoogleTokenResponse exchangeCode(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", code);
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("grant_type", "authorization_code");
+
+        try {
+            GoogleTokenResponse tokenResponse = restClient.post()
+                    .uri(GOOGLE_TOKEN_ENDPOINT)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(GoogleTokenResponse.class);
+
+            if (tokenResponse == null || tokenResponse.getIdToken() == null || tokenResponse.getIdToken().isBlank()) {
+                throw new GoogleOAuthException("구글 토큰 응답에 ID 토큰이 없습니다.");
+            }
+            return tokenResponse;
+        } catch (RestClientException ex) {
+            throw new GoogleOAuthException("구글 토큰 교환에 실패했습니다.");
+        }
+    }
+
+    private GoogleIdToken.Payload verifyIdToken(String idToken) {
+        try {
+            GoogleIdToken verifiedIdToken = idTokenVerifier.verify(idToken);
+            if (verifiedIdToken == null) {
+                throw new GoogleOAuthException("유효하지 않은 구글 ID 토큰입니다.");
+            }
+
+            GoogleIdToken.Payload payload = verifiedIdToken.getPayload();
+            if (!Boolean.TRUE.equals(payload.getEmailVerified())) {
+                throw new GoogleOAuthException("구글 이메일 인증이 완료되지 않은 계정입니다.");
+            }
+            return payload;
+        } catch (GeneralSecurityException | IOException ex) {
+            throw new GoogleOAuthException("구글 ID 토큰 검증에 실패했습니다.");
+        }
+    }
+
+    private User createUser(String loginId, GoogleIdToken.Payload payload) {
+        String email = payload.getEmail();
+        if (email == null || email.isBlank()) {
+            throw new GoogleOAuthException("구글 계정 이메일을 확인할 수 없습니다.");
+        }
+
+        Optional<User> existingEmailUser = userRepository.findByEmail(email);
+        if (existingEmailUser.isPresent()) {
+            throw new SocialAccountConflictException();
+        }
+
+        String name = (String) payload.get("name");
+        String picture = (String) payload.get("picture");
+        String encodedPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+        String nickname = createUniqueNickname(name, email);
+
+        User user = User.createSocialUser(loginId, encodedPassword, nickname, email, name, picture);
+        return userRepository.save(user);
+    }
+
+    private String createUniqueNickname(String name, String email) {
+        String base = name;
+        if (base == null || base.isBlank()) {
+            base = email.substring(0, email.indexOf("@"));
+        }
+
+        base = base.replaceAll("[^가-힣a-zA-Z0-9_-]", "");
+        if (base.isBlank()) {
+            base = "google_user";
+        }
+        base = truncate(base, NICKNAME_MAX_LENGTH);
+
+        if (!userRepository.existsByNickname(base)) {
+            return base;
+        }
+
+        for (int i = 0; i < 10; i++) {
+            String suffix = "_" + UUID.randomUUID().toString().substring(0, 8);
+            String candidate = truncate(base, NICKNAME_MAX_LENGTH - suffix.length()) + suffix;
+            if (!userRepository.existsByNickname(candidate)) {
+                return candidate;
+            }
+        }
+
+        throw new GoogleOAuthException("사용 가능한 닉네임 생성에 실패했습니다.");
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    private AuthLoginResponse issueTokens(User user) {
+        String accessToken = jwtProvider.generateAccessToken(String.valueOf(user.getId()));
+        String refreshToken = jwtProvider.generateRefreshToken(String.valueOf(user.getId()));
+
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + user.getId(),
+                refreshToken,
+                REFRESH_TOKEN_TTL_DAYS,
+                TimeUnit.DAYS
+        );
+
+        AuthLoginResponse.UserInfo userInfo = new AuthLoginResponse.UserInfo(
+                user.getNickname(),
+                user.getProfileImgUrl()
+        );
+
+        return new AuthLoginResponse(accessToken, refreshToken, userInfo);
+    }
+
+    private static class GoogleTokenResponse {
+        @JsonProperty("access_token")
+        private String accessToken;
+        @JsonProperty("expires_in")
+        private Long expiresIn;
+        @JsonProperty("id_token")
+        private String idToken;
+        private String scope;
+        @JsonProperty("token_type")
+        private String tokenType;
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public void setAccessToken(String accessToken) {
+            this.accessToken = accessToken;
+        }
+
+        public Long getExpiresIn() {
+            return expiresIn;
+        }
+
+        public void setExpiresIn(Long expiresIn) {
+            this.expiresIn = expiresIn;
+        }
+
+        public String getIdToken() {
+            return idToken;
+        }
+
+        public void setIdToken(String idToken) {
+            this.idToken = idToken;
+        }
+
+        public String getScope() {
+            return scope;
+        }
+
+        public void setScope(String scope) {
+            this.scope = scope;
+        }
+
+        public String getTokenType() {
+            return tokenType;
+        }
+
+        public void setTokenType(String tokenType) {
+            this.tokenType = tokenType;
+        }
+    }
+}

--- a/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
+++ b/src/main/java/net/diveon/backend/global/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/refresh", "/api/auth/check-loginId", "/api/auth/check-nickname", "/api/auth/email/send", "/api/auth/email/verify", "/api/auth/email/find-id", "/api/auth/email/send-reset", "/api/auth/email/password/reset", "/api/ad/**", "/error").permitAll()
+                        .requestMatchers("/local/google-login-test.html", "/api/local/auth/google/login", "/api/auth/google/login", "/api/auth/login", "/api/auth/signup", "/api/auth/refresh", "/api/auth/check-loginId", "/api/auth/check-nickname", "/api/auth/email/send", "/api/auth/email/verify", "/api/auth/email/find-id", "/api/auth/email/send-reset", "/api/auth/email/password/reset", "/api/ad/**", "/error").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/groups/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/members/pending").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups/*/problems").authenticated()

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -528,6 +528,34 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
         }
 
+        // 구글 소셜 로그인 실패 → 401
+        @ExceptionHandler(GoogleOAuthException.class)
+        public ResponseEntity<ErrorResponse> handleGoogleOAuth(
+                GoogleOAuthException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/google-oauth-failed",
+                        "Unauthorized",
+                        401,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+        }
+
+        // 이미 다른 로그인 방식으로 가입된 이메일 → 409
+        @ExceptionHandler(SocialAccountConflictException.class)
+        public ResponseEntity<ErrorResponse> handleSocialAccountConflict(
+                SocialAccountConflictException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/conflict/social-account",
+                        "Conflict",
+                        409,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+        }
+
         // 이메일 인증 코드 불일치/만료 → 400
         @ExceptionHandler(EmailVerificationCodeInvalidException.class)
         public ResponseEntity<ErrorResponse> handleEmailVerificationCodeInvalid(

--- a/src/main/java/net/diveon/backend/global/exception/GoogleOAuthException.java
+++ b/src/main/java/net/diveon/backend/global/exception/GoogleOAuthException.java
@@ -1,0 +1,12 @@
+package net.diveon.backend.global.exception;
+
+public class GoogleOAuthException extends RuntimeException {
+
+    public GoogleOAuthException() {
+        super("구글 로그인 처리에 실패했습니다.");
+    }
+
+    public GoogleOAuthException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/diveon/backend/global/exception/SocialAccountConflictException.java
+++ b/src/main/java/net/diveon/backend/global/exception/SocialAccountConflictException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class SocialAccountConflictException extends RuntimeException {
+
+    public SocialAccountConflictException() {
+        super("이미 다른 로그인 방식으로 가입된 이메일입니다.");
+    }
+}

--- a/src/main/resources/local-static/google-login-test.html
+++ b/src/main/resources/local-static/google-login-test.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Google Login Test</title>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <style>
+        :root {
+            color-scheme: light;
+            font-family: Arial, sans-serif;
+            background: #f4f6f8;
+            color: #17212b;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+        }
+
+        main {
+            width: min(760px, calc(100% - 32px));
+            background: #ffffff;
+            border: 1px solid #d9e0e7;
+            border-radius: 8px;
+            padding: 24px;
+            box-shadow: 0 12px 28px rgba(19, 32, 45, 0.08);
+        }
+
+        h1 {
+            margin: 0 0 16px;
+            font-size: 24px;
+            line-height: 1.25;
+        }
+
+        label {
+            display: block;
+            margin: 14px 0 6px;
+            font-size: 14px;
+            font-weight: 700;
+        }
+
+        input {
+            box-sizing: border-box;
+            width: 100%;
+            height: 42px;
+            border: 1px solid #b9c4cf;
+            border-radius: 6px;
+            padding: 0 12px;
+            font-size: 14px;
+        }
+
+        button {
+            height: 42px;
+            margin-top: 18px;
+            border: 0;
+            border-radius: 6px;
+            padding: 0 16px;
+            background: #1a73e8;
+            color: #ffffff;
+            font-size: 14px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        button:disabled {
+            background: #94a3b8;
+            cursor: not-allowed;
+        }
+
+        pre {
+            min-height: 160px;
+            max-height: 360px;
+            overflow: auto;
+            margin: 18px 0 0;
+            border: 1px solid #d9e0e7;
+            border-radius: 6px;
+            background: #101820;
+            color: #d6f5e3;
+            padding: 14px;
+            font-size: 13px;
+            line-height: 1.5;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+    </style>
+</head>
+<body>
+<main>
+    <h1>Google Login Test</h1>
+
+    <label for="clientId">Google OAuth Client ID</label>
+    <input id="clientId" placeholder="YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com">
+
+    <label for="backendEndpoint">Backend Endpoint</label>
+    <input id="backendEndpoint" value="http://localhost:8080/api/local/auth/google/login">
+
+    <label for="scope">Scope</label>
+    <input id="scope" value="openid email profile">
+
+    <button id="loginButton" type="button">Google Authorization Code 요청</button>
+
+    <pre id="result">대기 중...</pre>
+</main>
+
+<script>
+    const loginButton = document.getElementById("loginButton");
+    const result = document.getElementById("result");
+
+    function print(value) {
+        if (typeof value === "string") {
+            result.textContent = value;
+            return;
+        }
+        result.textContent = JSON.stringify(value, null, 2);
+    }
+
+    function getConfig() {
+        return {
+            clientId: document.getElementById("clientId").value.trim(),
+            backendEndpoint: document.getElementById("backendEndpoint").value.trim(),
+            scope: document.getElementById("scope").value.trim()
+        };
+    }
+
+    async function sendCodeToBackend(code, backendEndpoint) {
+        const response = await fetch(backendEndpoint, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({ code })
+        });
+
+        const responseText = await response.text();
+        let body;
+        try {
+            body = responseText ? JSON.parse(responseText) : null;
+        } catch (error) {
+            body = responseText;
+        }
+
+        if (!response.ok) {
+            throw {
+                status: response.status,
+                body
+            };
+        }
+
+        return body;
+    }
+
+    loginButton.addEventListener("click", () => {
+        const { clientId, backendEndpoint, scope } = getConfig();
+
+        if (!clientId) {
+            print("Google OAuth Client ID를 입력하십시오.");
+            return;
+        }
+
+        if (!backendEndpoint) {
+            print("백엔드 엔드포인트를 입력하십시오.");
+            return;
+        }
+
+        if (!window.google || !google.accounts || !google.accounts.oauth2) {
+            print("Google Identity Services SDK가 아직 로드되지 않았습니다. 잠시 후 다시 시도하십시오.");
+            return;
+        }
+
+        loginButton.disabled = true;
+        print("구글 인증 창을 여는 중...");
+
+        const codeClient = google.accounts.oauth2.initCodeClient({
+            client_id: clientId,
+            scope,
+            ux_mode: "popup",
+            callback: async (response) => {
+                try {
+                    if (response.error) {
+                        throw response;
+                    }
+
+                    print({
+                        step: "authorization_code_received",
+                        code: response.code
+                    });
+
+                    const backendResponse = await sendCodeToBackend(response.code, backendEndpoint);
+                    print({
+                        step: "backend_login_success",
+                        response: backendResponse
+                    });
+                } catch (error) {
+                    print({
+                        step: "failed",
+                        error
+                    });
+                } finally {
+                    loginButton.disabled = false;
+                }
+            },
+            error_callback: (error) => {
+                print({
+                    step: "google_popup_failed",
+                    error
+                });
+                loginButton.disabled = false;
+            }
+        });
+
+        codeClient.requestCode();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 구글 소셜 로그인 구현
- 로컬 테스트는 resource/local-static 및의 html 파일을 읽어야하므로
- 로컬에서 서버키고 http://localhost:8080/local/google-login-test.html 으로 접근
- 키 값은 나한테 물어보셈알려드림

## 관련 이슈
Closes #374


<!-- 주석은 제외되고 올라가니 무시하세요 -->
