### PR TITLE
[feat] 비공개 그룹 초대링크 구현 (#382)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
+++ b/src/main/java/net/diveon/backend/domain/group/controller/GroupController.java
@@ -6,6 +6,7 @@ import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
 import net.diveon.backend.domain.group.dto.GroupImageUploadResponse;
+import net.diveon.backend.domain.group.dto.GroupInviteCodeResponse;
 import net.diveon.backend.domain.group.dto.GroupListResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
@@ -15,6 +16,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import net.diveon.backend.domain.contest.dto.response.GroupContestListResponse;
 import net.diveon.backend.domain.contest.service.ContestService;
+import net.diveon.backend.domain.group.dto.GroupJoinByInviteResponse;
+import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
+import net.diveon.backend.domain.group.service.GroupMemberService;
 import net.diveon.backend.domain.group.service.GroupRankingService;
 import net.diveon.backend.domain.group.service.GroupService;
 import net.diveon.backend.global.response.ApiResponse;
@@ -37,12 +41,14 @@ import java.util.List;
 public class GroupController {
 
     private final GroupService groupService;
+    private final GroupMemberService groupMemberService;
     private final ContestService contestService;
     private final GroupRankingService groupRankingService;
 
-    public GroupController(GroupService groupService, ContestService contestService,
-                           GroupRankingService groupRankingService) {
+    public GroupController(GroupService groupService, GroupMemberService groupMemberService,
+                           ContestService contestService, GroupRankingService groupRankingService) {
         this.groupService = groupService;
+        this.groupMemberService = groupMemberService;
         this.contestService = contestService;
         this.groupRankingService = groupRankingService;
     }
@@ -159,6 +165,16 @@ public class GroupController {
         return ResponseEntity.ok(ApiResponse.success("그룹 전용 대회 목록 조회 성공", response));
     }
 
+    // 초대링크로 그룹 가입
+    @PostMapping("/join")
+    public ResponseEntity<ApiResponse<GroupJoinByInviteResponse>> joinByInviteCode(
+            @RequestParam String code,
+            @AuthenticationPrincipal String userId) {
+        GroupJoinByInviteResponse response = groupMemberService.joinByInviteCode(code, Long.parseLong(userId));
+        String message = "already_member".equals(response.getNewStatus()) ? "이미 가입된 그룹입니다." : "그룹에 참여했습니다.";
+        return ResponseEntity.ok(ApiResponse.success(message, response));
+    }
+
     // 그룹 생성
     @PostMapping
     public ResponseEntity<ApiResponse<GroupCreateResponse>> createGroup(
@@ -166,6 +182,24 @@ public class GroupController {
             @Valid @RequestBody GroupCreateRequest request) {
         GroupCreateResponse response = groupService.createGroup(Long.parseLong(userId), request);
         return ResponseEntity.status(201).body(ApiResponse.created("그룹이 성공적으로 생성되었습니다.", response));
+    }
+
+    // 초대코드 재발급 (그룹장만)
+    @PatchMapping("/{groupId}/invite-code")
+    public ResponseEntity<ApiResponse<GroupInviteCodeResponse>> regenerateInviteCode(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId) {
+        GroupInviteCodeResponse response = groupService.regenerateInviteCode(groupId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("초대코드 재발급 성공", response));
+    }
+
+    // 초대코드 조회 (그룹장만)
+    @GetMapping("/{groupId}/invite-code")
+    public ResponseEntity<ApiResponse<GroupInviteCodeResponse>> getInviteCode(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal String userId) {
+        GroupInviteCodeResponse response = groupService.getInviteCode(groupId, Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("초대코드 조회 성공", response));
     }
 
     // 그룹 이미지 업로드 (그룹장만 가능)

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupInviteCodeResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupInviteCodeResponse.java
@@ -1,0 +1,16 @@
+package net.diveon.backend.domain.group.dto;
+
+import java.time.LocalDateTime;
+
+public class GroupInviteCodeResponse {
+    private String invitationCode;
+    private LocalDateTime expiresAt;
+
+    public GroupInviteCodeResponse(String invitationCode, LocalDateTime expiresAt) {
+        this.invitationCode = invitationCode;
+        this.expiresAt = expiresAt;
+    }
+
+    public String getInvitationCode() { return invitationCode; }
+    public LocalDateTime getExpiresAt() { return expiresAt; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupJoinByInviteResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupJoinByInviteResponse.java
@@ -1,0 +1,20 @@
+package net.diveon.backend.domain.group.dto;
+
+public class GroupJoinByInviteResponse {
+    private Long userId;
+    private String newStatus;
+    private Long groupId;
+    private String groupTitle;
+
+    public GroupJoinByInviteResponse(Long userId, String newStatus, Long groupId, String groupTitle) {
+        this.userId = userId;
+        this.newStatus = newStatus;
+        this.groupId = groupId;
+        this.groupTitle = groupTitle;
+    }
+
+    public Long getUserId() { return userId; }
+    public String getNewStatus() { return newStatus; }
+    public Long getGroupId() { return groupId; }
+    public String getGroupTitle() { return groupTitle; }
+}

--- a/src/main/java/net/diveon/backend/domain/group/dto/GroupListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/group/dto/GroupListResponse.java
@@ -1,5 +1,6 @@
 package net.diveon.backend.domain.group.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public class GroupListResponse {
@@ -29,8 +30,9 @@ public class GroupListResponse {
         private int totalMembers;
         private List<String> tags;
         private boolean joined;
+        private boolean isPrivate;
 
-        public GroupItem(Long groupId, String title, String leader, int memberCount, int totalMembers, List<String> tags, boolean joined) {
+        public GroupItem(Long groupId, String title, String leader, int memberCount, int totalMembers, List<String> tags, boolean joined, boolean isPrivate) {
             this.groupId = groupId;
             this.title = title;
             this.leader = leader;
@@ -38,6 +40,7 @@ public class GroupListResponse {
             this.totalMembers = totalMembers;
             this.tags = tags;
             this.joined = joined;
+            this.isPrivate = isPrivate;
         }
 
         public Long getGroupId() { return groupId; }
@@ -47,5 +50,6 @@ public class GroupListResponse {
         public int getTotalMembers() { return totalMembers; }
         public List<String> getTags() { return tags; }
         public boolean isJoined() { return joined; }
+        public boolean getIsPrivate() { return isPrivate; }
     }
 }

--- a/src/main/java/net/diveon/backend/domain/group/entity/Group.java
+++ b/src/main/java/net/diveon/backend/domain/group/entity/Group.java
@@ -55,11 +55,14 @@ public class Group {
     @Column(name = "invitation_code", unique = true, length = 50)
     private String invitationCode;
 
+    @Column(name = "invitation_code_expires_at")
+    private LocalDateTime invitationCodeExpiresAt;
+
     public Group() {
     }
 
     public Group(User leader, Short limitMemberCount, String image, String title, String description,
-                 Boolean isPrivate, Boolean isAutoApprove, String invitationCode) {
+                 Boolean isPrivate, Boolean isAutoApprove, String invitationCode, LocalDateTime invitationCodeExpiresAt) {
         this.leader = leader;
         this.createdAt = LocalDateTime.now();
         this.limitMemberCount = limitMemberCount != null ? limitMemberCount : 50;
@@ -69,6 +72,7 @@ public class Group {
         this.isPrivate = isPrivate != null ? isPrivate : false;
         this.isAutoApprove = isAutoApprove != null ? isAutoApprove : false;
         this.invitationCode = invitationCode;
+        this.invitationCodeExpiresAt = invitationCodeExpiresAt;
     }
 
     public Long getId() { return id; }
@@ -81,6 +85,12 @@ public class Group {
     public Boolean getIsPrivate() { return isPrivate; }
     public Boolean getIsAutoApprove() { return isAutoApprove; }
     public String getInvitationCode() { return invitationCode; }
+    public LocalDateTime getInvitationCodeExpiresAt() { return invitationCodeExpiresAt; }
+
+    public void updateInvitationCode(String code, LocalDateTime expiresAt) {
+        this.invitationCode = code;
+        this.invitationCodeExpiresAt = expiresAt;
+    }
 
     public void update(String title, String description, Boolean isPrivate, Boolean isAutoApprove) {
         this.title = title;

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupRepository.java
@@ -20,10 +20,13 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     @Query("SELECT g FROM Group g WHERE " +
            "(:tag IS NULL OR EXISTS (SELECT gt FROM GroupTag gt WHERE gt.group = g AND gt.tag = :tag)) AND " +
-           "(:userId IS NULL OR EXISTS (SELECT gu FROM GroupUser gu WHERE gu.group = g AND gu.user.id = :userId))")
-    Page<Group> findAllWithFilters(@Param("tag") String tag, @Param("userId") Long userId, Pageable pageable);
+           "(:filterUserId IS NULL OR EXISTS (SELECT gu FROM GroupUser gu WHERE gu.group = g AND gu.user.id = :filterUserId)) AND " +
+           "(g.isPrivate = false OR (:currentUserId IS NOT NULL AND EXISTS (SELECT gu FROM GroupUser gu WHERE gu.group = g AND gu.user.id = :currentUserId)))")
+    Page<Group> findAllWithFilters(@Param("tag") String tag, @Param("filterUserId") Long filterUserId, @Param("currentUserId") Long currentUserId, Pageable pageable);
 
     Page<Group> findByTitleContainingIgnoreCase(String keyword, Pageable pageable);
+
+    Optional<Group> findByInvitationCode(String invitationCode);
 
     @Query(value = """
             SELECT
@@ -35,6 +38,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
                     + COALESCE(gs.cnt, 0) * 10
                     + COALESCE(cc.cnt, 0) * 100)                             AS score
             FROM domain_group g
+            WHERE g.is_private = false
             LEFT JOIN (
                 SELECT group_id, COUNT(*) AS cnt
                 FROM group_user
@@ -66,7 +70,16 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             ) cc ON cc.group_id = g.id
             ORDER BY score DESC
             """,
-            countQuery = "SELECT COUNT(*) FROM domain_group",
+            countQuery = "SELECT COUNT(*) FROM domain_group WHERE is_private = false",
             nativeQuery = true)
     Page<GroupRankingProjection> findGroupRanking(Pageable pageable);
 }
+/* 지금 방식 (SQL 한 방):
+DB에 쿼리 1번 → 결과 한 번에 받아옴
+
+Java에서 계산하는 방식: (N+1 문제)
+그룹이 10개면 → DB에 쿼리 30번
+그룹이 100개면 → DB에 쿼리 300번
+
+SQL문이 길고 복잡하긴 한데 성능상 차라리 낫다고 해서 선택
+*/

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupMemberService.java
@@ -1,9 +1,11 @@
 package net.diveon.backend.domain.group.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import net.diveon.backend.domain.group.dto.GroupAssignDecisionRequest;
+import net.diveon.backend.domain.group.dto.GroupJoinByInviteResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberListResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberKickResponse;
 import net.diveon.backend.domain.group.dto.GroupMemberCommonResponse;
@@ -24,6 +26,7 @@ import net.diveon.backend.global.exception.GroupLeaderCannotLeaveException;
 import net.diveon.backend.global.exception.GroupLeaderPermissionDeniedException;
 import net.diveon.backend.global.exception.GroupNotFoundException;
 import net.diveon.backend.global.exception.GroupUserNotFoundException;
+import net.diveon.backend.global.exception.InvitationCodeExpiredException;
 import net.diveon.backend.global.exception.UserNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -47,6 +50,24 @@ public class GroupMemberService {
         this.groupUserRepository = groupUserRepository;
         this.groupAssignRequestRepository = groupAssignRequestRepository;
         this.userRepository = userRepository;
+    }
+
+    // 초대링크로 그룹 가입
+    @Transactional
+    public GroupJoinByInviteResponse joinByInviteCode(String code, Long userId) {
+        Group group = groupRepository.findByInvitationCode(code)
+                .orElseThrow(GroupNotFoundException::new);
+        if (group.getInvitationCodeExpiresAt() == null ||
+                group.getInvitationCodeExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new InvitationCodeExpiredException();
+        }
+        if (groupUserRepository.findByGroupIdAndUserId(group.getId(), userId).isPresent()) {
+            return new GroupJoinByInviteResponse(userId, "already_member", group.getId(), group.getTitle());
+        }
+        validateGroupCapacity(group.getId(), group);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        groupUserRepository.save(new GroupUser(group, user, GroupRole.MEMBER));
+        return new GroupJoinByInviteResponse(userId, "member", group.getId(), group.getTitle());
     }
 
     // 그룹 가입 신청

--- a/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
+++ b/src/main/java/net/diveon/backend/domain/group/service/GroupService.java
@@ -5,6 +5,7 @@ import net.diveon.backend.domain.group.dto.GroupUpdateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateRequest;
 import net.diveon.backend.domain.group.dto.GroupCreateResponse;
 import net.diveon.backend.domain.group.dto.GroupDetailResponse;
+import net.diveon.backend.domain.group.dto.GroupInviteCodeResponse;
 import net.diveon.backend.domain.group.dto.GroupListResponse;
 import net.diveon.backend.domain.group.dto.GroupMyListResponse;
 import net.diveon.backend.domain.group.dto.GroupProblemListResponse;
@@ -43,10 +44,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -97,7 +100,7 @@ public class GroupService {
         // isJoined=true면 내 그룹만, 아니면 전체 조회
         Long filterUserId = Boolean.TRUE.equals(isJoined) ? userId : null;
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Group> groupPage = groupRepository.findAllWithFilters(tag, filterUserId, pageable);
+        Page<Group> groupPage = groupRepository.findAllWithFilters(tag, filterUserId, userId, pageable);
         return buildGroupListResponse(groupPage, userId, page);
     }
 
@@ -142,9 +145,10 @@ public class GroupService {
                         group.getTitle(),
                         group.getLeader().getNickname(),
                         memberCountMap.getOrDefault(group.getId(), 0L).intValue(),
-                        group.getLimitMemberCount(),
+                        group.getLimitMemberCount().intValue(),
                         tagMap.getOrDefault(group.getId(), List.of()),
-                        joinedGroupIds.contains(group.getId())
+                        joinedGroupIds.contains(group.getId()),
+                        group.getIsPrivate()
                 )).toList();
 
         return new GroupListResponse(groupPage.getTotalElements(), groupPage.getTotalPages(), page, groups);
@@ -224,15 +228,17 @@ public class GroupService {
         User leader = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
+        boolean isPrivate = Boolean.TRUE.equals(request.getIsPrivate());
         Group group = new Group(
                 leader,
-                null, // limitMemberCount → 기본값 50
-                null, // image → 이미지 업로드 추후 구현
+                null,
+                null,
                 request.getTitle(),
                 request.getDescription(),
                 request.getIsPrivate(),
                 request.getIsAutoApprove(),
-                null // invitationCode → 초대코드 추후 구현
+                isPrivate ? UUID.randomUUID().toString() : null,
+                isPrivate ? LocalDateTime.now().plusDays(30) : null
         );
         groupRepository.save(group);
 
@@ -346,6 +352,33 @@ public class GroupService {
                     return GroupMyListResponse.of(groupUser, isAlreadyAdded);
                 })
                 .toList();
+    }
+
+    // 초대코드 재발급 (그룹장만)
+    @Transactional
+    public GroupInviteCodeResponse regenerateInviteCode(Long groupId, Long userId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupAccessDeniedException::new);
+        if (groupUser.getRole() != GroupRole.LEADER) {
+            throw new GroupLeaderPermissionDeniedException();
+        }
+        group.updateInvitationCode(UUID.randomUUID().toString(), LocalDateTime.now().plusDays(30));
+        return new GroupInviteCodeResponse(group.getInvitationCode(), group.getInvitationCodeExpiresAt());
+    }
+
+    // 초대코드 조회 (그룹장만)
+    @Transactional(readOnly = true)
+    public GroupInviteCodeResponse getInviteCode(Long groupId, Long userId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        GroupUser groupUser = groupUserRepository.findByGroupIdAndUserId(groupId, userId)
+                .orElseThrow(GroupAccessDeniedException::new);
+        if (groupUser.getRole() != GroupRole.LEADER) {
+            throw new GroupLeaderPermissionDeniedException();
+        }
+        return new GroupInviteCodeResponse(group.getInvitationCode(), group.getInvitationCodeExpiresAt());
     }
 
     // 그룹 상세 조회

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -248,6 +248,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // 초대링크 만료 → 410
+        @ExceptionHandler(InvitationCodeExpiredException.class)
+        public ResponseEntity<ErrorResponse> handleInvitationCodeExpired(
+                InvitationCodeExpiredException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/invitation-code-expired",
+                        "Gone",
+                        410,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.GONE).body(body);
+        }
+
         // 그룹 유저 없음 → 404
         @ExceptionHandler(GroupUserNotFoundException.class)
         public ResponseEntity<ErrorResponse> handleGroupUserNotFound(

--- a/src/main/java/net/diveon/backend/global/exception/InvitationCodeExpiredException.java
+++ b/src/main/java/net/diveon/backend/global/exception/InvitationCodeExpiredException.java
@@ -1,0 +1,8 @@
+package net.diveon.backend.global.exception;
+
+public class InvitationCodeExpiredException extends RuntimeException {
+
+    public InvitationCodeExpiredException() {
+        super("초대링크가 만료되었습니다.");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- Group 엔티티에 invitation_code, invitation_code_expires_at 컬럼 추가
- 비공개 그룹 생성 시 UUID 초대코드 + 30일 만료일 자동 발급
- 그룹 목록 조회에서 비공개 그룹 필터링 (내가 속한 비공개 그룹만 노출)
- GET /api/groups/{groupId}/invite-code - 초대코드 조회 (그룹장만)
- PATCH /api/groups/{groupId}/invite-code - 초대코드 재발급 (그룹장만)
- POST /api/groups/join?code={UUID} - 초대링크로 즉시 가입
- 그룹 랭킹에서 비공개 그룹 제외
- 만료된 초대코드 410 Gone 처리

## 관련 이슈
Closes #382

<!-- 주석은 제외되고 올라가니 무시하세요 -->
