### PR TITLE
[feat] 문제 추천 알고리즘 구현 (#393)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
@@ -1,5 +1,6 @@
 package net.diveon.backend.domain.grade.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,6 +24,19 @@ public interface SolveResultRepository extends JpaRepository<SolveResult, Long>{
         @Param("userId") Long userId,
         @Param("probId") Long probId
     );
+
+    @Query("""
+        SELECT p.category, COUNT(r) AS cnt
+        FROM SolveResult r
+        JOIN r.submission ss
+        JOIN ss.problem p
+        WHERE ss.user.id = :userId
+          AND r.resultState = 'WRONG'
+          AND p.visibility = 'public'
+        GROUP BY p.category
+        ORDER BY cnt DESC
+        """)
+    List<Object[]> findWeakCategories(@Param("userId") Long userId);
 
     @Query(value = """
         SELECT COALESCE(SUM(solved.score), 0)

--- a/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
+++ b/src/main/java/net/diveon/backend/domain/problem/controller/ProblemController.java
@@ -4,10 +4,12 @@ import net.diveon.backend.domain.problem.dto.response.interfaces.ProblemDetailRe
 import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemListResponse;
 import net.diveon.backend.domain.problem.dto.response.ProblemRankingResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemRecommendResponse;
 import net.diveon.backend.domain.problem.service.ProblemDetailService;
 import net.diveon.backend.domain.problem.service.ProblemListService;
 import net.diveon.backend.domain.problem.service.ProblemRankingService;
 import net.diveon.backend.domain.problem.service.ProblemRandomService;
+import net.diveon.backend.domain.problem.service.ProblemRecommendService;
 import net.diveon.backend.domain.problem.service.ProblemTodayService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -27,15 +29,17 @@ public class ProblemController {
     private final ProblemRankingService problemRankingService;
     private final ProblemRandomService problemRandomService;
     private final ProblemTodayService problemTodayService;
+    private final ProblemRecommendService problemRecommendService;
 
     public ProblemController(ProblemDetailService problemDetailService, ProblemListService problemListService,
                              ProblemRankingService problemRankingService, ProblemRandomService problemRandomService,
-                             ProblemTodayService problemTodayService) {
+                             ProblemTodayService problemTodayService, ProblemRecommendService problemRecommendService) {
         this.problemDetailService = problemDetailService;
         this.problemListService = problemListService;
         this.problemRankingService = problemRankingService;
         this.problemRandomService = problemRandomService;
         this.problemTodayService = problemTodayService;
+        this.problemRecommendService = problemRecommendService;
     }
 
     @GetMapping("")
@@ -95,6 +99,14 @@ public class ProblemController {
     ) {
         ProblemListItemResponse responseData = problemRandomService.getRandomProblem(Long.parseLong(userId));
         return ResponseEntity.ok(ApiResponse.success("랜덤 문제 조회에 성공하였습니다.", responseData));
+    }
+
+    @GetMapping("/recommend")
+    public ResponseEntity<ApiResponse<ProblemRecommendResponse>> getRecommendProblems(
+        @AuthenticationPrincipal String userId
+    ) {
+        ProblemRecommendResponse responseData = problemRecommendService.recommend(Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("추천 문제 조회에 성공하였습니다.", responseData));
     }
 
     @GetMapping("/{probId}/ranking")

--- a/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemRecommendResponse.java
+++ b/src/main/java/net/diveon/backend/domain/problem/dto/response/ProblemRecommendResponse.java
@@ -1,0 +1,17 @@
+package net.diveon.backend.domain.problem.dto.response;
+
+import java.util.List;
+
+public class ProblemRecommendResponse {
+
+    private final String reason;
+    private final List<ProblemListItemResponse> problems;
+
+    public ProblemRecommendResponse(String reason, List<ProblemListItemResponse> problems) {
+        this.reason = reason;
+        this.problems = problems;
+    }
+
+    public String getReason() { return reason; }
+    public List<ProblemListItemResponse> getProblems() { return problems; }
+}

--- a/src/main/java/net/diveon/backend/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/problem/repository/ProblemRepository.java
@@ -3,9 +3,11 @@ package net.diveon.backend.domain.problem.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import net.diveon.backend.domain.problem.entity.Problem;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long>, JpaSpecificationExecutor<Problem> {
@@ -20,4 +22,34 @@ public interface ProblemRepository extends JpaRepository<Problem, Long>, JpaSpec
             LIMIT 1
             """, nativeQuery = true)
     Optional<Problem> findRandomPublicProblem();
+
+    @Query(value = """
+            SELECT * FROM problem_summary p
+            WHERE p.visibility = 'public'
+              AND p.category = :category
+              AND p.id NOT IN (
+                  SELECT ss.prob_id FROM solve_submission ss WHERE ss.submitter_id = :userId
+              )
+              AND (p.type != 'practice' OR EXISTS (
+                  SELECT 1 FROM problem_practice pp WHERE pp.prob_id = p.id AND pp.image_status = 'READY'
+              ))
+            ORDER BY p.solved_count DESC
+            LIMIT 3
+            """, nativeQuery = true)
+    List<Problem> findRecommendByCategory(@Param("userId") Long userId,
+                                          @Param("category") String category);
+
+    @Query(value = """
+            SELECT * FROM problem_summary p
+            WHERE p.visibility = 'public'
+              AND p.id NOT IN (
+                  SELECT ss.prob_id FROM solve_submission ss WHERE ss.submitter_id = :userId
+              )
+              AND (p.type != 'practice' OR EXISTS (
+                  SELECT 1 FROM problem_practice pp WHERE pp.prob_id = p.id AND pp.image_status = 'READY'
+              ))
+            ORDER BY p.solved_count DESC
+            LIMIT 3
+            """, nativeQuery = true)
+    List<Problem> findPopularUnsolvedProblems(@Param("userId") Long userId);
 }

