### PR TITLE
fix: 유저당 VM 1개 제한 시 다른 문제 VM 요청하면 기존 VM 종료 후 재생성 (#412)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/vm/repository/VmSessionRepository.java
+++ b/src/main/java/net/diveon/backend/domain/vm/repository/VmSessionRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface VmSessionRepository extends JpaRepository<VmSession, Long> {
 
     Optional<VmSession> findFirstByUserIdAndStatus(Long userId, String status);
+
+    Optional<VmSession> findFirstByUserIdAndProbIdAndStatus(Long userId, Long probId, String status);
 }

--- a/src/main/java/net/diveon/backend/domain/vm/service/VmService.java
+++ b/src/main/java/net/diveon/backend/domain/vm/service/VmService.java
@@ -12,6 +12,8 @@ import net.diveon.backend.domain.vm.repository.VmSessionRepository;
 import net.diveon.backend.global.exception.ImageNotReadyException;
 import net.diveon.backend.global.exception.ProblemNotFoundException;
 import net.diveon.backend.global.exception.VmNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,8 @@ import java.util.Optional;
 
 @Service
 public class VmService {
+
+    private static final Logger log = LoggerFactory.getLogger(VmService.class);
 
     private final VmSessionRepository vmSessionRepository;
     private final ProblemPracticeRepository problemPracticeRepository;
@@ -43,7 +47,7 @@ public class VmService {
             return VmStatusResponse.imageNotReady();
         }
 
-        Optional<VmSession> session = vmSessionRepository.findFirstByUserIdAndStatus(userId, "RUNNING");
+        Optional<VmSession> session = vmSessionRepository.findFirstByUserIdAndProbIdAndStatus(userId, probId, "RUNNING");
         if (session.isPresent()) {
             return VmStatusResponse.running(session.get().getContainerId());
         }
@@ -64,10 +68,23 @@ public class VmService {
             throw new ImageNotReadyException("이미지가 아직 준비 중입니다. (image_status: " + practice.getImageStatus() + ")");
         }
 
-        // 이미 기존 생성된 VM이 있는지 확인, 있으면 반환 (유저당 VM 생성 1개 제한)
+        // 이미 기존 생성된 VM이 있는지 확인 (유저당 VM 생성 1개 제한)
         Optional<VmSession> existing = vmSessionRepository.findFirstByUserIdAndStatus(userId, "RUNNING");
         if (existing.isPresent()) {
-            return VmCreateResponse.from(existing.get(), "기존 VM을 반환합니다.");
+            VmSession existingSession = existing.get();
+
+            // 같은 문제의 VM이 이미 떠있으면 그대로 재사용
+            if (existingSession.getProbId().equals(probId)) {
+                return VmCreateResponse.from(existingSession, "기존 VM을 반환합니다.");
+            }
+
+            // 다른 문제의 VM이 떠있으면 종료하고 새로 생성 (컨테이너 정리 실패해도 새 VM 생성은 진행)
+            try {
+                dockerService.stopAndRemoveContainer(existingSession.getContainerId());
+            } catch (Exception e) {
+                log.warn("이전 VM 컨테이너 정리 실패 (containerId: {})", existingSession.getContainerId(), e);
+            }
+            existingSession.stop();
         }
 
         // 없으면 DockerService 호출해서 컨테이너 생성하고, DB에 세션 저장하고, 응답 반환


### PR DESCRIPTION
## 작업 내용
- createVm: probId 다른 기존 RUNNING 세션 있으면 컨테이너 정지/삭제 후 새로 생성 (같은 probId면 재사용 유지)
- getStatus: probId 필터 누락으로 다른 문제의 VM이 RUNNING으로 잘못 노출되던 문제 수정


## 관련 이슈
Closes #412


<!-- 주석은 제외되고 올라가니 무시하세요 -->
