### PR TITLE
[fix] 본인 문제 자기풀이 점수 조작 방지 및 categoryMax 추가 (#410

### DIFF
--- a/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
+++ b/src/main/java/net/diveon/backend/domain/grade/repository/SolveResultRepository.java
@@ -58,6 +58,7 @@ public interface SolveResultRepository extends JpaRepository<SolveResult, Long>{
             WHERE ss.submitter_id = :userId
               AND sr.result_status = 'CORRECT'
               AND ps.visibility NOT IN ('group', 'contest')
+              AND ps.author_id != ss.submitter_id
             GROUP BY ps.id, ps.category, ps.difficulty
         ) deduped
         GROUP BY category
@@ -84,6 +85,7 @@ public interface SolveResultRepository extends JpaRepository<SolveResult, Long>{
             WHERE ss.submitter_id = :userId
               AND sr.result_status = 'CORRECT'
               AND ps.visibility NOT IN ('group', 'contest')
+              AND ps.author_id != ss.submitter_id
             GROUP BY ps.id, ps.difficulty
             ORDER BY score DESC
             LIMIT 100

--- a/src/main/java/net/diveon/backend/domain/user/dto/UserCategoryStatsResponse.java
+++ b/src/main/java/net/diveon/backend/domain/user/dto/UserCategoryStatsResponse.java
@@ -4,11 +4,16 @@ import java.util.Map;
 
 public class UserCategoryStatsResponse {
 
+    private static final int CATEGORY_MAX = 1080; // 오각형 차트 축 100% 기준값 (프론트에서 sqrt(score/categoryMax)로 사용)
+
     private final Map<String, Integer> categoryScores;
+    private final int categoryMax;
 
     public UserCategoryStatsResponse(Map<String, Integer> categoryScores) {
         this.categoryScores = categoryScores;
+        this.categoryMax = CATEGORY_MAX;
     }
 
     public Map<String, Integer> getCategoryScores() { return categoryScores; }
+    public int getCategoryMax() { return categoryMax; }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 티어 점수 / 카테고리 점수 집계 쿼리에서 작성자 본인이 푼 문제 제외 (author_id != submitter_id)
- 오각형 차트 categoryMax(1080) 필드 응답에 추가 - 프론트 sqrt 스케일링용

## 관련 이슈
Closes #


<!-- 주석은 제외되고 올라가니 무시하세요 -->