--- a/src/main/java/net/diveon/backend/domain/problem/service/ProblemRecommendService.java
+++ b/src/main/java/net/diveon/backend/domain/problem/service/ProblemRecommendService.java
@@ -1,0 +1,77 @@
+package net.diveon.backend.domain.problem.service;
+
+import net.diveon.backend.domain.grade.repository.SolveResultRepository;
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemRecommendResponse;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class ProblemRecommendService {
+
+    private final ProblemRepository problemRepository;
+    private final SolveResultRepository solveResultRepository;
+    private final SolveSubmissionRepository solveSubmissionRepository;
+
+    public ProblemRecommendService(ProblemRepository problemRepository,
+                                   SolveResultRepository solveResultRepository,
+                                   SolveSubmissionRepository solveSubmissionRepository) {
+        this.problemRepository = problemRepository;
+        this.solveResultRepository = solveResultRepository;
+        this.solveSubmissionRepository = solveSubmissionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemRecommendResponse recommend(Long userId) {
+        List<Object[]> weakCategories = solveResultRepository.findWeakCategories(userId);
+        Set<Long> solvedIds = Set.copyOf(solveSubmissionRepository.findSolvedProblemIdsByUserId(userId));
+
+        if (weakCategories.isEmpty()) {
+            return fallback(userId, solvedIds);
+        }
+
+        String topCategory = (String) weakCategories.get(0)[0];
+        List<Problem> recommended = problemRepository.findRecommendByCategory(userId, topCategory);
+
+        List<ProblemListItemResponse> result = new ArrayList<>(
+                recommended.stream()
+                        .map(p -> ProblemListItemResponse.of(p, solvedIds.contains(p.getId())))
+                        .toList()
+        );
+
+        if (result.isEmpty()) {
+            return fallback(userId, solvedIds);
+        }
+
+        if (result.size() < 3) {
+            Set<Long> alreadyIncluded = result.stream()
+                    .map(ProblemListItemResponse::getProbId)
+                    .collect(java.util.stream.Collectors.toSet());
+            List<Problem> popular = problemRepository.findPopularUnsolvedProblems(userId);
+            for (Problem p : popular) {
+                if (result.size() >= 3) break;
+                if (!alreadyIncluded.contains(p.getId())) {
+                    result.add(ProblemListItemResponse.of(p, solvedIds.contains(p.getId())));
+                }
+            }
+        }
+
+        String reason = topCategory + " 카테고리를 자주 틀리셨어요";
+        return new ProblemRecommendResponse(reason, result);
+    }
+
+    private ProblemRecommendResponse fallback(Long userId, Set<Long> solvedIds) {
+        List<Problem> popular = problemRepository.findPopularUnsolvedProblems(userId);
+        List<ProblemListItemResponse> result = popular.stream()
+                .map(p -> ProblemListItemResponse.of(p, solvedIds.contains(p.getId())))
+                .toList();
+        return new ProblemRecommendResponse("많은 사람들이 푼 문제를 추천해드려요", result);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- GET /api/problems/recommend 엔드포인트 추가
- 가장 많이 틀린 카테고리 기반 문제 추천 로직 구현
- 해당 카테고리 안 푼 문제 중 solved_count 높은 순으로 최대 3개 추천
- 3개 미달 시 인기 문제로 부족분 채우기
- 틀린 기록 없을 시 인기 문제 3개 폴백
- practice 문제는 image_status = READY인 것만 추천

## 관련 이슈
Closes #393


<!-- 주석은 제외되고 올라가니 무시하세요 -->
