### PR TITLE
[feat] 랜덤 문제 및 오늘의 문제 API 구현 (#378)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
@@ -1,11 +1,14 @@
 package net.diveon.backend.domain.problem.controller;
 
 import net.diveon.backend.domain.problem.dto.response.interfaces.ProblemDetailResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemListResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemRankingResponse;
 import net.diveon.backend.domain.problem.service.ProblemDetailService;
 import net.diveon.backend.domain.problem.service.ProblemListService;
 import net.diveon.backend.domain.problem.service.ProblemRankingService;
+import net.diveon.backend.domain.problem.service.ProblemRandomService;
+import net.diveon.backend.domain.problem.service.ProblemTodayService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,12 +25,17 @@ public class ProblemController {
     private final ProblemDetailService problemDetailService;
     private final ProblemListService problemListService;
     private final ProblemRankingService problemRankingService;
+    private final ProblemRandomService problemRandomService;
+    private final ProblemTodayService problemTodayService;
 
     public ProblemController(ProblemDetailService problemDetailService, ProblemListService problemListService,
-                             ProblemRankingService problemRankingService) {
+                             ProblemRankingService problemRankingService, ProblemRandomService problemRandomService,
+                             ProblemTodayService problemTodayService) {
         this.problemDetailService = problemDetailService;
         this.problemListService = problemListService;
         this.problemRankingService = problemRankingService;
+        this.problemRandomService = problemRandomService;
+        this.problemTodayService = problemTodayService;
     }
 
     @GetMapping("")
@@ -71,6 +79,22 @@ public class ProblemController {
 
         return ResponseEntity.status(200)
             .body(ApiResponse.success("문제 상세 조회에 성공하였습니다.", responseData));
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<ApiResponse<ProblemListItemResponse>> getTodayProblem(
+        @AuthenticationPrincipal String userId
+    ) {
+        ProblemListItemResponse responseData = problemTodayService.getTodayProblem(Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("오늘의 문제 조회에 성공하였습니다.", responseData));
+    }
+
+    @GetMapping("/random")
+    public ResponseEntity<ApiResponse<ProblemListItemResponse>> getRandomProblem(
+        @AuthenticationPrincipal String userId
+    ) {
+        ProblemListItemResponse responseData = problemRandomService.getRandomProblem(Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("랜덤 문제 조회에 성공하였습니다.", responseData));
     }
 
     @GetMapping("/{probId}/ranking")

--- a/src/main/java/net/diveon/backend/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/problem/repository/ProblemRepository.java
@@ -2,9 +2,22 @@ package net.diveon.backend.domain.problem.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 import net.diveon.backend.domain.problem.entity.Problem;
 
+import java.util.Optional;
+
 public interface ProblemRepository extends JpaRepository<Problem, Long>, JpaSpecificationExecutor<Problem> {
 
+    @Query(value = """
+            SELECT * FROM problem_summary p
+            WHERE p.visibility = 'public'
+            AND (p.type != 'practice' OR EXISTS (
+                SELECT 1 FROM problem_practice pp WHERE pp.prob_id = p.id AND pp.image_status = 'READY'
+            ))
+            ORDER BY RANDOM()
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<Problem> findRandomPublicProblem();
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemRandomService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemRandomService.java
@@ -1,0 +1,32 @@
+package net.diveon.backend.domain.problem.service;
+
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
+import net.diveon.backend.global.exception.ProblemNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+public class ProblemRandomService {
+
+    private final ProblemRepository problemRepository;
+    private final SolveSubmissionRepository solveSubmissionRepository;
+
+    public ProblemRandomService(ProblemRepository problemRepository, SolveSubmissionRepository solveSubmissionRepository) {
+        this.problemRepository = problemRepository;
+        this.solveSubmissionRepository = solveSubmissionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemListItemResponse getRandomProblem(long userId) {
+        Problem problem = problemRepository.findRandomPublicProblem()
+                .orElseThrow(ProblemNotFoundException::new);
+
+        Set<Long> solvedIds = Set.copyOf(solveSubmissionRepository.findSolvedProblemIdsByUserId(userId));
+        return ProblemListItemResponse.of(problem, solvedIds.contains(problem.getId()));
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemTodayService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemTodayService.java
@@ -1,0 +1,57 @@
+package net.diveon.backend.domain.problem.service;
+
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
+import net.diveon.backend.global.exception.ProblemNotFoundException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class ProblemTodayService {
+
+    private static final String TODAY_PROBLEM_KEY = "today_problem_id";
+
+    private final ProblemRepository problemRepository;
+    private final SolveSubmissionRepository solveSubmissionRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public ProblemTodayService(ProblemRepository problemRepository,
+                               SolveSubmissionRepository solveSubmissionRepository,
+                               RedisTemplate<String, String> redisTemplate) {
+        this.problemRepository = problemRepository;
+        this.solveSubmissionRepository = solveSubmissionRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void refreshTodayProblem() {
+        problemRepository.findRandomPublicProblem().ifPresent(problem ->
+                redisTemplate.opsForValue().set(TODAY_PROBLEM_KEY, String.valueOf(problem.getId()), 25, TimeUnit.HOURS)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemListItemResponse getTodayProblem(long userId) {
+        String problemIdStr = redisTemplate.opsForValue().get(TODAY_PROBLEM_KEY);
+
+        Problem problem;
+        if (problemIdStr == null) {
+            problem = problemRepository.findRandomPublicProblem()
+                    .orElseThrow(ProblemNotFoundException::new);
+            redisTemplate.opsForValue().set(TODAY_PROBLEM_KEY, String.valueOf(problem.getId()), 25, TimeUnit.HOURS);
+        } else {
+            problem = problemRepository.findById(Long.parseLong(problemIdStr))
+                    .orElseThrow(ProblemNotFoundException::new);
+        }
+
+        Set<Long> solvedIds = Set.copyOf(solveSubmissionRepository.findSolvedProblemIdsByUserId(userId));
+        return ProblemListItemResponse.of(problem, solvedIds.contains(problem.getId()));
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 랜덤 문제 조회 API 구현 (`GET /api/problems/random`)
- 오늘의 문제 조회 API 구현 (`GET /api/problems/today`)
- 공개 문제 중 랜덤 조회 쿼리 추가
- 오늘의 문제 매일 자정 자동 갱신 스케줄러 구현 (Redis 캐싱)


## 관련 이슈
Closes #


<!-- 주석은 제외되고 올라가니 무시하세요 -->
