### PR TITLE
[feat] 카테고리별 점수 조회 및 마이페이지 API 구현 (#404)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
+++ b/src/main/java/net/diveon/backend/domain/contest/repository/ContestParticipantRepository.java
@@ -70,4 +70,15 @@ public interface ContestParticipantRepository extends JpaRepository<ContestParti
     List<ContestParticipant> findByContestIdAndUserIds(
             @Param("contestId") Long contestId,
             @Param("userIds") List<Long> userIds);
+
+    @Query(value = """
+            SELECT cp FROM ContestParticipant cp
+            JOIN FETCH cp.contest c
+            WHERE cp.user.id = :userId
+            ORDER BY cp.joinedAt DESC
+            """,
+            countQuery = """
+            SELECT COUNT(cp) FROM ContestParticipant cp WHERE cp.user.id = :userId
+            """)
+    Page<ContestParticipant> findMyContestsByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
@@ -39,6 +39,32 @@ public interface SolveResultRepository extends JpaRepository<SolveResult, Long>{
     List<Object[]> findWeakCategories(@Param("userId") Long userId);
 
     @Query(value = """
+        SELECT category, COALESCE(SUM(score), 0) AS score
+        FROM (
+            SELECT ps.category,
+                   CASE ps.difficulty
+                       WHEN '1' THEN 10
+                       WHEN '2' THEN 20
+                       WHEN '3' THEN 30
+                       WHEN '4' THEN 40
+                       WHEN '5' THEN 50
+                       WHEN '6' THEN 60
+                       WHEN '7' THEN 70
+                       ELSE 0
+                   END AS score
+            FROM solve_result sr
+            JOIN solve_submission ss ON sr.submission_id = ss.id
+            JOIN problem_summary ps ON ss.prob_id = ps.id
+            WHERE ss.submitter_id = :userId
+              AND sr.result_status = 'CORRECT'
+              AND ps.visibility NOT IN ('group', 'contest')
+            GROUP BY ps.id, ps.category, ps.difficulty
+        ) deduped
+        GROUP BY category
+        """, nativeQuery = true)
+    List<Object[]> findCategoryScoreByUserId(@Param("userId") Long userId);
+
+    @Query(value = """
         SELECT COALESCE(SUM(solved.score), 0)
         FROM (
             SELECT

--- a/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
+++ b/src/main/java/net/diveon/backend/domain/group/repository/GroupUserRepository.java
@@ -34,4 +34,16 @@ public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
     );
     List<GroupUser> findAllByUserId(Long userId);
     List<GroupUser> findAllByGroupIdIn(List<Long> groupIds);
+
+    @Query(value = """
+            SELECT gu FROM GroupUser gu
+            JOIN FETCH gu.group g
+            JOIN FETCH g.leader
+            WHERE gu.user.id = :userId
+            ORDER BY gu.joinedAt DESC
+            """,
+            countQuery = """
+            SELECT COUNT(gu) FROM GroupUser gu WHERE gu.user.id = :userId
+            """)
+    Page<GroupUser> findMyGroupsByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/net/diveon/backend/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/net/diveon/backend/domain/problem/repository/ProblemRepository.java
@@ -1,5 +1,7 @@
 package net.diveon.backend.domain.problem.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -52,4 +54,66 @@ public interface ProblemRepository extends JpaRepository<Problem, Long>, JpaSpec
             LIMIT 3
             """, nativeQuery = true)
     List<Problem> findPopularUnsolvedProblems(@Param("userId") Long userId);
+
+    @Query(value = """
+            SELECT DISTINCT p.* FROM problem_summary p
+            JOIN solve_submission ss ON ss.prob_id = p.id
+            JOIN solve_result sr ON sr.submission_id = ss.id
+            WHERE ss.submitter_id = :userId
+              AND sr.result_status = 'CORRECT'
+              AND (:visibility IS NULL OR p.visibility = :visibility)
+            ORDER BY p.id DESC
+            """,
+            countQuery = """
+            SELECT COUNT(DISTINCT p.id) FROM problem_summary p
+            JOIN solve_submission ss ON ss.prob_id = p.id
+            JOIN solve_result sr ON sr.submission_id = ss.id
+            WHERE ss.submitter_id = :userId
+              AND sr.result_status = 'CORRECT'
+              AND (:visibility IS NULL OR p.visibility = :visibility)
+            """,
+            nativeQuery = true)
+    Page<Problem> findSolvedByUserId(@Param("userId") Long userId,
+                                     @Param("visibility") String visibility,
+                                     Pageable pageable);
+
+    @Query(value = """
+            SELECT DISTINCT p.* FROM problem_summary p
+            JOIN solve_submission ss ON ss.prob_id = p.id
+            JOIN solve_result sr ON sr.submission_id = ss.id
+            WHERE ss.submitter_id = :userId
+              AND sr.result_status = 'WRONG'
+              AND (:visibility IS NULL OR p.visibility = :visibility)
+              AND NOT EXISTS (
+                  SELECT 1 FROM solve_submission ss2
+                  JOIN solve_result sr2 ON sr2.submission_id = ss2.id
+                  WHERE ss2.submitter_id = :userId
+                    AND ss2.prob_id = p.id
+                    AND sr2.result_status = 'CORRECT'
+              )
+            ORDER BY p.id DESC
+            """,
+            countQuery = """
+            SELECT COUNT(DISTINCT p.id) FROM problem_summary p
+            JOIN solve_submission ss ON ss.prob_id = p.id
+            JOIN solve_result sr ON sr.submission_id = ss.id
+            WHERE ss.submitter_id = :userId
+              AND sr.result_status = 'WRONG'
+              AND (:visibility IS NULL OR p.visibility = :visibility)
+              AND NOT EXISTS (
+                  SELECT 1 FROM solve_submission ss2
+                  JOIN solve_result sr2 ON sr2.submission_id = ss2.id
+                  WHERE ss2.submitter_id = :userId
+                    AND ss2.prob_id = p.id
+                    AND sr2.result_status = 'CORRECT'
+              )
+            """,
+            nativeQuery = true)
+    Page<Problem> findFailedByUserId(@Param("userId") Long userId,
+                                     @Param("visibility") String visibility,
+                                     Pageable pageable);
+
+    Page<Problem> findByAuthorIdAndVisibility(Long authorId, String visibility, Pageable pageable);
+
+    Page<Problem> findByAuthorId(Long authorId, Pageable pageable);
 }

--- a/src/main/java/net/diveon/backend/domain/user/controller/ProfileController.java
+++ b/src/main/java/net/diveon/backend/domain/user/controller/ProfileController.java
@@ -1,10 +1,18 @@
 package net.diveon.backend.domain.user.controller;
 
 import jakarta.validation.Valid;
+import net.diveon.backend.domain.problem.dto.response.ProblemListResponse;
+import net.diveon.backend.domain.user.dto.MyContestListResponse;
+import net.diveon.backend.domain.user.dto.MyGroupListResponse;
 import net.diveon.backend.domain.user.dto.PasswordUpdateRequest;
 import net.diveon.backend.domain.user.dto.ProfileShowResponse;
 import net.diveon.backend.domain.user.dto.ProfileUpdateRequest;
+import net.diveon.backend.domain.user.dto.UserCategoryStatsResponse;
+import net.diveon.backend.domain.user.service.MyPageContestService;
+import net.diveon.backend.domain.user.service.MyPageGroupService;
+import net.diveon.backend.domain.user.service.MyPageProblemService;
 import net.diveon.backend.domain.user.service.ProfileService;
+import net.diveon.backend.domain.user.service.UserCategoryStatsService;
 import net.diveon.backend.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,9 +28,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProfileController {
 
     private final ProfileService profileService;
+    private final UserCategoryStatsService userCategoryStatsService;
+    private final MyPageProblemService myPageProblemService;
+    private final MyPageGroupService myPageGroupService;
+    private final MyPageContestService myPageContestService;
 
-    public ProfileController(ProfileService profileService) {
+    public ProfileController(ProfileService profileService,
+                             UserCategoryStatsService userCategoryStatsService,
+                             MyPageProblemService myPageProblemService,
+                             MyPageGroupService myPageGroupService,
+                             MyPageContestService myPageContestService) {
         this.profileService = profileService;
+        this.userCategoryStatsService = userCategoryStatsService;
+        this.myPageProblemService = myPageProblemService;
+        this.myPageGroupService = myPageGroupService;
+        this.myPageContestService = myPageContestService;
     }
     // 프로필 조회
     @GetMapping("/show")
@@ -37,6 +58,62 @@ public class ProfileController {
             @RequestBody ProfileUpdateRequest request) {
         profileService.updateProfile(Long.parseLong(userId), request);
         return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다.", null));
+    }
+
+    // 카테고리별 점수 (거미줄 차트)
+    @GetMapping("/category-stats")
+    public ResponseEntity<ApiResponse<UserCategoryStatsResponse>> getCategoryStats(
+            @AuthenticationPrincipal String userId) {
+        UserCategoryStatsResponse response = userCategoryStatsService.getCategoryStats(Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.success("카테고리별 점수 조회에 성공하였습니다.", response));
+    }
+
+    // 푼 문제 목록 (visibility 필터: public/private/group/contest, 미입력 시 전체)
+    @GetMapping("/problems/solved")
+    public ResponseEntity<ApiResponse<ProblemListResponse>> getSolvedProblems(
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) String visibility) {
+        return ResponseEntity.ok(ApiResponse.success("푼 문제 목록 조회에 성공하였습니다.",
+                myPageProblemService.getSolvedProblems(Long.parseLong(userId), page, visibility)));
+    }
+
+    // 못 푼 문제 목록 (WRONG 기록 있고 CORRECT 없는 문제, visibility 필터 가능)
+    @GetMapping("/problems/failed")
+    public ResponseEntity<ApiResponse<ProblemListResponse>> getFailedProblems(
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) String visibility) {
+        return ResponseEntity.ok(ApiResponse.success("못 푼 문제 목록 조회에 성공하였습니다.",
+                myPageProblemService.getFailedProblems(Long.parseLong(userId), page, visibility)));
+    }
+
+    // 출제한 문제 목록 (visibility 필터 가능)
+    @GetMapping("/problems/authored")
+    public ResponseEntity<ApiResponse<ProblemListResponse>> getAuthoredProblems(
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) String visibility) {
+        return ResponseEntity.ok(ApiResponse.success("출제한 문제 목록 조회에 성공하였습니다.",
+                myPageProblemService.getAuthoredProblems(Long.parseLong(userId), page, visibility)));
+    }
+
+    // 속한 그룹 목록
+    @GetMapping("/groups")
+    public ResponseEntity<ApiResponse<MyGroupListResponse>> getMyGroups(
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page) {
+        return ResponseEntity.ok(ApiResponse.success("속한 그룹 목록 조회에 성공하였습니다.",
+                myPageGroupService.getMyGroups(Long.parseLong(userId), page)));
+    }
+
+    // 속한 대회 목록 (종료된 대회 포함)
+    @GetMapping("/contests")
+    public ResponseEntity<ApiResponse<MyContestListResponse>> getMyContests(
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "1") int page) {
+        return ResponseEntity.ok(ApiResponse.success("속한 대회 목록 조회에 성공하였습니다.",
+                myPageContestService.getMyContests(Long.parseLong(userId), page)));
     }
 
     // 비밀번호 변경

