### PR TITLE
fix: 원격 docker run 실패 시 exit status/stderr 검증 없이 성공 처리되던 문제 수정 (#415)

### DIFF
--- a/src/main/java/net/diveon/backend/domain/vm/service/DockerServiceImpl.java
+++ b/src/main/java/net/diveon/backend/domain/vm/service/DockerServiceImpl.java
@@ -3,16 +3,22 @@ package net.diveon.backend.domain.vm.service;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;
+import net.diveon.backend.global.exception.VmCreationFailedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
 
 @Service
 @Profile("prod")
 public class DockerServiceImpl implements DockerService {
+
+    private static final Logger log = LoggerFactory.getLogger(DockerServiceImpl.class);
 
     private final String vmHost;
     private final String vmUser;
@@ -35,19 +41,33 @@ public class DockerServiceImpl implements DockerService {
                 "docker run -d --memory 256m --cpus 0.3 --network none --name syslab-vm-%d-%d %s sleep infinity",
                 userId, probId, image
         );
-        return executeCommand(command).trim(); // docker run 명령어 만들어서 executeCommand에 넘김
+        CommandResult result = executeCommand(command); // docker run 명령어 만들어서 executeCommand에 넘김
+
+        // exit status가 0이 아니거나 컨테이너 ID가 비어있으면 원격 docker run이 실패한 것
+        if (result.exitStatus() != 0 || result.stdout().isBlank()) {
+            log.error("VM 컨테이너 생성 실패 (userId={}, probId={}, exitStatus={}, stderr={})",
+                    userId, probId, result.exitStatus(), result.stderr());
+            throw new VmCreationFailedException("VM 컨테이너 생성에 실패했습니다: " + result.stderr());
+        }
+
+        return result.stdout();
     }
 
 
     // SSH로 VM EC2 접속 후 컨테이너 중지 및 삭제
     @Override
     public void stopAndRemoveContainer(String containerId) {
-        executeCommand("docker stop " + containerId + " && docker rm " + containerId);
-    } // stop + rm 명령어 만들어서 executeCommand에 넘김
+        // stop + rm 명령어 만들어서 executeCommand에 넘김
+        CommandResult result = executeCommand("docker stop " + containerId + " && docker rm " + containerId);
+        if (result.exitStatus() != 0) {
+            log.warn("컨테이너 정지/삭제 실패 (containerId={}, exitStatus={}, stderr={})",
+                    containerId, result.exitStatus(), result.stderr());
+        }
+    }
 
 
     // 실제 SSH실행 담당
-    private String executeCommand(String command) {
+    private CommandResult executeCommand(String command) {
         Session session = null;
         ChannelExec channel = null;
         try {
@@ -63,7 +83,9 @@ public class DockerServiceImpl implements DockerService {
             // 연결된 SSH 세션에서 명령어 실행 채널열고, command 실행
             channel = (ChannelExec) session.openChannel("exec");
             channel.setCommand(command);
-            channel.setErrStream(System.err);
+
+            ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
+            channel.setErrStream(errBuffer);
 
             // 실행결과 (컨테이너 ID)를 한 줄씩 읽어서 반환
             BufferedReader reader = new BufferedReader(new InputStreamReader(channel.getInputStream()));
@@ -75,7 +97,14 @@ public class DockerServiceImpl implements DockerService {
                 output.append(line);
             }
 
-            return output.toString();
+            // exit status는 채널이 닫힌 뒤에야 확정되므로 닫힐 때까지 잠깐 대기 (최대 5초)
+            int waited = 0;
+            while (!channel.isClosed() && waited < 100) {
+                Thread.sleep(50);
+                waited++;
+            }
+
+            return new CommandResult(output.toString().trim(), errBuffer.toString().trim(), channel.getExitStatus());
         } catch (Exception e) {
             throw new RuntimeException("VM EC2 SSH 명령 실행 실패: " + e.getMessage(), e);
         } finally { // 끝나면 SSH 연결 끊기 (안 끊으면 연결이 계속 쌓여서 문제 발생 위험)
@@ -83,6 +112,8 @@ public class DockerServiceImpl implements DockerService {
             if (session != null) session.disconnect();
         }
     }
+
+    private record CommandResult(String stdout, String stderr, int exitStatus) {}
 }
 
 

--- a/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/diveon/backend/global/exception/GlobalExceptionHandler.java
@@ -178,6 +178,20 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
         }
 
+        // VM EC2에서 컨테이너 생성 실패 → 502
+        @ExceptionHandler(VmCreationFailedException.class)
+        public ResponseEntity<ErrorResponse> handleVmCreationFailed(
+                VmCreationFailedException ex, HttpServletRequest request) {
+                ErrorResponse body = new ErrorResponse(
+                        "https://diveon.net/problems/vm-creation-failed",
+                        "Bad Gateway",
+                        502,
+                        ex.getMessage(),
+                        request.getRequestURI()
+                );
+                return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(body);
+        }
+
         // 본인 VM이 아닌 경우 → 403
         @ExceptionHandler(VmAccessDeniedException.class)
         public ResponseEntity<ErrorResponse> handleVmAccessDenied(

--- a/src/main/java/net/diveon/backend/global/exception/VmCreationFailedException.java
+++ b/src/main/java/net/diveon/backend/global/exception/VmCreationFailedException.java
@@ -1,0 +1,7 @@
+package net.diveon.backend.global.exception;
+
+public class VmCreationFailedException extends RuntimeException {
+    public VmCreationFailedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
- DockerServiceImpl: SSH 명령 실행 결과의 exit status/stderr를 캡처하는 CommandResult 도입, SLF4J 로깅 추가
- runContainer: exit status 비정상이거나 컨테이너 ID가 비어있으면 VmCreationFailedException 발생 (빈 container_id로 DB row 저장되던 버그 차단)
- stopAndRemoveContainer: 실패 시 warn 로그만 남기고 진행 (정리 작업 특성상 관대하게 유지)
- VmCreationFailedException 추가 및 GlobalExceptionHandler에 502 매핑

<!-- PR 제목 예시: [feat] 로그인 API 구현 (#21) -->

## 작업 내용
- 

## 관련 이슈
Closes #


<!-- 주석은 제외되고 올라가니 무시하세요 -->