--- a/src/main/java/net/diveon/backend/domain/user/dto/MyContestItemResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/MyContestItemResponse.java
@@ -1,0 +1,42 @@
+package net.diveon.backend.domain.user.dto;
+
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+
+import java.time.LocalDateTime;
+
+public class MyContestItemResponse {
+
+    private final Long contestId;
+    private final String title;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
+    private final String status;
+    private final String role;
+
+    public MyContestItemResponse(Long contestId, String title, LocalDateTime startTime, LocalDateTime endTime, String status, String role) {
+        this.contestId = contestId;
+        this.title = title;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+        this.role = role;
+    }
+
+    public static MyContestItemResponse of(ContestParticipant cp) {
+        return new MyContestItemResponse(
+            cp.getContest().getId(),
+            cp.getContest().getTitle(),
+            cp.getContest().getStartTime(),
+            cp.getContest().getEndTime(),
+            cp.getContest().getStatus().name(),
+            cp.getRole().name()
+        );
+    }
+
+    public Long getContestId() { return contestId; }
+    public String getTitle() { return title; }
+    public LocalDateTime getStartTime() { return startTime; }
+    public LocalDateTime getEndTime() { return endTime; }
+    public String getStatus() { return status; }
+    public String getRole() { return role; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/MyContestListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/MyContestListResponse.java
@@ -1,0 +1,38 @@
+package net.diveon.backend.domain.user.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class MyContestListResponse {
+
+    private final Long total;
+    private final Integer page;
+    private final Integer pageSize;
+    private final Integer totalPages;
+    private final List<MyContestItemResponse> contests;
+
+    public MyContestListResponse(Long total, Integer page, Integer pageSize, Integer totalPages, List<MyContestItemResponse> contests) {
+        this.total = total;
+        this.page = page;
+        this.pageSize = pageSize;
+        this.totalPages = totalPages;
+        this.contests = contests;
+    }
+
+    public static MyContestListResponse of(Page<?> pageResult, List<MyContestItemResponse> contests) {
+        return new MyContestListResponse(
+            pageResult.getTotalElements(),
+            pageResult.getNumber() + 1,
+            pageResult.getSize(),
+            pageResult.getTotalPages(),
+            contests
+        );
+    }
+
+    public Long getTotal() { return total; }
+    public Integer getPage() { return page; }
+    public Integer getPageSize() { return pageSize; }
+    public Integer getTotalPages() { return totalPages; }
+    public List<MyContestItemResponse> getContests() { return contests; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/MyGroupItemResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/MyGroupItemResponse.java
@@ -1,0 +1,40 @@
+package net.diveon.backend.domain.user.dto;
+
+import net.diveon.backend.domain.group.entity.GroupUser;
+
+public class MyGroupItemResponse {
+
+    private final Long groupId;
+    private final String title;
+    private final String image;
+    private final String role;
+    private final Boolean isPrivate;
+    private final Long memberCount;
+
+    public MyGroupItemResponse(Long groupId, String title, String image, String role, Boolean isPrivate, Long memberCount) {
+        this.groupId = groupId;
+        this.title = title;
+        this.image = image;
+        this.role = role;
+        this.isPrivate = isPrivate;
+        this.memberCount = memberCount;
+    }
+
+    public static MyGroupItemResponse of(GroupUser gu, Long memberCount) {
+        return new MyGroupItemResponse(
+            gu.getGroup().getId(),
+            gu.getGroup().getTitle(),
+            gu.getGroup().getImage(),
+            gu.getRole().name(),
+            gu.getGroup().getIsPrivate(),
+            memberCount
+        );
+    }
+
+    public Long getGroupId() { return groupId; }
+    public String getTitle() { return title; }
+    public String getImage() { return image; }
+    public String getRole() { return role; }
+    public Boolean getIsPrivate() { return isPrivate; }
+    public Long getMemberCount() { return memberCount; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/MyGroupListResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/MyGroupListResponse.java
@@ -1,0 +1,38 @@
+package net.diveon.backend.domain.user.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class MyGroupListResponse {
+
+    private final Long total;
+    private final Integer page;
+    private final Integer pageSize;
+    private final Integer totalPages;
+    private final List<MyGroupItemResponse> groups;
+
+    public MyGroupListResponse(Long total, Integer page, Integer pageSize, Integer totalPages, List<MyGroupItemResponse> groups) {
+        this.total = total;
+        this.page = page;
+        this.pageSize = pageSize;
+        this.totalPages = totalPages;
+        this.groups = groups;
+    }
+
+    public static MyGroupListResponse of(Page<?> pageResult, List<MyGroupItemResponse> groups) {
+        return new MyGroupListResponse(
+            pageResult.getTotalElements(),
+            pageResult.getNumber() + 1,
+            pageResult.getSize(),
+            pageResult.getTotalPages(),
+            groups
+        );
+    }
+
+    public Long getTotal() { return total; }
+    public Integer getPage() { return page; }
+    public Integer getPageSize() { return pageSize; }
+    public Integer getTotalPages() { return totalPages; }
+    public List<MyGroupItemResponse> getGroups() { return groups; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/dto/UserCategoryStatsResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/UserCategoryStatsResponse.java
@@ -1,0 +1,14 @@
+package net.diveon.backend.domain.user.dto;
+
+import java.util.Map;
+
+public class UserCategoryStatsResponse {
+
+    private final Map<String, Integer> categoryScores;
+
+    public UserCategoryStatsResponse(Map<String, Integer> categoryScores) {
+        this.categoryScores = categoryScores;
+    }
+
+    public Map<String, Integer> getCategoryScores() { return categoryScores; }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/MyPageContestService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/MyPageContestService.java
@@ -1,0 +1,33 @@
+package net.diveon.backend.domain.user.service;
+
+import net.diveon.backend.domain.contest.entity.ContestParticipant;
+import net.diveon.backend.domain.contest.repository.ContestParticipantRepository;
+import net.diveon.backend.domain.user.dto.MyContestItemResponse;
+import net.diveon.backend.domain.user.dto.MyContestListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class MyPageContestService {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final ContestParticipantRepository contestParticipantRepository;
+
+    public MyPageContestService(ContestParticipantRepository contestParticipantRepository) {
+        this.contestParticipantRepository = contestParticipantRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MyContestListResponse getMyContests(Long userId, int page) {
+        Page<ContestParticipant> result = contestParticipantRepository.findMyContestsByUserId(userId, PageRequest.of(page - 1, PAGE_SIZE));
+        List<MyContestItemResponse> items = result.getContent().stream()
+                .map(MyContestItemResponse::of)
+                .toList();
+        return MyContestListResponse.of(result, items);
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/MyPageGroupService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/MyPageGroupService.java
@@ -1,0 +1,33 @@
+package net.diveon.backend.domain.user.service;
+
+import net.diveon.backend.domain.group.entity.GroupUser;
+import net.diveon.backend.domain.group.repository.GroupUserRepository;
+import net.diveon.backend.domain.user.dto.MyGroupItemResponse;
+import net.diveon.backend.domain.user.dto.MyGroupListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class MyPageGroupService {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final GroupUserRepository groupUserRepository;
+
+    public MyPageGroupService(GroupUserRepository groupUserRepository) {
+        this.groupUserRepository = groupUserRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MyGroupListResponse getMyGroups(Long userId, int page) {
+        Page<GroupUser> result = groupUserRepository.findMyGroupsByUserId(userId, PageRequest.of(page - 1, PAGE_SIZE));
+        List<MyGroupItemResponse> items = result.getContent().stream()
+                .map(gu -> MyGroupItemResponse.of(gu, groupUserRepository.countByGroupId(gu.getGroup().getId())))
+                .toList();
+        return MyGroupListResponse.of(result, items);
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/MyPageProblemService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/MyPageProblemService.java
@@ -1,0 +1,59 @@
+package net.diveon.backend.domain.user.service;
+
+import net.diveon.backend.domain.grade.repository.SolveSubmissionRepository;
+import net.diveon.backend.domain.problem.dto.response.ProblemListItemResponse;
+import net.diveon.backend.domain.problem.dto.response.ProblemListResponse;
+import net.diveon.backend.domain.problem.entity.Problem;
+import net.diveon.backend.domain.problem.repository.ProblemRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class MyPageProblemService {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final ProblemRepository problemRepository;
+    private final SolveSubmissionRepository solveSubmissionRepository;
+
+    public MyPageProblemService(ProblemRepository problemRepository,
+                                SolveSubmissionRepository solveSubmissionRepository) {
+        this.problemRepository = problemRepository;
+        this.solveSubmissionRepository = solveSubmissionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemListResponse getSolvedProblems(Long userId, int page, String visibility) {
+        Page<Problem> result = problemRepository.findSolvedByUserId(userId, visibility, PageRequest.of(page - 1, PAGE_SIZE));
+        List<ProblemListItemResponse> items = result.getContent().stream()
+                .map(p -> ProblemListItemResponse.of(p, true))
+                .toList();
+        return ProblemListResponse.of(result, items);
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemListResponse getFailedProblems(Long userId, int page, String visibility) {
+        Page<Problem> result = problemRepository.findFailedByUserId(userId, visibility, PageRequest.of(page - 1, PAGE_SIZE));
+        List<ProblemListItemResponse> items = result.getContent().stream()
+                .map(p -> ProblemListItemResponse.of(p, false))
+                .toList();
+        return ProblemListResponse.of(result, items);
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemListResponse getAuthoredProblems(Long userId, int page, String visibility) {
+        Set<Long> solvedIds = Set.copyOf(solveSubmissionRepository.findSolvedProblemIdsByUserId(userId));
+        Page<Problem> result = visibility != null
+                ? problemRepository.findByAuthorIdAndVisibility(userId, visibility, PageRequest.of(page - 1, PAGE_SIZE))
+                : problemRepository.findByAuthorId(userId, PageRequest.of(page - 1, PAGE_SIZE));
+        List<ProblemListItemResponse> items = result.getContent().stream()
+                .map(p -> ProblemListItemResponse.of(p, solvedIds.contains(p.getId())))
+                .toList();
+        return ProblemListResponse.of(result, items);
+    }
+}

--- a/src/main/java/net/diveon/backend/domain/user/service/UserCategoryStatsService.java
+++ b/src/main/java/net/diveon/backend/domain/user/service/UserCategoryStatsService.java
@@ -1,0 +1,40 @@
+package net.diveon.backend.domain.user.service;
+
+import net.diveon.backend.domain.grade.repository.SolveResultRepository;
+import net.diveon.backend.domain.user.dto.UserCategoryStatsResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class UserCategoryStatsService {
+
+    private static final List<String> ALL_CATEGORIES =
+            List.of("Process", "Memory", "Kernel", "Thread", "FileSystem");
+
+    private final SolveResultRepository solveResultRepository;
+
+    public UserCategoryStatsService(SolveResultRepository solveResultRepository) {
+        this.solveResultRepository = solveResultRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public UserCategoryStatsResponse getCategoryStats(Long userId) {
+        List<Object[]> rows = solveResultRepository.findCategoryScoreByUserId(userId);
+
+        Map<String, Integer> scores = new LinkedHashMap<>();
+        for (String category : ALL_CATEGORIES) {
+            scores.put(category, 0);
+        }
+        for (Object[] row : rows) {
+            String category = (String) row[0];
+            int score = ((Number) row[1]).intValue();
+            scores.put(category, score);
+        }
+
+        return new UserCategoryStatsResponse(scores);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- GET /api/profile/category-stats: 카테고리별 점수(m) 조회 (오각형 차트용)
- GET /api/profile/problems/solved: 푼 문제 목록 (visibility 필터, 페이지네이션)
- GET /api/profile/problems/failed: 못 푼 문제 목록 (visibility 필터, 페이지네이션)
- GET /api/profile/problems/authored: 출제한 문제 목록 (visibility 필터, 페이지네이션)
- GET /api/profile/groups: 속한 그룹 목록 (페이지네이션)
- GET /api/profile/contests: 속한 대회 목록 (페이지네이션)

## 관련 이슈
Closes #404 


<!-- 주석은 제외되고 올라가니 무시하세요 -->
